### PR TITLE
fix: distinguish missing vs permission errors in file operations (#51)

### DIFF
--- a/src/files.ts
+++ b/src/files.ts
@@ -39,8 +39,11 @@ export function copyFile(src: string, dest: string): boolean {
 export function fileExists(absPath: string): boolean {
   try {
     return fs.statSync(absPath).isFile();
-  } catch {
-    return false;
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw err;
   }
 }
 
@@ -50,8 +53,11 @@ export function fileExists(absPath: string): boolean {
 export function dirExists(absPath: string): boolean {
   try {
     return fs.statSync(absPath).isDirectory();
-  } catch {
-    return false;
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw err;
   }
 }
 
@@ -61,8 +67,16 @@ export function dirExists(absPath: string): boolean {
 export function readFile(absPath: string): string | null {
   try {
     return fs.readFileSync(absPath, "utf-8");
-  } catch {
-    return null;
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return null;
+    }
+    if (code === "EACCES" || code === "EPERM") {
+      console.warn(`Warning: permission denied reading ${absPath}`);
+      return null;
+    }
+    throw err;
   }
 }
 

--- a/tests/unit/files.test.js
+++ b/tests/unit/files.test.js
@@ -28,6 +28,10 @@ describe('fileExists', () => {
   it('returns false for non-existent files', () => {
     assert.equal(fileExists(path.join(tmpDir, 'nope.txt')), false);
   });
+
+  it('re-throws on unexpected errors', () => {
+    assert.throws(() => fileExists(path.join(tmpDir, 'bad\x00path')));
+  });
 });
 
 describe('dirExists', () => {
@@ -37,6 +41,10 @@ describe('dirExists', () => {
 
   it('returns false for non-existent directories', () => {
     assert.equal(dirExists(path.join(tmpDir, 'nope')), false);
+  });
+
+  it('re-throws on unexpected errors', () => {
+    assert.throws(() => dirExists(path.join(tmpDir, 'bad\x00path')));
   });
 });
 
@@ -61,6 +69,12 @@ describe('readFile', () => {
 
   it('returns null for non-existent files', () => {
     assert.equal(readFile(path.join(tmpDir, 'nope.txt')), null);
+  });
+
+  it('re-throws on unexpected errors (EISDIR)', () => {
+    const dir = path.join(tmpDir, 'a-directory');
+    fs.mkdirSync(dir);
+    assert.throws(() => readFile(dir), (err) => err.code === 'EISDIR');
   });
 });
 


### PR DESCRIPTION
## Summary
- readFile(): ENOENT → null, EACCES/EPERM → warn + null, other → re-throw
- fileExists(): ENOENT → false, other → re-throw
- dirExists(): ENOENT → false, other → re-throw
- 3 new tests: unexpected error re-throwing for each function

## Test plan
- [x] 137 tests pass
- [x] Existing non-existent file tests unchanged
- [x] New tests verify non-ENOENT errors propagate

**Pending: Szabo + Knuth review before merge**

Fixes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)