### PR TITLE
feat: hooks actively spawn agents instead of printing reminders (#68)

### DIFF
--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -29,6 +29,16 @@ Agents challenge each other using classified findings:
 - `[DEFECT]` blocks progress. `[RISK]`, `[QUESTION]`, `[SUGGESTION]` are advisory.
 - When agents disagree, they escalate to the human after one exchange each. Human decides.
 
+### Hook directives are MANDATORY
+
+When a dev-team hook outputs `ACTION REQUIRED — spawn these agents`, you MUST:
+1. Spawn each listed agent as a **background** subagent using the Agent tool with `subagent_type: "general-purpose"`
+2. Include the agent's full definition by reading from `.claude/agents/<agent>.md`
+3. Include the changed file path and instruction to produce classified findings
+4. After all reviews complete, delete `.claude/dev-team-review-pending.json`
+
+Do NOT skip this. Do NOT treat hook output as optional. The pre-commit gate will BLOCK commits if flagged agents were not spawned. If you believe a review is unnecessary for trivial changes, delete `.claude/dev-team-review-pending.json` and explain why to the user.
+
 ### Skills
 
 - `/dev-team:challenge` — critically examine a proposal or implementation

--- a/templates/hooks/dev-team-post-change-review.js
+++ b/templates/hooks/dev-team-post-change-review.js
@@ -160,8 +160,41 @@ if (isCodeFile && !isTestFile) {
   flags.push("@dev-team-knuth (new or changed code path to audit)");
 }
 
-if (flags.length > 0) {
-  console.log(`[dev-team review] Flag for review: ${flags.join(", ")}`);
+if (flags.length === 0) {
+  process.exit(0);
 }
+
+// Track which agents have been flagged this session (for pre-commit gate to verify)
+const fs = require("fs");
+const trackingPath = path.join(process.cwd(), ".claude", "dev-team-review-pending.json");
+let pending = [];
+try {
+  pending = JSON.parse(fs.readFileSync(trackingPath, "utf-8"));
+} catch {
+  // No tracking file yet
+}
+
+for (const flag of flags) {
+  const agent = flag.split(" ")[0]; // e.g. "@dev-team-szabo"
+  if (!pending.includes(agent)) {
+    pending.push(agent);
+  }
+}
+
+try {
+  fs.mkdirSync(path.dirname(trackingPath), { recursive: true });
+  fs.writeFileSync(trackingPath, JSON.stringify(pending, null, 2));
+} catch {
+  // Best effort — don't fail the hook over tracking
+}
+
+// Output as a DIRECTIVE, not a suggestion. CLAUDE.md instructs the LLM to act on this.
+console.log(`[dev-team] ACTION REQUIRED — spawn these agents as background reviewers:`);
+for (const flag of flags) {
+  console.log(`  → ${flag}`);
+}
+console.log(
+  `Use the Agent tool to spawn each as a general-purpose subagent with their agent definition from .claude/agents/.`,
+);
 
 process.exit(0);

--- a/templates/hooks/dev-team-pre-commit-gate.js
+++ b/templates/hooks/dev-team-pre-commit-gate.js
@@ -4,12 +4,18 @@
  * dev-team-pre-commit-gate.js
  * TaskCompleted hook.
  *
- * When a task completes, checks staged changes and reminds about
- * review agents if they were not consulted. Advisory — always exits 0.
+ * When a task completes, checks:
+ * 1. Whether flagged review agents were actually spawned
+ * 2. Whether memory files need updating
+ *
+ * BLOCKS (exit 2) if review agents were flagged but not consulted.
+ * Advisory (exit 0) for memory reminders.
  */
 
 "use strict";
 
+const fs = require("fs");
+const path = require("path");
 const { execFileSync } = require("child_process");
 
 let stagedFiles = "";
@@ -29,34 +35,45 @@ if (files.length === 0) {
   process.exit(0);
 }
 
-const reminders = [];
-
-const hasSecurityFiles = files.some((f) =>
-  /auth|login|password|token|session|crypto|secret|permission/.test(f),
-);
-if (hasSecurityFiles) {
-  reminders.push("@dev-team-szabo for security review");
+// Check for pending reviews that were never completed
+const trackingPath = path.join(process.cwd(), ".claude", "dev-team-review-pending.json");
+let pendingReviews = [];
+try {
+  pendingReviews = JSON.parse(fs.readFileSync(trackingPath, "utf-8"));
+} catch {
+  // No tracking file — no pending reviews
 }
+
+if (pendingReviews.length > 0) {
+  console.error(
+    `[dev-team pre-commit] BLOCKED — these agents were flagged for review but not yet spawned:`,
+  );
+  for (const agent of pendingReviews) {
+    console.error(`  → ${agent}`);
+  }
+  console.error("");
+  console.error(
+    "Spawn each agent as a background subagent using the Agent tool with their definition",
+  );
+  console.error("from .claude/agents/. After review completes, clear the tracking file:");
+  console.error("  rm .claude/dev-team-review-pending.json");
+  console.error("");
+  console.error("To skip this check (e.g. for trivial changes), delete the tracking file first.");
+  process.exit(2);
+}
+
+// Memory freshness check (advisory only)
+const reminders = [];
 
 const hasImplFiles = files.some(
   (f) => /\.(js|ts|jsx|tsx|py|rb|go|java|rs)$/.test(f) && !/\.(test|spec)\./.test(f),
 );
-if (hasImplFiles) {
-  reminders.push("@dev-team-knuth for quality audit");
-}
 
-const hasApiFiles = files.some((f) => /\/api\/|\/routes?\/|schema|\.graphql$/.test(f));
-if (hasApiFiles) {
-  reminders.push("@dev-team-mori for UI impact review");
-}
-
-// Memory freshness check: if significant work was done but no memory files were updated, remind.
 const hasMemoryUpdates = files.some(
   (f) => f.endsWith("dev-team-learnings.md") || /agent-memory\/.*MEMORY\.md$/.test(f),
 );
 
 if (hasImplFiles && !hasMemoryUpdates) {
-  // Check unstaged memory changes too — author may have updated but not staged yet
   let unstagedMemory = false;
   try {
     const unstaged = execFileSync("git", ["diff", "--name-only"], {

--- a/tests/unit/hooks.test.js
+++ b/tests/unit/hooks.test.js
@@ -307,34 +307,44 @@ describe('dev-team-tdd-enforce', () => {
 describe('dev-team-pre-commit-gate', () => {
   const hook = 'dev-team-pre-commit-gate.js';
 
-  it('always exits 0 (advisory only)', () => {
-    // Hook reads from git, but outside a git repo it exits 0
+  it('exits 0 when no git repo', () => {
     const result = runHook(hook, {});
     assert.equal(result.code, 0);
   });
 
-  it('reminds about security review for staged auth files', () => {
+  it('blocks (exit 2) when pending reviews exist', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-team-precommit-'));
     try {
       execFileSync('git', ['init'], { cwd: tmpDir, encoding: 'utf-8' });
       execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: tmpDir, encoding: 'utf-8' });
       execFileSync('git', ['config', 'user.name', 'Test'], { cwd: tmpDir, encoding: 'utf-8' });
-      fs.writeFileSync(path.join(tmpDir, 'auth.js'), 'module.exports = {}');
-      execFileSync('git', ['add', 'auth.js'], { cwd: tmpDir, encoding: 'utf-8' });
+      fs.writeFileSync(path.join(tmpDir, 'handler.js'), 'module.exports = {}');
+      execFileSync('git', ['add', 'handler.js'], { cwd: tmpDir, encoding: 'utf-8' });
 
-      const stdout = execFileSync(process.execPath, [path.join(HOOKS_DIR, hook)], {
-        encoding: 'utf-8',
-        timeout: 5000,
-        cwd: tmpDir,
-      });
-      assert.ok(stdout.includes('@dev-team-szabo'));
-      assert.ok(stdout.includes('@dev-team-knuth'));
+      // Create pending review tracking file
+      fs.mkdirSync(path.join(tmpDir, '.claude'), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, '.claude', 'dev-team-review-pending.json'),
+        JSON.stringify(['@dev-team-szabo', '@dev-team-knuth']),
+      );
+
+      try {
+        execFileSync(process.execPath, [path.join(HOOKS_DIR, hook)], {
+          encoding: 'utf-8',
+          timeout: 5000,
+          cwd: tmpDir,
+        });
+        assert.fail('Should exit 2 when pending reviews exist');
+      } catch (err) {
+        assert.equal(err.status, 2, 'should block with exit 2');
+        assert.ok(err.stderr.includes('@dev-team-szabo'), 'should list pending agents');
+      }
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 
-  it('produces no reminders when only non-code files are staged', () => {
+  it('exits 0 when no pending reviews', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-team-precommit-'));
     try {
       execFileSync('git', ['init'], { cwd: tmpDir, encoding: 'utf-8' });


### PR DESCRIPTION
## Summary

The #1 systemic gap: hooks flagged agents for review but nothing spawned them. README went stale across 3 releases because Docs was never invoked.

**Before**: hook prints "Flag for review: @dev-team-docs" → message scrolls past → nobody acts on it
**After**: hook outputs "ACTION REQUIRED" directive + writes tracking file → LLM spawns agents → pre-commit gate blocks if reviews not completed

### How it works
1. **Edit/Write** → `post-change-review` outputs directive + writes `.claude/dev-team-review-pending.json`
2. **LLM reads directive** → spawns flagged agents as background subagents (enforced by CLAUDE.md)
3. **Reviews complete** → tracking file deleted
4. **TaskCompleted** → `pre-commit-gate` checks tracking file → **BLOCKS** (exit 2) if agents not spawned

### Escape hatch
For trivial changes: `rm .claude/dev-team-review-pending.json`

## Test plan
- [x] Pre-commit gate blocks when pending reviews exist (exit 2)
- [x] Pre-commit gate allows when no pending reviews (exit 0)
- [x] Memory freshness checks still work (advisory)
- [x] Post-change-review still exits 0 (advisory hook, tracking is best-effort)
- [x] All 124 tests pass, 0 lint warnings

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)