### PR TITLE
fix: add learnings placement guide to CLAUDE.md template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,19 @@ Agents challenge each other using classified findings:
 - `/dev-team:challenge` — critically examine a proposal or implementation
 - `/dev-team:task` — start an iterative task loop with adversarial review gates
 
+### Learnings — where to write what
+
+All project and process learnings MUST go to in-repo files, NOT to machine-local memory (`~/.claude/projects/`). Machine-local memory is invisible to other developers, agents, and sessions.
+
+| What | Where | Examples |
+|------|-------|---------|
+| Project patterns, process rules, tech debt, overruled challenges | `.claude/dev-team-learnings.md` | "We use PostgreSQL", "Hooks over guidelines", "Knuth's finding X was overruled because Y" |
+| Agent-specific calibration | `.claude/agent-memory/<agent>/MEMORY.md` | Szabo: "Auth uses JWT not sessions", Knuth: "Coverage weak in parsers" |
+| Formal architecture decisions | `docs/adr/` | ADR format, not learnings |
+| User-specific preferences only | Machine-local memory | Personal style, name, role — things that vary per person, not per project |
+
+When the human gives feedback about process, coding style, or tool behavior: write it to `dev-team-learnings.md`. Only use machine-local memory for things that are truly personal and would not apply to another developer on the same project.
+
 <!-- dev-team:end -->
 
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -28,4 +28,17 @@ Agents challenge each other using classified findings:
 - `/dev-team:challenge` — critically examine a proposal or implementation
 - `/dev-team:task` — start an iterative task loop with adversarial review gates
 
+### Learnings — where to write what
+
+All project and process learnings MUST go to in-repo files, NOT to machine-local memory (`~/.claude/projects/`). Machine-local memory is invisible to other developers, agents, and sessions.
+
+| What | Where | Examples |
+|------|-------|---------|
+| Project patterns, process rules, tech debt, overruled challenges | `.claude/dev-team-learnings.md` | "We use PostgreSQL", "Hooks over guidelines", "Knuth's finding X was overruled because Y" |
+| Agent-specific calibration | `.claude/agent-memory/<agent>/MEMORY.md` | Szabo: "Auth uses JWT not sessions", Knuth: "Coverage weak in parsers" |
+| Formal architecture decisions | `docs/adr/` | ADR format, not learnings |
+| User-specific preferences only | Machine-local memory | Personal style, name, role — things that vary per person, not per project |
+
+When the human gives feedback about process, coding style, or tool behavior: write it to `dev-team-learnings.md`. Only use machine-local memory for things that are truly personal and would not apply to another developer on the same project.
+
 <!-- dev-team:end -->


### PR DESCRIPTION
## Summary

Add a "Learnings — where to write what" section to the CLAUDE.md template that directs AI assistants to write project learnings to in-repo files, not machine-local memory.

| What | Where |
|------|-------|
| Project patterns, process, tech debt | `.claude/dev-team-learnings.md` |
| Agent-specific calibration | `.claude/agent-memory/<agent>/MEMORY.md` |
| Architecture decisions | `docs/adr/` |
| User-specific preferences only | Machine-local memory |

Without this, learnings are invisible to other developers and agents.

## Test plan

- [ ] CI passes
- [x] Template content matches dogfooded CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)