### PR TITLE
fix: derive update command maps from init.ts to prevent drift

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -9,6 +9,7 @@ import {
   mergeClaudeMd,
 } from "./files";
 import type { HookSettings, HookMatcher } from "./files";
+import { ALL_AGENTS, QUALITY_HOOKS } from "./init";
 
 interface Preferences {
   version: string;
@@ -26,27 +27,16 @@ interface UpdateSummary {
   settings: boolean;
 }
 
-/**
- * Maps agent labels to filenames. Must stay in sync with init.ts ALL_AGENTS.
- */
-const AGENT_FILES: Record<string, string> = {
-  Voss: "dev-team-voss.md",
-  Mori: "dev-team-mori.md",
-  Szabo: "dev-team-szabo.md",
-  Knuth: "dev-team-knuth.md",
-  Beck: "dev-team-beck.md",
-  Deming: "dev-team-deming.md",
-};
+// Derived from init.ts — single source of truth, no drift
+const AGENT_FILES: Record<string, string> = Object.fromEntries(
+  ALL_AGENTS.map((a) => [a.label, a.file]),
+);
 
-const HOOK_FILES: Record<string, string> = {
-  "TDD enforcement": "dev-team-tdd-enforce.js",
-  "Safety guard": "dev-team-safety-guard.js",
-  "Post-change review": "dev-team-post-change-review.js",
-  "Pre-commit gate": "dev-team-pre-commit-gate.js",
-  "Task loop": "dev-team-task-loop.js",
-};
+const HOOK_FILES: Record<string, string> = Object.fromEntries(
+  QUALITY_HOOKS.map((h) => [h.label, h.file]),
+);
 
-const SKILL_DIRS = ["dev-team-challenge", "dev-team-task"];
+const SKILL_DIRS = ["dev-team-challenge", "dev-team-task", "dev-team-review", "dev-team-audit"];
 
 /**
  * Update flow: upgrades installed agents, hooks, and skills to latest templates.

--- a/tests/integration/update.test.js
+++ b/tests/integration/update.test.js
@@ -117,4 +117,23 @@ describe('dev-team update', () => {
     const content = fs.readFileSync(learningsPath, 'utf-8');
     assert.ok(content.includes('PostgreSQL'), 'learnings should not be overwritten');
   });
+
+  it('updates all agents including those added after initial install', async () => {
+    await run(tmpDir, ['--all']);
+
+    // Stale every agent file
+    const agentsDir = path.join(tmpDir, '.claude', 'agents');
+    const agentFiles = fs.readdirSync(agentsDir);
+    for (const f of agentFiles) {
+      fs.writeFileSync(path.join(agentsDir, f), 'stale');
+    }
+
+    await update(tmpDir);
+
+    // Every agent should be restored — none should be our sentinel value
+    for (const f of agentFiles) {
+      const content = fs.readFileSync(path.join(agentsDir, f), 'utf-8');
+      assert.ok(content.startsWith('---'), `${f} should have been updated (should start with frontmatter)`);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- `AGENT_FILES` and `HOOK_FILES` in update.ts were hardcoded to the original 6 agents / 5 hooks
- Missing: Docs, Architect, Release, Lead, Watch list hook, review/audit skills
- Fix: import `ALL_AGENTS` and `QUALITY_HOOKS` from init.ts and derive maps with `Object.fromEntries()`
- Also added `dev-team-review` and `dev-team-audit` to `SKILL_DIRS`
- Regression test: stales all agent files and verifies update restores every one

## Test plan
- [x] All 118 tests pass
- [x] Regression test covers all 10 agents
- [x] No more hardcoded duplication between init.ts and update.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)