### PR TITLE
fix: address silent failure risks in error handling and hooks

### DIFF
--- a/.claude/hooks/dev-team-issue-pr-enforce.js
+++ b/.claude/hooks/dev-team-issue-pr-enforce.js
@@ -13,7 +13,13 @@
 
 'use strict';
 
-const input = JSON.parse(process.argv[2] || '{}');
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || '{}');
+} catch (err) {
+  console.warn(`[dev-team issue-pr-enforce] Warning: Failed to parse hook input, allowing operation. ${err.message}`);
+  process.exit(0);
+}
 const command = (input.tool_input && input.tool_input.command) || '';
 
 function isGitCommit(cmd) {

--- a/.claude/hooks/dev-team-lint-format.js
+++ b/.claude/hooks/dev-team-lint-format.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+/**
+ * dev-team-lint-format.js
+ * PostToolUse hook on Edit/Write.
+ *
+ * Runs oxlint and oxfmt --write on the modified file.
+ * Advisory only — always exits 0.
+ */
+
+"use strict";
+
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+let input = {};
+try {
+  input = JSON.parse(require("fs").readFileSync(0, "utf-8"));
+} catch {
+  process.exit(0);
+}
+
+const filePath = (input.tool_input && (input.tool_input.file_path || input.tool_input.path)) || "";
+if (!filePath) {
+  process.exit(0);
+}
+
+const ext = path.extname(filePath);
+const LINTABLE = [".js", ".ts", ".jsx", ".tsx"];
+if (!LINTABLE.includes(ext)) {
+  process.exit(0);
+}
+
+try {
+  execFileSync("npx", ["oxlint", filePath], { encoding: "utf-8", timeout: 10000, stdio: "pipe" });
+} catch (err) {
+  if (err.stdout) process.stdout.write(err.stdout);
+}
+
+try {
+  execFileSync("npx", ["oxfmt", "--write", filePath], { encoding: "utf-8", timeout: 10000, stdio: "pipe" });
+} catch {
+  // oxfmt failure is non-blocking
+}
+
+process.exit(0);

--- a/.claude/hooks/dev-team-post-change-review.js
+++ b/.claude/hooks/dev-team-post-change-review.js
@@ -12,7 +12,13 @@
 
 const path = require("path");
 
-const input = JSON.parse(process.argv[2] || "{}");
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || "{}");
+} catch (err) {
+  console.warn(`[dev-team post-change-review] Warning: Failed to parse hook input, allowing operation. ${err.message}`);
+  process.exit(0);
+}
 const filePath = (input.tool_input && (input.tool_input.file_path || input.tool_input.path)) || "";
 
 if (!filePath) {

--- a/.claude/hooks/dev-team-precommit-lint-format.js
+++ b/.claude/hooks/dev-team-precommit-lint-format.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+/**
+ * dev-team-precommit-lint-format.js
+ * PreToolUse hook on Bash.
+ *
+ * Before a git commit, runs full oxlint + oxfmt --check on src/, scripts/, templates/hooks/.
+ * Exit 2 = block, exit 0 = allow.
+ */
+
+"use strict";
+
+const { execFileSync } = require("child_process");
+
+let input = {};
+try {
+  input = JSON.parse(require("fs").readFileSync(0, "utf-8"));
+} catch {
+  process.exit(0);
+}
+
+const command = (input.tool_input && input.tool_input.command) || "";
+
+if (!/\bgit\s+commit\b/.test(command)) {
+  process.exit(0);
+}
+
+const dirs = ["src/", "scripts/", "templates/hooks/"];
+
+// Run oxlint
+try {
+  execFileSync("npx", ["oxlint", ...dirs], { encoding: "utf-8", timeout: 30000, stdio: "pipe" });
+} catch (err) {
+  if (err.stdout) process.stdout.write(err.stdout);
+  if (err.stderr) process.stderr.write(err.stderr);
+  console.error("[dev-team precommit] Lint errors found. Fix them before committing.");
+  process.exit(2);
+}
+
+// Run oxfmt --check
+try {
+  execFileSync("npx", ["oxfmt", "--check", ...dirs], { encoding: "utf-8", timeout: 30000, stdio: "pipe" });
+} catch (err) {
+  if (err.stdout) process.stdout.write(err.stdout);
+  if (err.stderr) process.stderr.write(err.stderr);
+  console.error("[dev-team precommit] Formatting issues found. Run `npm run format` before committing.");
+  process.exit(2);
+}
+
+process.exit(0);

--- a/.claude/hooks/dev-team-safety-guard.js
+++ b/.claude/hooks/dev-team-safety-guard.js
@@ -10,7 +10,13 @@
 
 "use strict";
 
-const input = JSON.parse(process.argv[2] || "{}");
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || "{}");
+} catch (err) {
+  console.warn(`[dev-team safety-guard] Warning: Failed to parse hook input, allowing operation. ${err.message}`);
+  process.exit(0);
+}
 const command = (input.tool_input && input.tool_input.command) || "";
 
 const BLOCKED_PATTERNS = [

--- a/.claude/hooks/dev-team-tdd-enforce.js
+++ b/.claude/hooks/dev-team-tdd-enforce.js
@@ -17,7 +17,13 @@
 const { execFileSync } = require("child_process");
 const path = require("path");
 
-const input = JSON.parse(process.argv[2] || "{}");
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || "{}");
+} catch (err) {
+  console.warn(`[dev-team tdd-enforce] Warning: Failed to parse hook input, allowing operation. ${err.message}`);
+  process.exit(0);
+}
 const filePath = (input.tool_input && (input.tool_input.file_path || input.tool_input.path)) || "";
 
 if (!filePath) {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,15 @@
             "command": "node .claude/hooks/dev-team-safety-guard.js"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/dev-team-precommit-lint-format.js"
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -31,6 +40,10 @@
           {
             "type": "command",
             "command": "node .claude/hooks/dev-team-tdd-enforce.js"
+          },
+          {
+            "type": "command",
+            "command": "node .claude/hooks/dev-team-lint-format.js"
           }
         ]
       }

--- a/src/files.ts
+++ b/src/files.ts
@@ -83,8 +83,10 @@ export function mergeSettings(existingPath: string, newFragment: HookSettings): 
   let existing: { hooks?: Record<string, HookMatcher[]> } = {};
   try {
     existing = JSON.parse(fs.readFileSync(existingPath, "utf-8"));
-  } catch {
-    // File doesn't exist or is invalid — start fresh
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.warn(`Warning: ${existingPath} exists but is not valid JSON. Starting fresh.`);
+    }
   }
 
   if (!existing.hooks) {
@@ -132,6 +134,13 @@ export function mergeClaudeMd(
   }
 
   if (existing.includes(BEGIN_MARKER)) {
+    if (!existing.includes(END_MARKER)) {
+      console.warn(
+        "Warning: Found dev-team begin marker but no end marker in CLAUDE.md. Appending instead of replacing.",
+      );
+      writeFile(filePath, existing.trimEnd() + "\n\n" + newContent + "\n");
+      return "appended";
+    }
     const beforeMarker = existing.substring(0, existing.indexOf(BEGIN_MARKER));
     const afterMarker = existing.substring(existing.indexOf(END_MARKER) + END_MARKER.length);
     writeFile(filePath, beforeMarker + newContent + afterMarker);

--- a/templates/agents/dev-team-deming.md
+++ b/templates/agents/dev-team-deming.md
@@ -25,7 +25,8 @@ After making changes:
 
 You always check for:
 - **Hook coverage**: Is every enforceable rule actually enforced by a hook? If agents keep flagging the same pattern in reviews, it should be a hook instead.
-- **Linter and formatter configuration**: Are they set up? Are they running in CI? Are they covering all relevant file types?
+- **Linter and formatter configuration**: Are they set up? Are they covering all relevant file types?
+- **Enforcement placement**: For every tool (linter, formatter, SAST, type checker, dependency auditor), critically assess where it should run: PostToolUse hook (per-file, immediate feedback), pre-commit hook (full scope, blocks commit), CI pipeline (authoritative gate), or a combination. Per-file hooks shift discovery left but can't catch cross-file issues. Pre-commit gates catch everything before code leaves the machine. CI is the final authority but feedback is slowest. The right answer is usually a layered combination — recommend the specific layers for each tool and justify why.
 - **SAST integration**: Is there static analysis for the project's language? Is it running automatically?
 - **Dependency freshness**: Are dependencies up to date? Are there known vulnerabilities in the dependency tree?
 - **CI/CD pipeline speed**: Are independent steps running in parallel? Are there unnecessary rebuilds? Is caching configured?

--- a/templates/hooks/dev-team-post-change-review.js
+++ b/templates/hooks/dev-team-post-change-review.js
@@ -12,7 +12,15 @@
 
 const path = require("path");
 
-const input = JSON.parse(process.argv[2] || "{}");
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || "{}");
+} catch (err) {
+  console.warn(
+    `[dev-team post-change-review] Warning: Failed to parse hook input, allowing operation. ${err.message}`,
+  );
+  process.exit(0);
+}
 const filePath = (input.tool_input && (input.tool_input.file_path || input.tool_input.path)) || "";
 
 if (!filePath) {

--- a/templates/hooks/dev-team-safety-guard.js
+++ b/templates/hooks/dev-team-safety-guard.js
@@ -10,7 +10,17 @@
 
 "use strict";
 
-const input = JSON.parse(process.argv[2] || "{}");
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || "{}");
+} catch (err) {
+  // SECURITY TRADEOFF: Failing open means parse errors bypass safety checks.
+  // We accept this because failing closed (exit 2) would block all Bash operations when input is malformed.
+  console.warn(
+    `[dev-team safety-guard] Warning: Failed to parse hook input, allowing operation. ${err.message}`,
+  );
+  process.exit(0);
+}
 const command = (input.tool_input && input.tool_input.command) || "";
 
 const BLOCKED_PATTERNS = [

--- a/templates/hooks/dev-team-tdd-enforce.js
+++ b/templates/hooks/dev-team-tdd-enforce.js
@@ -17,7 +17,15 @@
 const { execFileSync } = require("child_process");
 const path = require("path");
 
-const input = JSON.parse(process.argv[2] || "{}");
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || "{}");
+} catch (err) {
+  console.warn(
+    `[dev-team tdd-enforce] Warning: Failed to parse hook input, allowing operation. ${err.message}`,
+  );
+  process.exit(0);
+}
 const filePath = (input.tool_input && (input.tool_input.file_path || input.tool_input.path)) || "";
 
 if (!filePath) {

--- a/tests/unit/files.test.js
+++ b/tests/unit/files.test.js
@@ -105,6 +105,17 @@ describe('mergeSettings', () => {
     const result = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
     assert.equal(result.hooks.PreToolUse.length, 1);
   });
+
+  it('warns and starts fresh when settings file contains corrupt JSON', () => {
+    const settingsPath = path.join(tmpDir, 'settings.json');
+    fs.writeFileSync(settingsPath, '{ invalid json');
+
+    const fragment = { hooks: { PostToolUse: [{ matcher: 'Edit', hooks: [{ type: 'command', command: 'test' }] }] } };
+    mergeSettings(settingsPath, fragment);
+
+    const result = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    assert.deepEqual(result.hooks.PostToolUse[0].matcher, 'Edit');
+  });
 });
 
 describe('mergeClaudeMd', () => {
@@ -137,5 +148,17 @@ describe('mergeClaudeMd', () => {
     assert.ok(content.includes('updated'));
     assert.ok(!content.includes('old'));
     assert.ok(content.includes('Footer'));
+  });
+
+  it('appends instead of corrupting when begin marker exists but end marker is missing', () => {
+    const p = path.join(tmpDir, 'CLAUDE.md');
+    fs.writeFileSync(p, '# Project\n\n<!-- dev-team:begin -->\nold content without end marker');
+
+    const result = mergeClaudeMd(p, '<!-- dev-team:begin -->\nnew\n<!-- dev-team:end -->');
+    assert.equal(result, 'appended');
+
+    const content = fs.readFileSync(p, 'utf-8');
+    assert.ok(content.includes('old content without end marker'), 'should preserve original content');
+    assert.ok(content.includes('new'), 'should append new content');
   });
 });


### PR DESCRIPTION
## Summary

- **mergeClaudeMd**: detect missing END marker, warn and append instead of corrupting
- **mergeSettings**: distinguish file-not-found from corrupt JSON, warn on corruption
- **Hook JSON.parse**: wrap in try-catch with `console.warn` across all 3 template hooks + 4 dogfooded hooks
- **Dogfooded lint/format hooks**: per-file oxlint+oxfmt on PostToolUse, full check on pre-commit
- **@dev-team-deming**: updated to recommend layered enforcement placement (PostToolUse → pre-commit → CI)
- 2 new unit tests covering the edge cases

## Review notes

Reviewed by `@dev-team-knuth` and `@dev-team-szabo` through the adversarial task loop. Two iterations:
1. Core fixes + tests
2. Fixed dogfooded hooks (Szabo caught `.claude/hooks/` copies were missed + `dev-team-issue-pr-enforce.js`), added `console.warn` to catch blocks

## Test plan

- [x] `npm run build` compiles without errors
- [x] `npm test` passes all 25 tests (2 new edge case tests)
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [ ] CI passes on all 3 OS x 3 Node versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)