### PR TITLE
feat: add configurable agent watch lists (#25)

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -91,6 +91,11 @@ const QUALITY_HOOKS: HookDefinition[] = [
     file: "dev-team-task-loop.js",
     description: "Iterative task loop with adversarial review gates",
   },
+  {
+    label: "Watch list",
+    file: "dev-team-watch-list.js",
+    description: "Auto-spawn agents when file patterns match (configurable)",
+  },
 ];
 
 interface PresetDefinition {

--- a/templates/hooks/dev-team-watch-list.js
+++ b/templates/hooks/dev-team-watch-list.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+/**
+ * dev-team-watch-list.js
+ * PostToolUse hook on Edit/Write.
+ *
+ * Reads configurable file-pattern-to-agent mappings from .claude/dev-team.json
+ * and outputs structured spawn recommendations when patterns match.
+ * Advisory only — always exits 0.
+ *
+ * Config format in dev-team.json:
+ * {
+ *   "watchLists": [
+ *     { "pattern": "src/db/", "agents": ["dev-team-codd"], "reason": "database code changed" },
+ *     { "pattern": "\\.graphql$", "agents": ["dev-team-mori", "dev-team-voss"], "reason": "API schema changed" }
+ *   ]
+ * }
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || "{}");
+} catch (err) {
+  console.warn(
+    `[dev-team watch-list] Warning: Failed to parse hook input, allowing operation. ${err.message}`,
+  );
+  process.exit(0);
+}
+
+const filePath = (input.tool_input && (input.tool_input.file_path || input.tool_input.path)) || "";
+
+if (!filePath) {
+  process.exit(0);
+}
+
+// Read watch list config
+let watchLists = [];
+try {
+  const prefsPath = path.join(process.cwd(), ".claude", "dev-team.json");
+  const prefs = JSON.parse(fs.readFileSync(prefsPath, "utf-8"));
+  watchLists = prefs.watchLists || [];
+} catch {
+  // No config or invalid — skip silently
+  process.exit(0);
+}
+
+if (watchLists.length === 0) {
+  process.exit(0);
+}
+
+const matches = [];
+
+for (const entry of watchLists) {
+  if (!entry.pattern || !entry.agents) continue;
+
+  try {
+    const regex = new RegExp(entry.pattern);
+    if (regex.test(filePath)) {
+      for (const agent of entry.agents) {
+        if (!matches.some((m) => m.agent === agent)) {
+          matches.push({
+            agent,
+            reason: entry.reason || `file matched pattern: ${entry.pattern}`,
+          });
+        }
+      }
+    }
+  } catch {
+    // Invalid regex — skip this entry
+    continue;
+  }
+}
+
+if (matches.length > 0) {
+  const agentList = matches.map((m) => `@${m.agent} (${m.reason})`).join(", ");
+  console.log(`[dev-team watch-list] Spawn recommended: ${agentList}`);
+}
+
+process.exit(0);

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -11,6 +11,10 @@
           {
             "type": "command",
             "command": "node .claude/hooks/dev-team-tdd-enforce.js"
+          },
+          {
+            "type": "command",
+            "command": "node .claude/hooks/dev-team-watch-list.js"
           }
         ]
       }

--- a/tests/scenarios/node-project.test.js
+++ b/tests/scenarios/node-project.test.js
@@ -43,7 +43,7 @@ describe('Node.js project scenario', () => {
 
     // Hooks installed
     const hooks = fs.readdirSync(path.join(tmpDir, '.claude', 'hooks'));
-    assert.equal(hooks.length, 5);
+    assert.equal(hooks.length, 6);
 
     // Existing CLAUDE.md preserved
     const claudeMd = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf-8');

--- a/tests/unit/hooks.test.js
+++ b/tests/unit/hooks.test.js
@@ -420,6 +420,103 @@ describe('dev-team-pre-commit-gate', () => {
   });
 });
 
+// ─── Watch List ──────────────────────────────────────────────────────────────
+
+describe('dev-team-watch-list', () => {
+  const hook = 'dev-team-watch-list.js';
+  let tmpDir;
+  let originalCwd;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-team-watchlist-'));
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+    fs.mkdirSync(path.join(tmpDir, '.claude'), { recursive: true });
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('exits 0 with no config file', () => {
+    const input = JSON.stringify({ tool_input: { file_path: '/app/src/db/schema.ts' } });
+    const stdout = execFileSync(process.execPath, [path.join(HOOKS_DIR, hook), input], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      cwd: tmpDir,
+    });
+    assert.equal(stdout, '');
+  });
+
+  it('matches file patterns and recommends agent spawn', () => {
+    const prefs = {
+      watchLists: [
+        { pattern: 'src/db/', agents: ['dev-team-codd'], reason: 'database code changed' },
+      ],
+    };
+    fs.writeFileSync(path.join(tmpDir, '.claude', 'dev-team.json'), JSON.stringify(prefs));
+
+    const input = JSON.stringify({ tool_input: { file_path: '/app/src/db/schema.ts' } });
+    const stdout = execFileSync(process.execPath, [path.join(HOOKS_DIR, hook), input], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      cwd: tmpDir,
+    });
+    assert.ok(stdout.includes('@dev-team-codd'), 'should recommend codd');
+    assert.ok(stdout.includes('database code changed'), 'should include reason');
+  });
+
+  it('does not match when pattern does not match file', () => {
+    const prefs = {
+      watchLists: [
+        { pattern: 'src/db/', agents: ['dev-team-codd'], reason: 'database code changed' },
+      ],
+    };
+    fs.writeFileSync(path.join(tmpDir, '.claude', 'dev-team.json'), JSON.stringify(prefs));
+
+    const input = JSON.stringify({ tool_input: { file_path: '/app/src/ui/button.tsx' } });
+    const stdout = execFileSync(process.execPath, [path.join(HOOKS_DIR, hook), input], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      cwd: tmpDir,
+    });
+    assert.equal(stdout, '');
+  });
+
+  it('handles multiple watch list entries', () => {
+    const prefs = {
+      watchLists: [
+        { pattern: '\\.graphql$', agents: ['dev-team-mori', 'dev-team-voss'], reason: 'API schema changed' },
+        { pattern: 'src/db/', agents: ['dev-team-codd'], reason: 'database code changed' },
+      ],
+    };
+    fs.writeFileSync(path.join(tmpDir, '.claude', 'dev-team.json'), JSON.stringify(prefs));
+
+    const input = JSON.stringify({ tool_input: { file_path: '/app/schema.graphql' } });
+    const stdout = execFileSync(process.execPath, [path.join(HOOKS_DIR, hook), input], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      cwd: tmpDir,
+    });
+    assert.ok(stdout.includes('@dev-team-mori'), 'should recommend mori');
+    assert.ok(stdout.includes('@dev-team-voss'), 'should recommend voss');
+  });
+
+  it('exits 0 with empty watchLists', () => {
+    const prefs = { watchLists: [] };
+    fs.writeFileSync(path.join(tmpDir, '.claude', 'dev-team.json'), JSON.stringify(prefs));
+
+    const input = JSON.stringify({ tool_input: { file_path: '/app/src/index.ts' } });
+    const stdout = execFileSync(process.execPath, [path.join(HOOKS_DIR, hook), input], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      cwd: tmpDir,
+    });
+    assert.equal(stdout, '');
+  });
+});
+
 // ─── Task Loop ───────────────────────────────────────────────────────────────
 
 describe('dev-team-task-loop', () => {


### PR DESCRIPTION
## Summary
- New PostToolUse hook (`dev-team-watch-list.js`) reads file-pattern-to-agent mappings from dev-team.json
- Recommends spawning domain agents when patterns match
- Config: \`"watchLists": [{ "pattern": "src/db/", "agents": ["dev-team-codd"], "reason": "..." }]\`
- Advisory only — always exits 0

## Test plan
- [x] 5 new hook tests: no config, pattern match, no match, multiple entries, empty list
- [x] All 114 tests pass

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)