### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Validate semver tag matches package.json
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+
+      - name: Run full test suite
+        run: npm test
+
+      - name: Validate agents
+        run: node scripts/validate-agents.js
+
+      - name: Validate hooks
+        run: node scripts/validate-hooks.js
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` (was missing from initial commit)
- Automated npm publish on version tags (v*)
- Validates semver tag matches package.json, runs tests, then publishes

## After merge
Re-tag v0.1.0 to trigger first npm publish.

refs #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)