### PR TITLE
test: add scenario tests for Node.js, Python, and upgrade paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,10 @@
   "scripts": {
     "build": "tsc",
     "pretest": "npm run build",
-    "test": "node --test tests/unit/files.test.js tests/unit/hooks.test.js tests/integration/fresh-project.test.js tests/integration/idempotency.test.js",
+    "test": "node --test tests/unit/files.test.js tests/unit/hooks.test.js tests/integration/fresh-project.test.js tests/integration/idempotency.test.js tests/scenarios/node-project.test.js tests/scenarios/python-project.test.js tests/scenarios/upgrade-path.test.js",
     "test:unit": "node --test tests/unit/files.test.js tests/unit/hooks.test.js",
     "test:integration": "node --test tests/integration/fresh-project.test.js tests/integration/idempotency.test.js",
+    "test:scenarios": "node --test tests/scenarios/node-project.test.js tests/scenarios/python-project.test.js tests/scenarios/upgrade-path.test.js",
     "lint": "oxlint src/ scripts/ templates/hooks/",
     "format": "oxfmt --write src/ scripts/ templates/hooks/",
     "format:check": "oxfmt --check src/ scripts/ templates/hooks/",

--- a/tests/scenarios/node-project.test.js
+++ b/tests/scenarios/node-project.test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const { run } = require('../../dist/init');
+
+let tmpDir;
+let originalCwd;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-team-node-'));
+  originalCwd = process.cwd();
+  process.chdir(tmpDir);
+
+  // Simulate a Node.js project
+  fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({
+    name: 'my-node-app',
+    version: '1.0.0',
+    scripts: { test: 'node --test' },
+  }, null, 2));
+  fs.mkdirSync(path.join(tmpDir, 'src'));
+  fs.writeFileSync(path.join(tmpDir, 'src', 'index.js'), 'module.exports = { hello: () => "world" };');
+  fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), '# My Node App\n\nExisting project instructions.\n');
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('Node.js project scenario', () => {
+  it('installs into a project with existing package.json and CLAUDE.md', async () => {
+    await run(tmpDir, ['--all']);
+
+    // Agents installed
+    const agents = fs.readdirSync(path.join(tmpDir, '.claude', 'agents'));
+    assert.equal(agents.length, 6);
+    assert.ok(agents.includes('dev-team-voss.md'));
+
+    // Hooks installed
+    const hooks = fs.readdirSync(path.join(tmpDir, '.claude', 'hooks'));
+    assert.equal(hooks.length, 5);
+
+    // Existing CLAUDE.md preserved
+    const claudeMd = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf-8');
+    assert.ok(claudeMd.includes('My Node App'), 'should preserve existing content');
+    assert.ok(claudeMd.includes('dev-team:begin'), 'should add dev-team section');
+
+    // Original package.json untouched
+    const pkg = JSON.parse(fs.readFileSync(path.join(tmpDir, 'package.json'), 'utf-8'));
+    assert.equal(pkg.name, 'my-node-app');
+
+    // Settings.json has hook configuration
+    const settings = JSON.parse(fs.readFileSync(path.join(tmpDir, '.claude', 'settings.json'), 'utf-8'));
+    assert.ok(settings.hooks.PreToolUse, 'should have PreToolUse hooks');
+    assert.ok(settings.hooks.PostToolUse, 'should have PostToolUse hooks');
+  });
+
+  it('agent files reference language-agnostic patterns', async () => {
+    await run(tmpDir, ['--all']);
+
+    // Voss agent should not be Node-specific
+    const voss = fs.readFileSync(path.join(tmpDir, '.claude', 'agents', 'dev-team-voss.md'), 'utf-8');
+    assert.ok(!voss.includes('require('), 'agent should not contain Node-specific code');
+    assert.ok(voss.includes('description:'), 'should have valid frontmatter');
+  });
+
+  it('hooks are executable Node.js scripts', async () => {
+    await run(tmpDir, ['--all']);
+
+    const hookDir = path.join(tmpDir, '.claude', 'hooks');
+    const hookFiles = fs.readdirSync(hookDir);
+
+    for (const file of hookFiles) {
+      const content = fs.readFileSync(path.join(hookDir, file), 'utf-8');
+      assert.ok(content.startsWith('#!/usr/bin/env node'), `${file} should have node shebang`);
+    }
+  });
+});

--- a/tests/scenarios/python-project.test.js
+++ b/tests/scenarios/python-project.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const { run } = require('../../dist/init');
+
+let tmpDir;
+let originalCwd;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-team-python-'));
+  originalCwd = process.cwd();
+  process.chdir(tmpDir);
+
+  // Simulate a Python project
+  fs.writeFileSync(path.join(tmpDir, 'pyproject.toml'), '[project]\nname = "my-python-app"\nversion = "1.0.0"\n');
+  fs.mkdirSync(path.join(tmpDir, 'src', 'my_app'), { recursive: true });
+  fs.writeFileSync(path.join(tmpDir, 'src', 'my_app', '__init__.py'), '');
+  fs.writeFileSync(path.join(tmpDir, 'src', 'my_app', 'main.py'), 'def hello():\n    return "world"\n');
+  fs.mkdirSync(path.join(tmpDir, 'tests'));
+  fs.writeFileSync(path.join(tmpDir, 'tests', 'test_main.py'), 'def test_hello():\n    assert True\n');
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('Python project scenario', () => {
+  it('installs into a Python project without Node artifacts', async () => {
+    await run(tmpDir, ['--all']);
+
+    // Agents installed
+    assert.ok(fs.existsSync(path.join(tmpDir, '.claude', 'agents', 'dev-team-szabo.md')));
+    assert.ok(fs.existsSync(path.join(tmpDir, '.claude', 'agents', 'dev-team-knuth.md')));
+
+    // No package.json created (dev-team should not add Node artifacts to Python projects)
+    assert.ok(!fs.existsSync(path.join(tmpDir, 'package.json')), 'should not create package.json');
+
+    // CLAUDE.md created fresh (no existing one)
+    assert.ok(fs.existsSync(path.join(tmpDir, 'CLAUDE.md')));
+    const claudeMd = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf-8');
+    assert.ok(claudeMd.includes('dev-team:begin'));
+
+    // pyproject.toml untouched
+    const pyproject = fs.readFileSync(path.join(tmpDir, 'pyproject.toml'), 'utf-8');
+    assert.ok(pyproject.includes('my-python-app'));
+  });
+
+  it('hooks work with Python file paths', async () => {
+    await run(tmpDir, ['--all']);
+
+    // The post-change-review hook should flag Knuth for .py files
+    const { execFileSync } = require('child_process');
+    const hookPath = path.join(tmpDir, '.claude', 'hooks', 'dev-team-post-change-review.js');
+    const input = JSON.stringify({ tool_input: { file_path: '/app/src/my_app/main.py' } });
+
+    const stdout = execFileSync(process.execPath, [hookPath, input], {
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+    assert.ok(stdout.includes('@dev-team-knuth'), 'should flag Knuth for .py files');
+  });
+
+  it('tdd-enforce recognizes Python test patterns', async () => {
+    await run(tmpDir, ['--all']);
+
+    const { execFileSync } = require('child_process');
+    const hookPath = path.join(tmpDir, '.claude', 'hooks', 'dev-team-tdd-enforce.js');
+
+    // Python test files should be skipped (not blocked)
+    const input = JSON.stringify({ tool_input: { file_path: '/app/tests/test_main.py' } });
+    const stdout = execFileSync(process.execPath, [hookPath, input], {
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+    // Exit 0 means allowed
+    assert.ok(true);
+  });
+});

--- a/tests/scenarios/upgrade-path.test.js
+++ b/tests/scenarios/upgrade-path.test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const { run } = require('../../dist/init');
+
+let tmpDir;
+let originalCwd;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-team-upgrade-'));
+  originalCwd = process.cwd();
+  process.chdir(tmpDir);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('upgrade path scenario', () => {
+  it('re-running init preserves customizations and adds new content', async () => {
+    // First install
+    await run(tmpDir, ['--all']);
+
+    // Simulate user customizations
+    const claudeMdPath = path.join(tmpDir, 'CLAUDE.md');
+    const originalClaudeMd = fs.readFileSync(claudeMdPath, 'utf-8');
+    fs.writeFileSync(claudeMdPath, '# My Custom Rules\n\nDo X not Y.\n\n' + originalClaudeMd);
+
+    // Simulate agent memory accumulation
+    const memoryPath = path.join(tmpDir, '.claude', 'agent-memory', 'dev-team-voss', 'MEMORY.md');
+    fs.writeFileSync(memoryPath, '# Voss Memory\n\n- Uses PostgreSQL\n- REST API with Express\n');
+
+    // Simulate custom settings additions
+    const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    settings.customField = 'user-added';
+    fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+
+    // Re-run init (simulating upgrade)
+    await run(tmpDir, ['--all']);
+
+    // Custom CLAUDE.md content preserved
+    const updatedClaudeMd = fs.readFileSync(claudeMdPath, 'utf-8');
+    assert.ok(updatedClaudeMd.includes('My Custom Rules'), 'should preserve custom content above markers');
+    assert.ok(updatedClaudeMd.includes('Do X not Y'), 'should preserve custom instructions');
+    assert.ok(updatedClaudeMd.includes('dev-team:begin'), 'should still have dev-team section');
+
+    // Agent memory preserved
+    const memory = fs.readFileSync(memoryPath, 'utf-8');
+    assert.ok(memory.includes('PostgreSQL'), 'should preserve accumulated agent memory');
+
+    // Custom settings field preserved
+    const updatedSettings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    assert.equal(updatedSettings.customField, 'user-added', 'should preserve custom settings fields');
+
+    // Hooks not duplicated
+    for (const [event, entries] of Object.entries(updatedSettings.hooks)) {
+      const commands = entries.flatMap((e) => (e.hooks || []).map((h) => h.command));
+      const unique = [...new Set(commands)];
+      assert.equal(commands.length, unique.length, `${event} hooks should not have duplicates after re-run`);
+    }
+  });
+
+  it('handles project that already has .claude/ with non-dev-team content', async () => {
+    // Pre-existing .claude directory with custom agents
+    fs.mkdirSync(path.join(tmpDir, '.claude', 'agents'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, '.claude', 'agents', 'custom-agent.md'), '---\nname: custom\n---\nMy agent');
+    fs.writeFileSync(path.join(tmpDir, '.claude', 'settings.json'), JSON.stringify({
+      hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'echo custom' }] }] },
+    }));
+
+    await run(tmpDir, ['--all']);
+
+    // Custom agent preserved
+    assert.ok(fs.existsSync(path.join(tmpDir, '.claude', 'agents', 'custom-agent.md')), 'should not delete custom agents');
+
+    // Dev-team agents added alongside
+    assert.ok(fs.existsSync(path.join(tmpDir, '.claude', 'agents', 'dev-team-voss.md')));
+
+    // Custom hooks preserved alongside dev-team hooks
+    const settings = JSON.parse(fs.readFileSync(path.join(tmpDir, '.claude', 'settings.json'), 'utf-8'));
+    const preToolUseCommands = settings.hooks.PreToolUse.flatMap((e) => (e.hooks || []).map((h) => h.command));
+    assert.ok(preToolUseCommands.includes('echo custom'), 'should preserve custom hooks');
+    assert.ok(preToolUseCommands.some((c) => c.includes('dev-team')), 'should add dev-team hooks');
+  });
+});


### PR DESCRIPTION
## Summary

- Node.js project scenario: install with existing package.json + CLAUDE.md
- Python project scenario: verify language-agnostic install and hook behavior
- Upgrade path scenario: re-run preserves customizations, handles pre-existing .claude/

90 total tests (was 82).

## Test plan

- [x] `npm test` passes all 90 tests
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)