### PR TITLE
feat: add enforcement gap detection to Deming scan (#67)

### DIFF
--- a/src/scan.ts
+++ b/src/scan.ts
@@ -2,8 +2,8 @@ import path from "path";
 import { fileExists, readFile, dirExists } from "./files";
 
 export interface ScanFinding {
-  category: "linter" | "formatter" | "sast" | "ci" | "dependency";
-  status: "found" | "missing" | "outdated";
+  category: "linter" | "formatter" | "sast" | "ci" | "dependency" | "enforcement";
+  status: "found" | "missing" | "outdated" | "gap";
   tool: string;
   recommendation: string;
 }
@@ -173,6 +173,65 @@ export function scanProject(targetDir: string): ScanFinding[] {
     });
   }
 
+  // Enforcement gap detection: CI checks vs local hook coverage
+  const ciScripts = parseCiScripts(targetDir);
+  const hookCommands = parseHookCommands(targetDir);
+
+  const coverageMappings: Array<{
+    scriptNames: string[];
+    hookFile: string;
+    partial?: boolean;
+    partialReason?: string;
+  }> = [
+    { scriptNames: ["lint"], hookFile: "dev-team-pre-commit-lint.js" },
+    { scriptNames: ["format:check"], hookFile: "dev-team-pre-commit-lint.js" },
+    {
+      scriptNames: ["test"],
+      hookFile: "dev-team-tdd-enforce.js",
+      partial: true,
+      partialReason: "hook ensures tests exist but does not run them",
+    },
+  ];
+
+  for (const scriptName of ciScripts) {
+    const mapping = coverageMappings.find((m) => m.scriptNames.includes(scriptName));
+
+    if (!mapping) {
+      findings.push({
+        category: "enforcement",
+        status: "gap",
+        tool: scriptName,
+        recommendation: `CI runs "${scriptName}" but no local hook enforces it. Add a hook or accept the delayed feedback.`,
+      });
+      continue;
+    }
+
+    const hookPresent = hookCommands.some((cmd) => cmd.includes(mapping.hookFile));
+
+    if (!hookPresent) {
+      findings.push({
+        category: "enforcement",
+        status: "gap",
+        tool: scriptName,
+        recommendation: `CI runs "${scriptName}" but the corresponding hook (${mapping.hookFile}) is not installed. Run dev-team init to add it.`,
+      });
+    } else if (mapping.partial) {
+      findings.push({
+        category: "enforcement",
+        status: "found",
+        tool: scriptName,
+        recommendation: `CI runs "${scriptName}" \u2014 partially covered by ${mapping.hookFile} (${mapping.partialReason}).`,
+      });
+    } else {
+      findings.push({
+        category: "enforcement",
+        status: "found",
+        tool: scriptName,
+        recommendation: `CI runs "${scriptName}" \u2014 covered locally by ${mapping.hookFile}.`,
+      });
+    }
+  }
+
   return findings;
 }
 
@@ -185,8 +244,9 @@ export function formatScanReport(findings: ScanFinding[]): string {
 
   const missing = findings.filter((f) => f.status === "missing");
   const found = findings.filter((f) => f.status === "found");
+  const gaps = findings.filter((f) => f.status === "gap");
 
-  if (missing.length === 0) {
+  if (missing.length === 0 && gaps.length === 0) {
     lines.push("  All checked tooling categories are covered.\n");
   }
 
@@ -196,10 +256,62 @@ export function formatScanReport(findings: ScanFinding[]): string {
   for (const f of missing) {
     lines.push(`  [MISSING] ${f.category}: ${f.recommendation}`);
   }
+  for (const f of gaps) {
+    lines.push(`  [GAP]     ${f.category}: ${f.recommendation}`);
+  }
 
-  if (missing.length > 0) {
+  if (missing.length > 0 || gaps.length > 0) {
     lines.push("\n  Tip: Run @dev-team-deming for deeper analysis and automated setup.");
   }
 
   return lines.join("\n");
+}
+
+/**
+ * Parses package.json scripts to find CI-relevant check names.
+ * Returns script names for: lint, format:check, test, typecheck, build.
+ */
+export function parseCiScripts(targetDir: string): string[] {
+  const ciRelevantScripts = ["lint", "format:check", "test", "typecheck", "build"];
+  const pkgContent = readFile(path.join(targetDir, "package.json"));
+  if (!pkgContent) return [];
+
+  try {
+    const pkg = JSON.parse(pkgContent);
+    const scripts = pkg.scripts || {};
+    return ciRelevantScripts.filter((name) => name in scripts);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Parses .claude/settings.json to extract all hook command strings.
+ * Returns an array of command strings found across all hook events.
+ */
+export function parseHookCommands(targetDir: string): string[] {
+  const settingsContent = readFile(path.join(targetDir, ".claude", "settings.json"));
+  if (!settingsContent) return [];
+
+  try {
+    const settings = JSON.parse(settingsContent);
+    const hooks = settings.hooks || {};
+    const commands: string[] = [];
+
+    for (const matchers of Object.values(hooks) as Array<
+      Array<{ hooks?: Array<{ command?: string }> }>
+    >) {
+      for (const matcher of matchers) {
+        for (const hook of matcher.hooks || []) {
+          if (hook.command) {
+            commands.push(hook.command);
+          }
+        }
+      }
+    }
+
+    return commands;
+  } catch {
+    return [];
+  }
 }

--- a/tests/unit/scan.test.js
+++ b/tests/unit/scan.test.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
-const { scanProject, formatScanReport } = require('../../dist/scan');
+const { scanProject, formatScanReport, parseCiScripts, parseHookCommands } = require('../../dist/scan');
 
 let tmpDir;
 
@@ -79,6 +79,203 @@ describe('scanProject', () => {
   });
 });
 
+describe('enforcement gap detection', () => {
+  it('flags gap when CI has lint script but no hook installed', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ scripts: { lint: 'eslint .', test: 'jest' } }),
+    );
+    const findings = scanProject(tmpDir);
+    const gaps = findings.filter(
+      (f) => f.category === 'enforcement' && f.status === 'gap',
+    );
+    assert.ok(gaps.length > 0, 'expected at least one enforcement gap');
+    const lintGap = gaps.find((f) => f.tool === 'lint');
+    assert.ok(lintGap, 'expected a gap for lint');
+    assert.ok(lintGap.recommendation.includes('dev-team-pre-commit-lint.js'));
+  });
+
+  it('reports found when CI lint script has matching hook', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ scripts: { lint: 'eslint .' } }),
+    );
+    fs.mkdirSync(path.join(tmpDir, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: 'Bash',
+              hooks: [
+                {
+                  type: 'command',
+                  command: 'node .claude/hooks/dev-team-pre-commit-lint.js',
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+    const findings = scanProject(tmpDir);
+    const lintEnforcement = findings.find(
+      (f) => f.category === 'enforcement' && f.tool === 'lint',
+    );
+    assert.ok(lintEnforcement, 'expected enforcement finding for lint');
+    assert.equal(lintEnforcement.status, 'found');
+    assert.ok(lintEnforcement.recommendation.includes('covered locally'));
+  });
+
+  it('reports test script as partially covered by tdd-enforce hook', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ scripts: { test: 'jest' } }),
+    );
+    fs.mkdirSync(path.join(tmpDir, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Edit|Write',
+              hooks: [
+                {
+                  type: 'command',
+                  command: 'node .claude/hooks/dev-team-tdd-enforce.js',
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+    const findings = scanProject(tmpDir);
+    const testEnforcement = findings.find(
+      (f) => f.category === 'enforcement' && f.tool === 'test',
+    );
+    assert.ok(testEnforcement, 'expected enforcement finding for test');
+    assert.equal(testEnforcement.status, 'found');
+    assert.ok(testEnforcement.recommendation.includes('partially covered'));
+  });
+
+  it('flags gap for CI scripts with no known hook mapping', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ scripts: { build: 'tsc', typecheck: 'tsc --noEmit' } }),
+    );
+    const findings = scanProject(tmpDir);
+    const gaps = findings.filter(
+      (f) => f.category === 'enforcement' && f.status === 'gap',
+    );
+    const buildGap = gaps.find((f) => f.tool === 'build');
+    const typecheckGap = gaps.find((f) => f.tool === 'typecheck');
+    assert.ok(buildGap, 'expected a gap for build');
+    assert.ok(typecheckGap, 'expected a gap for typecheck');
+    assert.ok(buildGap.recommendation.includes('no local hook'));
+  });
+
+  it('produces no enforcement findings when no package.json exists', () => {
+    const findings = scanProject(tmpDir);
+    const enforcement = findings.filter((f) => f.category === 'enforcement');
+    assert.equal(
+      enforcement.length,
+      0,
+      'expected no enforcement findings without package.json',
+    );
+  });
+});
+
+describe('parseCiScripts', () => {
+  it('extracts CI-relevant scripts from package.json', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        scripts: {
+          lint: 'eslint .',
+          'format:check': 'prettier --check .',
+          dev: 'nodemon',
+        },
+      }),
+    );
+    const scripts = parseCiScripts(tmpDir);
+    assert.ok(scripts.includes('lint'));
+    assert.ok(scripts.includes('format:check'));
+    assert.ok(!scripts.includes('dev'), 'dev is not a CI-relevant script');
+  });
+
+  it('returns empty array when no package.json exists', () => {
+    const scripts = parseCiScripts(tmpDir);
+    assert.deepEqual(scripts, []);
+  });
+
+  it('returns empty array for invalid JSON', () => {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), 'not json');
+    const scripts = parseCiScripts(tmpDir);
+    assert.deepEqual(scripts, []);
+  });
+});
+
+describe('parseHookCommands', () => {
+  it('extracts hook commands from settings.json', () => {
+    fs.mkdirSync(path.join(tmpDir, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: 'Bash',
+              hooks: [
+                {
+                  type: 'command',
+                  command: 'node .claude/hooks/dev-team-pre-commit-lint.js',
+                },
+              ],
+            },
+          ],
+          PostToolUse: [
+            {
+              matcher: 'Edit|Write',
+              hooks: [
+                {
+                  type: 'command',
+                  command: 'node .claude/hooks/dev-team-tdd-enforce.js',
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+    const commands = parseHookCommands(tmpDir);
+    assert.ok(
+      commands.includes('node .claude/hooks/dev-team-pre-commit-lint.js'),
+    );
+    assert.ok(
+      commands.includes('node .claude/hooks/dev-team-tdd-enforce.js'),
+    );
+  });
+
+  it('returns empty array when no settings.json exists', () => {
+    const commands = parseHookCommands(tmpDir);
+    assert.deepEqual(commands, []);
+  });
+
+  it('returns empty array for invalid JSON', () => {
+    fs.mkdirSync(path.join(tmpDir, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.claude', 'settings.json'),
+      'not json',
+    );
+    const commands = parseHookCommands(tmpDir);
+    assert.deepEqual(commands, []);
+  });
+});
+
+
 describe('formatScanReport', () => {
   it('formats findings as readable report', () => {
     const findings = [
@@ -99,4 +296,43 @@ describe('formatScanReport', () => {
     const report = formatScanReport(findings);
     assert.ok(report.includes('All checked tooling'));
   });
+  it('formats gap findings with [GAP] tag', () => {
+    const findings = [
+      {
+        category: 'enforcement',
+        status: 'gap',
+        tool: 'build',
+        recommendation: 'CI runs "build" but no local hook enforces it.',
+      },
+    ];
+    const report = formatScanReport(findings);
+    assert.ok(report.includes('[GAP]'));
+    assert.ok(report.includes('enforcement'));
+    assert.ok(report.includes('no local hook'));
+  });
+
+  it('does not show all-OK message when gaps exist', () => {
+    const findings = [
+      {
+        category: 'linter',
+        status: 'found',
+        tool: 'ESLint',
+        recommendation: 'ok',
+      },
+      {
+        category: 'enforcement',
+        status: 'gap',
+        tool: 'build',
+        recommendation: 'CI runs "build" but no local hook enforces it.',
+      },
+    ];
+    const report = formatScanReport(findings);
+    assert.ok(
+      !report.includes('All checked tooling'),
+      'should not show all-OK when gaps exist',
+    );
+    assert.ok(report.includes('[GAP]'));
+    assert.ok(report.includes('Tip:'));
+  });
+
 });


### PR DESCRIPTION
## Summary
- scanProject() now detects gaps between CI enforcement and local hooks
- Compares package.json scripts (lint, format:check, test, build) against .claude/settings.json hooks
- Known mappings: pre-commit-lint covers lint + format:check, tdd-enforce partially covers test
- New finding status: "gap" rendered as [GAP] in scan report
- Helper functions: parseCiScripts(), parseHookCommands() exported for reuse
- 13 new tests (148 total in scan suite)

## Test plan
- [x] 148 tests pass
- [x] Gap detection with/without hooks
- [x] Partial coverage noted for test enforcement
- [x] Helper function edge cases (missing files, invalid JSON)

**Pending: Szabo + Knuth review before merge**

Fixes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)