### PR TITLE
feat: add /dev-team:review and /dev-team:audit skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ Agents challenge each other using classified findings:
 
 - `/dev-team:challenge` — critically examine a proposal or implementation
 - `/dev-team:task` — start an iterative task loop with adversarial review gates
+- `/dev-team:review` — orchestrated multi-agent parallel review of changes
+- `/dev-team:audit` — full codebase security + quality + tooling audit
 
 ### Learnings — where to write what
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -253,7 +253,7 @@ export async function run(targetDir: string, flags: string[] = []): Promise<void
 
   // Step 9: Copy skills
   const skillsSrcDir = path.join(templates, "skills");
-  const skillDirs = ["dev-team-challenge", "dev-team-task"];
+  const skillDirs = ["dev-team-challenge", "dev-team-task", "dev-team-review", "dev-team-audit"];
   for (const skillDir of skillDirs) {
     const src = path.join(skillsSrcDir, skillDir, "SKILL.md");
     const dest = path.join(skillsDir, skillDir, "SKILL.md");
@@ -283,7 +283,7 @@ export async function run(targetDir: string, flags: string[] = []): Promise<void
   console.log("\nDone! Installed:\n");
   console.log(`  Agents:    ${selectedAgents.join(", ")} (${agentCount} files)`);
   console.log(`  Hooks:     ${selectedHooks.join(", ")} (${hookCount} files)`);
-  console.log("  Skills:    challenge, task");
+  console.log("  Skills:    challenge, task, review, audit");
   console.log(`  Memory:    ${selectedAgents.length} agent memories + shared learnings`);
   console.log(`  CLAUDE.md: ${claudeResult}`);
   console.log(`  Settings:  ${settingsPath}`);

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -27,6 +27,8 @@ Agents challenge each other using classified findings:
 
 - `/dev-team:challenge` — critically examine a proposal or implementation
 - `/dev-team:task` — start an iterative task loop with adversarial review gates
+- `/dev-team:review` — orchestrated multi-agent parallel review of changes
+- `/dev-team:audit` — full codebase security + quality + tooling audit
 
 ### Learnings — where to write what
 

--- a/templates/skills/dev-team-audit/SKILL.md
+++ b/templates/skills/dev-team-audit/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: dev-team:audit
+description: Full codebase audit combining security, quality, and tooling assessments. Use to run a comprehensive scan with Szabo (security), Knuth (quality), and Deming (tooling) in parallel. Can be scoped to specific directories or file patterns.
+---
+
+Run a comprehensive audit of: $ARGUMENTS
+
+## Setup
+
+1. Determine the audit scope:
+   - If a directory or file pattern is given, scope the audit to those paths
+   - If no argument, audit the entire codebase
+   - Respect `.gitignore` — skip `node_modules/`, `dist/`, build artifacts
+
+2. The audit always spawns three specialist agents:
+   - **@dev-team-szabo** — Security audit
+   - **@dev-team-knuth** — Quality and correctness audit
+   - **@dev-team-deming** — Tooling and automation audit
+
+## Execution
+
+1. Spawn all three agents as **parallel background subagents** using the Agent tool with `subagent_type: "general-purpose"`.
+
+2. Each agent's prompt must include:
+   - The agent's full definition (read from `.claude/agents/<agent>.md`)
+   - The scope (directory/pattern or "full codebase")
+   - Instruction to produce classified findings: `[DEFECT]`, `[RISK]`, `[QUESTION]`, `[SUGGESTION]`
+   - Instruction to read the actual code and tests for full context
+
+3. Agent-specific instructions:
+
+   **Szabo (Security)**:
+   - Map all trust boundaries and entry points
+   - Check for OWASP Top 10 vulnerabilities
+   - Audit auth/authz flows end-to-end
+   - Review secret management and dependency vulnerabilities
+
+   **Knuth (Quality)**:
+   - Identify untested code paths and coverage gaps
+   - Find boundary conditions without tests
+   - Check assertion quality in existing tests
+   - Map test-to-requirement traceability
+
+   **Deming (Tooling)**:
+   - Inventory current tooling (linters, formatters, SAST, CI)
+   - Identify missing automation opportunities
+   - Check for stale dependencies and known vulnerabilities
+   - Evaluate CI pipeline efficiency
+
+4. Wait for all agents to complete.
+
+## Report
+
+Produce a consolidated audit report:
+
+### Executive summary
+
+One paragraph summarizing the overall health of the codebase across all three domains.
+
+### Security findings (@dev-team-szabo)
+
+List all findings, grouped by classification:
+- `[DEFECT]` — must fix
+- `[RISK]` — should address
+- `[QUESTION]` / `[SUGGESTION]` — consider
+
+### Quality findings (@dev-team-knuth)
+
+Same grouping. Include specific files and line references.
+
+### Tooling findings (@dev-team-deming)
+
+Same grouping. Include actionable recommendations.
+
+### Priority matrix
+
+| Priority | Finding | Agent | Action |
+|----------|---------|-------|--------|
+| P0 (fix now) | `[DEFECT]` items | ... | ... |
+| P1 (fix soon) | `[RISK]` items | ... | ... |
+| P2 (improve) | `[SUGGESTION]` items | ... | ... |
+
+### Recommended next steps
+
+Numbered list of concrete actions, ordered by priority. Each action should reference the specific finding it addresses.

--- a/templates/skills/dev-team-review/SKILL.md
+++ b/templates/skills/dev-team-review/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: dev-team:review
+description: Orchestrated multi-agent parallel review. Use to review a PR, branch, or set of changes with multiple specialist agents simultaneously. Spawns agents based on changed file patterns and produces a unified review summary.
+---
+
+Run a multi-agent parallel review of: $ARGUMENTS
+
+## Setup
+
+1. Determine what to review:
+   - If a PR number or branch is given, use `git diff` to get the changed files
+   - If a directory or file pattern is given, review those files
+   - If no argument, review all uncommitted changes (`git diff HEAD`)
+
+2. Categorize changed files by domain to determine which agents to spawn:
+
+| File pattern | Agent | Reason |
+|---|---|---|
+| `auth`, `login`, `password`, `token`, `session`, `crypto`, `secret`, `permission`, `oauth`, `jwt`, `cors`, `csrf` | @dev-team-szabo | Security surface |
+| `/api/`, `/routes/`, `schema`, `.graphql`, `.proto`, `openapi` | @dev-team-mori | API/UI contract |
+| `docker`, `.env`, `config`, `migration`, `database`, `.sql`, `deploy` | @dev-team-voss | Infrastructure |
+| `.github/workflows`, `.claude/`, `tsconfig`, `eslint`, `prettier`, `package.json` | @dev-team-deming | Tooling |
+| `readme`, `changelog`, `.md`, `/docs/` | @dev-team-docs | Documentation |
+| `/adr/`, `architecture`, `/core/`, `/domain/` | @dev-team-architect | Architecture |
+| `package.json`, `version`, `changelog`, release workflows | @dev-team-release | Release artifacts |
+| Any `.js`, `.ts`, `.py`, `.go`, `.java`, `.rs` (non-test) | @dev-team-knuth | Quality/coverage |
+
+3. Always include @dev-team-szabo and @dev-team-knuth — they review all code changes.
+
+## Execution
+
+1. Spawn each selected agent as a **parallel background subagent** using the Agent tool with `subagent_type: "general-purpose"`.
+
+2. Each agent's prompt must include:
+   - The agent's full definition (read from `.claude/agents/<agent>.md`)
+   - The list of changed files relevant to their domain
+   - Instruction to produce classified findings: `[DEFECT]`, `[RISK]`, `[QUESTION]`, `[SUGGESTION]`
+   - Instruction to read the actual code — not just the diff — for full context
+
+3. Wait for all agents to complete.
+
+## Report
+
+Produce a unified review summary:
+
+### Blocking findings ([DEFECT])
+
+List all `[DEFECT]` findings from all agents. These must be resolved before merge.
+
+Format each as:
+```
+**[DEFECT]** @agent-name — file:line
+Description of the defect and why it blocks.
+```
+
+### Advisory findings
+
+Group by severity:
+- **[RISK]** — likely failure modes
+- **[QUESTION]** — decisions needing justification
+- **[SUGGESTION]** — specific improvements
+
+### Verdict
+
+- **Approve** — No `[DEFECT]` findings. Advisory items noted.
+- **Request changes** — `[DEFECT]` findings must be resolved.
+
+State the verdict clearly. List what must be fixed for approval if requesting changes.


### PR DESCRIPTION
## Summary
- Adds `/dev-team:review` skill — orchestrated multi-agent parallel review that spawns agents based on changed file patterns, collects classified findings, and produces a unified review with approve/request-changes verdict
- Adds `/dev-team:audit` skill — full codebase audit spawning Szabo (security), Knuth (quality), and Deming (tooling) in parallel with consolidated priority matrix
- Both skills registered in installer and documented in CLAUDE.md template

## Test plan
- [x] All 90 tests pass (skills are template files, installed via existing copyFile path)
- [x] Skill YAML frontmatter valid
- [x] Installer registers both new skills in `skillDirs` array
- [x] CLAUDE.md template lists both new skills

Fixes #14, Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)