### PR TITLE
feat: add GitHub Release creation to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,14 @@ name: Release
 
 on:
   push:
-    tags: ['v*']
-
-permissions:
-  contents: read
-  id-token: write
+    tags: ['v[0-9]*']
 
 jobs:
-  validate:
+  publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -54,3 +53,34 @@ jobs:
         run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  github-release:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract changelog for this version
+        run: |
+          VERSION="${TAG_REF#v}"
+          NOTES=$(awk -v ver="$VERSION" '
+            index($0, "## [" ver "]") == 1 { found=1; next }
+            /^## \[/ { if(found) exit }
+            found { print }
+          ' CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            echo "::warning::No changelog entry found for version ${VERSION}"
+            echo "Release ${VERSION}" > /tmp/release-notes.md
+          else
+            echo "$NOTES" | sed '/./,$!d' > /tmp/release-notes.md
+          fi
+        env:
+          TAG_REF: ${{ github.ref_name }}
+
+      - name: Create GitHub Release
+        run: gh release create "$TAG_REF" --title "$TAG_REF" --notes-file /tmp/release-notes.md
+        env:
+          TAG_REF: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- Split release workflow into `publish` and `github-release` jobs with scoped permissions
- Extract changelog section for the tagged version using awk string matching (not regex)
- Create GitHub Release with changelog as body after successful npm publish
- Tighten tag filter from `v*` to `v[0-9]*`
- Guard against empty changelog (warns, uses fallback text)

## Review notes

Reviewed by @dev-team-szabo (security) and @dev-team-knuth (quality) using actual agent definitions. Both converged on the same core issues (awk regex, permission scope, empty changelog). All addressed.

## Test plan

- [ ] CI passes
- [ ] Verify on next release tag that GitHub Release is created with correct changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)