### PR TITLE
fix: cross-platform CI test paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "templates/"
   ],
   "scripts": {
-    "test": "node --test 'tests/unit/*.test.js' 'tests/integration/*.test.js'",
-    "test:unit": "node --test 'tests/unit/*.test.js'",
-    "test:integration": "node --test 'tests/integration/*.test.js'",
+    "test": "node --test tests/unit/files.test.js tests/integration/fresh-project.test.js tests/integration/idempotency.test.js",
+    "test:unit": "node --test tests/unit/files.test.js",
+    "test:integration": "node --test tests/integration/fresh-project.test.js tests/integration/idempotency.test.js",
     "test:scenarios": "node --test tests/scenarios/",
     "lint": "eslint bin/ lib/ templates/hooks/",
     "format:check": "prettier --check .",


### PR DESCRIPTION
## Summary
- Glob patterns in npm scripts aren't expanded on all platforms (macOS sh, Windows)
- Changed to explicit file paths for test scripts
- Fixes CI failures on all matrix combinations

## Test plan
- [ ] CI passes on ubuntu/macos/windows × Node 18/20/22

refs #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)