### PR TITLE
ci: enable npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,6 @@ jobs:
         run: node scripts/validate-hooks.js
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Repo is now public. Adds --provenance for npm supply chain security.

refs #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)