### PR TITLE
docs: sync README.md with v0.3 features and system guide (#55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,105 +2,304 @@
 
 Adversarial AI agent team for any project. Installs [Claude Code](https://claude.ai/claude-code) agents, hooks, and skills that enforce quality through productive friction.
 
-Instead of an AI that agrees with everything, dev-team gives you six opinionated specialists that challenge each other — and you.
+Instead of an AI that agrees with everything, dev-team gives you ten opinionated specialists that challenge each other — and you. Hooks enforce the process deterministically. Agents can't skip reviews. Commits are blocked until the team signs off.
+
+## How the system works
+
+```mermaid
+graph TB
+    subgraph Skills["Skills (entry points)"]
+        S1["/dev-team:task"]
+        S2["/dev-team:review"]
+        S3["/dev-team:audit"]
+        S4["/dev-team:challenge"]
+    end
+
+    subgraph Lead["Orchestrator"]
+        L["@dev-team-lead\nAnalyzes task → selects agents\nManages review loop"]
+    end
+
+    subgraph Impl["Implementation Agents (sonnet)"]
+        Voss["@dev-team-voss\nBackend"]
+        Mori["@dev-team-mori\nFrontend"]
+        Beck["@dev-team-beck\nTests"]
+        Deming["@dev-team-deming\nTooling"]
+        Docs["@dev-team-docs\nDocumentation"]
+        Release["@dev-team-release\nRelease Manager"]
+    end
+
+    subgraph Rev["Review Agents (opus, read-only)"]
+        Szabo["@dev-team-szabo\nSecurity"]
+        Knuth["@dev-team-knuth\nQuality"]
+        Architect["@dev-team-architect\nArchitecture"]
+    end
+
+    subgraph Hooks["Hooks (deterministic enforcement)"]
+        H1["safety-guard\nBlocks dangerous commands"]
+        H2["tdd-enforce\nBlocks code without tests"]
+        H3["post-change-review\nFlags + spawns reviewers"]
+        H4["pre-commit-gate\nBlocks if reviews pending"]
+        H5["watch-list\nCustom pattern → agent"]
+        H6["task-loop\nIteration management"]
+    end
+
+    subgraph Mem["Persistent Memory"]
+        M1["agent-memory/\nPer-agent calibration"]
+        M2["dev-team-learnings.md\nShared knowledge"]
+    end
+
+    S1 --> L
+    S2 -->|spawns by file pattern| Rev
+    S3 -->|spawns Szabo+Knuth+Deming| Rev
+    S3 -->|spawns| Deming
+    S4 -->|structured review| Rev
+    L -->|delegates| Impl
+    L -->|spawns parallel| Rev
+    Impl -->|writes code| Hooks
+    H3 -->|ACTION REQUIRED| Rev
+    Rev -->|"[DEFECT] → fix"| Impl
+    Rev -->|findings| L
+    H4 -.->|blocks commit| L
+    Impl & Rev -->|write| Mem
+    Mem -->|loaded at start| Impl & Rev
+```
+
+### The flow
+
+1. **You give a task** → `@dev-team-lead` or `/dev-team:task`
+2. **Lead delegates** → picks the right implementer (Voss for backend, Mori for frontend, etc.)
+3. **Implementer writes code** → hooks fire automatically on every edit
+4. **Hooks flag reviewers** → `ACTION REQUIRED` directive + tracking file written
+5. **Reviewers spawn in parallel** → produce classified findings (`[DEFECT]`, `[RISK]`, etc.)
+6. **`[DEFECT]` found** → goes back to implementer for fixing
+7. **No defects remain** → tracking file cleared → commit allowed
+8. **Memory updated** → learnings persisted for next session
+
+The key: **hooks make this mandatory**. The pre-commit gate blocks if flagged reviewers weren't spawned. Agents can't be skipped.
 
 ## Install
 
 ```bash
-npx @fredericboyer/dev-team init        # Interactive wizard
-npx @fredericboyer/dev-team init --all  # Everything, no prompts
+npx @fredericboyer/dev-team init                    # Interactive wizard
+npx @fredericboyer/dev-team init --all              # Everything, no prompts
+npx @fredericboyer/dev-team init --preset backend   # Backend-heavy bundle
+npx @fredericboyer/dev-team init --preset fullstack  # All agents
+npx @fredericboyer/dev-team init --preset data       # Data pipeline bundle
 ```
 
 Requires Node.js 18+ and Claude Code.
 
+### After installation
+
+```bash
+npx @fredericboyer/dev-team update                  # Upgrade to latest templates
+npx @fredericboyer/dev-team create-agent <name>     # Scaffold a custom agent
+```
+
 ## What you get
 
-### Agents
+### Agents (10)
 
-| Agent | Role | When to use |
-|-------|------|-------------|
-| `@dev-team-voss` | Backend Engineer | API design, data modeling, system architecture, error handling |
-| `@dev-team-mori` | Frontend/UI Engineer | Components, accessibility, UX patterns, state management |
-| `@dev-team-szabo` | Security Auditor | Vulnerability review, auth flows, attack surface analysis |
-| `@dev-team-knuth` | Quality Auditor | Coverage gaps, boundary conditions, correctness verification |
-| `@dev-team-beck` | Test Implementer | Writing tests, TDD cycles, translating audit findings into test cases |
-| `@dev-team-deming` | Tooling Optimizer | Linters, formatters, CI/CD, hooks, onboarding, automation |
+| Agent | Role | Model | When to use |
+|-------|------|-------|-------------|
+| `@dev-team-lead` | **Orchestrator** | opus | Auto-delegates to specialists, manages review loops |
+| `@dev-team-voss` | Backend Engineer | sonnet | API design, data modeling, system architecture |
+| `@dev-team-mori` | Frontend Engineer | sonnet | Components, accessibility, UX patterns |
+| `@dev-team-szabo` | Security Auditor | opus | Vulnerability review, auth flows, attack surfaces |
+| `@dev-team-knuth` | Quality Auditor | opus | Coverage gaps, boundary conditions, correctness |
+| `@dev-team-beck` | Test Implementer | sonnet | Writing tests, TDD cycles |
+| `@dev-team-deming` | Tooling Optimizer | sonnet | Linters, formatters, CI/CD, hooks, automation |
+| `@dev-team-docs` | Documentation Engineer | sonnet | Doc accuracy, stale docs, doc-code sync |
+| `@dev-team-architect` | Architect | opus | Coupling, dependency direction, ADR compliance |
+| `@dev-team-release` | Release Manager | sonnet | Versioning, changelog, semver validation |
 
-Szabo and Knuth use Opus (deep analysis, read-only). Voss, Mori, Beck, and Deming use Sonnet (implementation, full access).
+**Opus** agents do deep analysis — Szabo, Knuth, and Architect are read-only reviewers; Lead uses opus for orchestration with full access. **Sonnet** agents implement (faster, full write access).
 
-### Hooks
+### Hooks (6)
 
-| Hook | Trigger | What it does |
-|------|---------|-------------|
-| Safety guard | Before Bash commands | Blocks dangerous commands (`rm -rf`, `chmod 777`, force push to main, `DROP TABLE/DATABASE`, `curl\|sh`, and others) |
-| TDD enforcement | After file edits | Blocks implementation changes when no corresponding test file exists and no tests were modified in the session |
-| Post-change review | After file edits | Routes files to domain agents for review (security → Szabo, API → Mori, infra → Voss, tooling → Deming, code → Knuth). Advisory, does not block. |
-| Pre-commit gate | On task completion | Reminds about running review agents before committing. Advisory, does not block. |
-| Task loop | On stop | Manages iterative task loop with adversarial review gates |
+| Hook | Trigger | Behavior |
+|------|---------|----------|
+| Safety guard | Before Bash | **Blocks** dangerous commands (`rm -rf /`, force push, `DROP TABLE`, `curl\|sh`). Fails closed on malformed input. |
+| TDD enforcement | After Edit/Write | **Blocks** implementation changes without corresponding test files. |
+| Post-change review | After Edit/Write | **Flags + tracks** domain agents for review. Writes tracking file. Outputs `ACTION REQUIRED` directive. |
+| Pre-commit gate | On task completion | **Blocks** commit if flagged agents were not spawned. Advisory for memory freshness. |
+| Watch list | After Edit/Write | **Flags** custom agents based on configurable file-pattern-to-agent mappings in `dev-team.json`. |
+| Task loop | On stop | Manages iteration counting for `/dev-team:task` adversarial review loop. |
 
 All hooks are Node.js scripts — work on macOS, Linux, and Windows.
 
-### Skills
+### Skills (4)
 
 | Skill | What it does |
 |-------|-------------|
-| `/dev-team:challenge` | Critically examine a proposal, approach, or implementation |
-| `/dev-team:task` | Start an iterative task loop with adversarial review gates |
+| `/dev-team:task` | Iterative task loop — implement, review, fix defects, repeat until clean |
+| `/dev-team:review` | Parallel multi-agent review — spawns agents based on changed file patterns |
+| `/dev-team:audit` | Full codebase scan — Szabo (security) + Knuth (quality) + Deming (tooling) |
+| `/dev-team:challenge` | Critical examination of a proposal or design decision |
 
-### Challenge protocol
+## Step-by-step usage guide
 
-Agents challenge each other using classified findings:
+### 1. Start a task
 
-- **[DEFECT]** — Concretely wrong. Blocks progress.
-- **[RISK]** — Not wrong today, but creates a likely failure mode. Advisory.
-- **[QUESTION]** — Decision needs justification. Advisory.
-- **[SUGGESTION]** — Works, but here's a specific improvement. Advisory.
+```
+@dev-team-lead Add rate limiting to the API endpoints
+```
 
-Rules: concrete evidence required, one exchange before escalation, human decides disputes.
+Or use the task loop for automatic iteration:
 
-## How it works
+```
+/dev-team:task Add rate limiting to the API endpoints
+```
 
-### Task loop (`/dev-team:task`)
+Lead analyzes the task, picks Voss (backend), and spawns Szabo + Knuth as reviewers.
 
-For non-trivial work, the task loop enforces quality convergence:
+### 2. Let the agents work
 
-1. Implementing agent works on the task
-2. Review agents challenge in parallel
-3. If any `[DEFECT]` found → loop continues with fixes
-4. If no `[DEFECT]` remains → done
-5. Max iterations (default: 10) as safety cap
+The implementing agent explores the codebase, writes code, and writes tests. Hooks fire on every edit:
 
-The implementing agent can't declare "done" alone — the adversarial review is the quality gate.
+- **TDD hook** ensures tests exist before implementation
+- **Post-change-review** flags reviewers and writes a tracking file
+- The LLM **spawns flagged agents as background reviewers** (mandatory, not optional)
 
-### Agent memory
+### 3. Review cycle
 
-Each agent maintains persistent memory (`.claude/agent-memory/<agent>/MEMORY.md`) that calibrates over time:
+Reviewers produce classified findings:
 
-- Project-specific patterns and conventions
-- What challenges were accepted vs. overruled
-- Quality benchmarks learned from the codebase
+```
+[DEFECT] @dev-team-szabo — src/api/rate-limit.ts:42
+  Rate limit key uses client IP, but behind a load balancer req.ip
+  returns the LB address. All clients share one rate limit bucket.
 
-Shared team learnings are stored in `.claude/dev-team-learnings.md`.
+[RISK] @dev-team-knuth — tests/rate-limit.test.ts
+  Tests mock the Redis client. No integration test verifies actual
+  TTL expiry behavior.
+
+[SUGGESTION] @dev-team-knuth — src/api/rate-limit.ts:15
+  Extract rate limit config to environment variables for per-env tuning.
+```
+
+`[DEFECT]` goes back for fixing. `[RISK]` and `[SUGGESTION]` are reported to you.
+
+### 4. Commit
+
+Once all defects are resolved:
+- Tracking file is deleted
+- Pre-commit gate allows the commit
+- Memory files are updated with learnings
+
+If you try to commit with pending reviews, the pre-commit gate **blocks**:
+
+```
+[dev-team pre-commit] BLOCKED — these agents were flagged but not spawned:
+  → @dev-team-szabo
+  → @dev-team-knuth
+```
+
+### 5. Other workflows
+
+**Review a PR or branch:**
+```
+/dev-team:review
+```
+
+**Audit the whole codebase:**
+```
+/dev-team:audit src/
+```
+
+**Challenge a design before building it:**
+```
+/dev-team:challenge Should we use JWT or session tokens for auth?
+```
+
+## Challenge protocol
+
+Every agent uses the same classification:
+
+- **`[DEFECT]`** — Concretely wrong. Will produce incorrect behavior. **Blocks progress.**
+- **`[RISK]`** — Not wrong today, but creates a likely failure mode. Advisory.
+- **`[QUESTION]`** — Decision needs justification. Advisory.
+- **`[SUGGESTION]`** — Works, but here is a specific improvement. Advisory.
+
+Rules:
+1. Every finding must include concrete evidence (file, line, input, scenario)
+2. Only `[DEFECT]` blocks — everything else is advisory
+3. When agents disagree: one exchange each, then escalate to the human
+4. Human decides all disputes
+
+## Agent memory
+
+Each agent maintains persistent memory that calibrates over time:
+
+```
+.claude/
+  agent-memory/
+    dev-team-voss/MEMORY.md     # Voss's project-specific patterns
+    dev-team-szabo/MEMORY.md    # Szabo's security findings
+    dev-team-knuth/MEMORY.md    # Knuth's coverage observations
+    ...
+  dev-team-learnings.md         # Shared team knowledge
+```
+
+Memory is loaded at session start (first 200 lines). Agents write learnings after each task. The pre-commit gate reminds you to update memory if code changed but learnings didn't.
 
 ## Customization
 
-After installation, you can:
+### Edit agents
 
-- **Edit agent prompts** in `.claude/agents/` to adjust focus areas or challenge style
-- **Disable hooks** by removing entries from `.claude/settings.json`
-- **Add your own agents** following the same frontmatter format
-- **Tune agent memory** in `.claude/agent-memory/` to accelerate calibration
+Agent definitions live in `.claude/agents/`. Edit focus areas, challenge style, or philosophy to match your project.
+
+### Create custom agents
+
+```bash
+npx @fredericboyer/dev-team create-agent codd    # Scaffold a new agent
+```
+
+See [docs/custom-agents.md](docs/custom-agents.md) for the full authoring guide with format reference, blank template, and a worked example.
+
+### Configure watch lists
+
+Add file-pattern-to-agent mappings in `.claude/dev-team.json`:
+
+```json
+{
+  "watchLists": [
+    { "pattern": "src/db/", "agents": ["dev-team-codd"], "reason": "database code changed" },
+    { "pattern": "\\.graphql$", "agents": ["dev-team-mori"], "reason": "API schema changed" }
+  ]
+}
+```
+
+### Preset bundles
+
+| Preset | Agents included |
+|--------|----------------|
+| `backend` | Voss, Szabo, Knuth, Beck, Deming, Architect, Release |
+| `fullstack` | All 10 agents |
+| `data` | Voss, Szabo, Knuth, Beck, Deming, Docs |
+
+`@dev-team-lead` is included in `fullstack` only. For other presets, invoke Lead manually with `@dev-team-lead` when you want automatic delegation.
+
+### Update
+
+```bash
+npx @fredericboyer/dev-team update
+```
+
+Updates agents, hooks, and skills to the latest templates. Preserves your agent memory, shared learnings, and CLAUDE.md content outside dev-team markers.
 
 ## What gets installed
 
 ```
 .claude/
-  agents/           # Agent definitions (YAML frontmatter + prompt)
-  hooks/            # Quality enforcement scripts
-  skills/           # Skill definitions
-  agent-memory/     # Per-agent persistent memory
-  settings.json     # Hook configuration
-CLAUDE.md           # Project instructions (dev-team section added via markers)
+  agents/              # 10 agent definitions (YAML frontmatter + prompt)
+  hooks/               # 6 quality enforcement scripts
+  skills/              # 4 skill definitions
+  agent-memory/        # Per-agent persistent memory (never overwritten on update)
+  dev-team-learnings.md  # Shared team knowledge (never overwritten on update)
+  dev-team.json        # Installation preferences
+  settings.json        # Hook configuration (merged additively)
+CLAUDE.md              # Project instructions (dev-team section via markers)
 ```
 
 ## Contributing
@@ -117,7 +316,7 @@ CLAUDE.md           # Project instructions (dev-team section added via markers)
 npm install          # Install dependencies (dev only, zero runtime deps)
 npm run build        # Compile TypeScript
 npm test             # Build + run all tests
-npm run lint         # Run oxlint
+npm run lint         # Run oxlint (0 warnings target)
 npm run format       # Run oxfmt
 ```
 


### PR DESCRIPTION
## Summary
Complete README rewrite reflecting v0.3 state:
- Mermaid architecture diagram (agents, hooks, skills, memory, enforcement flow)
- Step-by-step usage guide from task → delegation → review → commit
- All 10 agents, 6 hooks, 4 skills, 3 presets documented
- Watch list config, custom agent creation, update command
- Diagram corrected per Docs agent: skills route directly to agents, not all through Lead

## Agent reviews
- **@dev-team-docs**: 0 defects, 1 suggestion (diagram skill routing — fixed)
- **@dev-team-release**: 2 defects (opus read-only claim — fixed, hardcoded test count — removed), 1 suggestion (preset Lead clarification — added)

## Test plan
- [x] No code changes — documentation only
- [x] Mermaid diagram validates successfully
- [x] All factual claims cross-referenced against source files by both review agents

Fixes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)