### PR TITLE
feat: add memory freshness check to pre-commit gate (#39)

### DIFF
--- a/templates/hooks/dev-team-pre-commit-gate.js
+++ b/templates/hooks/dev-team-pre-commit-gate.js
@@ -50,8 +50,39 @@ if (hasApiFiles) {
   reminders.push("@dev-team-mori for UI impact review");
 }
 
+// Memory freshness check: if significant work was done but no memory files were updated, remind.
+const hasMemoryUpdates = files.some(
+  (f) => /dev-team-learnings\.md$/.test(f) || /agent-memory\/.*MEMORY\.md$/.test(f),
+);
+
+if (hasImplFiles && !hasMemoryUpdates) {
+  // Check unstaged memory changes too — author may have updated but not staged yet
+  let unstagedMemory = false;
+  try {
+    const unstaged = execFileSync("git", ["diff", "--name-only"], {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    unstagedMemory = unstaged
+      .split("\n")
+      .some((f) => /dev-team-learnings\.md$/.test(f) || /agent-memory\/.*MEMORY\.md$/.test(f));
+  } catch {
+    // Ignore — best effort
+  }
+
+  if (unstagedMemory) {
+    reminders.push(
+      "Memory files were updated but not staged — run `git add .claude/dev-team-learnings.md .claude/agent-memory/` if learnings should be included",
+    );
+  } else {
+    reminders.push(
+      "Update .claude/dev-team-learnings.md or agent memory with any patterns, conventions, or decisions from this work",
+    );
+  }
+}
+
 if (reminders.length > 0) {
-  console.log(`[dev-team pre-commit] Before committing, consider running: ${reminders.join(", ")}`);
+  console.log(`[dev-team pre-commit] Before committing, consider: ${reminders.join("; ")}`);
 }
 
 process.exit(0);

--- a/tests/unit/hooks.test.js
+++ b/tests/unit/hooks.test.js
@@ -354,6 +354,70 @@ describe('dev-team-pre-commit-gate', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it('reminds to update memory when code is staged without memory files', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-team-precommit-'));
+    try {
+      execFileSync('git', ['init'], { cwd: tmpDir, encoding: 'utf-8' });
+      execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: tmpDir, encoding: 'utf-8' });
+      execFileSync('git', ['config', 'user.name', 'Test'], { cwd: tmpDir, encoding: 'utf-8' });
+      fs.writeFileSync(path.join(tmpDir, 'handler.js'), 'module.exports = {}');
+      execFileSync('git', ['add', 'handler.js'], { cwd: tmpDir, encoding: 'utf-8' });
+
+      const stdout = execFileSync(process.execPath, [path.join(HOOKS_DIR, hook)], {
+        encoding: 'utf-8',
+        timeout: 5000,
+        cwd: tmpDir,
+      });
+      assert.ok(stdout.includes('dev-team-learnings'), 'should remind about learnings');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not remind about memory when learnings file is staged', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-team-precommit-'));
+    try {
+      execFileSync('git', ['init'], { cwd: tmpDir, encoding: 'utf-8' });
+      execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: tmpDir, encoding: 'utf-8' });
+      execFileSync('git', ['config', 'user.name', 'Test'], { cwd: tmpDir, encoding: 'utf-8' });
+      fs.mkdirSync(path.join(tmpDir, '.claude'), { recursive: true });
+      fs.writeFileSync(path.join(tmpDir, 'handler.js'), 'module.exports = {}');
+      fs.writeFileSync(path.join(tmpDir, '.claude', 'dev-team-learnings.md'), '# Updated');
+      execFileSync('git', ['add', 'handler.js', '.claude/dev-team-learnings.md'], { cwd: tmpDir, encoding: 'utf-8' });
+
+      const stdout = execFileSync(process.execPath, [path.join(HOOKS_DIR, hook)], {
+        encoding: 'utf-8',
+        timeout: 5000,
+        cwd: tmpDir,
+      });
+      assert.ok(!stdout.includes('dev-team-learnings'), 'should not remind when learnings are staged');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not remind about memory when agent memory is staged', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-team-precommit-'));
+    try {
+      execFileSync('git', ['init'], { cwd: tmpDir, encoding: 'utf-8' });
+      execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: tmpDir, encoding: 'utf-8' });
+      execFileSync('git', ['config', 'user.name', 'Test'], { cwd: tmpDir, encoding: 'utf-8' });
+      fs.mkdirSync(path.join(tmpDir, '.claude', 'agent-memory', 'dev-team-voss'), { recursive: true });
+      fs.writeFileSync(path.join(tmpDir, 'handler.js'), 'module.exports = {}');
+      fs.writeFileSync(path.join(tmpDir, '.claude', 'agent-memory', 'dev-team-voss', 'MEMORY.md'), '# Updated');
+      execFileSync('git', ['add', 'handler.js', '.claude/agent-memory/dev-team-voss/MEMORY.md'], { cwd: tmpDir, encoding: 'utf-8' });
+
+      const stdout = execFileSync(process.execPath, [path.join(HOOKS_DIR, hook)], {
+        encoding: 'utf-8',
+        timeout: 5000,
+        cwd: tmpDir,
+      });
+      assert.ok(!stdout.includes('dev-team-learnings'), 'should not remind when agent memory is staged');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ─── Task Loop ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Extends `dev-team-pre-commit-gate.js` (TaskCompleted hook) to check memory freshness
- When implementation code is staged but no `dev-team-learnings.md` or `agent-memory/*.md` files are included, reminds to update them
- Detects unstaged memory changes and suggests staging them
- Advisory only — always exits 0

## Test plan
- [x] Reminder fires when code staged without memory files
- [x] Reminder suppressed when `dev-team-learnings.md` is staged
- [x] Reminder suppressed when agent memory MEMORY.md is staged
- [x] All 109 tests pass
- [x] Existing pre-commit gate behavior unchanged

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)