### PR TITLE
feat: duplicate marker protection + backup corrupted settings (#52, #56)

### DIFF
--- a/src/files.ts
+++ b/src/files.ts
@@ -99,7 +99,15 @@ export function mergeSettings(existingPath: string, newFragment: HookSettings): 
     existing = JSON.parse(fs.readFileSync(existingPath, "utf-8"));
   } catch (err: unknown) {
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-      console.warn(`Warning: ${existingPath} exists but is not valid JSON. Starting fresh.`);
+      const backupPath = existingPath + ".bak";
+      try {
+        fs.copyFileSync(existingPath, backupPath);
+        console.warn(
+          `Warning: ${existingPath} is not valid JSON. Backed up to ${backupPath}. Starting fresh.`,
+        );
+      } catch {
+        console.warn(`Warning: ${existingPath} is not valid JSON. Starting fresh.`);
+      }
     }
   }
 
@@ -155,8 +163,18 @@ export function mergeClaudeMd(
       writeFile(filePath, existing.trimEnd() + "\n\n" + newContent + "\n");
       return "appended";
     }
-    const beforeMarker = existing.substring(0, existing.indexOf(BEGIN_MARKER));
-    const afterMarker = existing.substring(existing.indexOf(END_MARKER) + END_MARKER.length);
+    const firstBegin = existing.indexOf(BEGIN_MARKER);
+    const firstEnd = existing.indexOf(END_MARKER);
+
+    const secondBegin = existing.indexOf(BEGIN_MARKER, firstBegin + 1);
+    if (secondBegin !== -1) {
+      console.warn(
+        "Warning: Found duplicate dev-team marker pairs in CLAUDE.md. Replacing the first pair only and preserving all other content.",
+      );
+    }
+
+    const beforeMarker = existing.substring(0, firstBegin);
+    const afterMarker = existing.substring(firstEnd + END_MARKER.length);
     writeFile(filePath, beforeMarker + newContent + afterMarker);
     return "replaced";
   }

--- a/src/update.ts
+++ b/src/update.ts
@@ -63,7 +63,15 @@ export async function update(targetDir: string): Promise<void> {
   try {
     prefs = JSON.parse(prefsContent);
   } catch {
-    console.error("Error: dev-team.json is corrupted. Run `npx dev-team init` to reinitialize.");
+    const backupPath = prefsPath + ".bak";
+    try {
+      copyFile(prefsPath, backupPath);
+      console.error(
+        `Error: dev-team.json is corrupted. Backed up to ${backupPath}. Run \`npx dev-team init\` to reinitialize.`,
+      );
+    } catch {
+      console.error("Error: dev-team.json is corrupted. Run `npx dev-team init` to reinitialize.");
+    }
     process.exit(1);
   }
 

--- a/tests/unit/files.test.js
+++ b/tests/unit/files.test.js
@@ -130,6 +130,19 @@ describe('mergeSettings', () => {
     const result = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
     assert.deepEqual(result.hooks.PostToolUse[0].matcher, 'Edit');
   });
+
+  it('backs up corrupted settings file before overwriting', () => {
+    const settingsPath = path.join(tmpDir, 'settings.json');
+    const corruptContent = '{ invalid json }}}';
+    fs.writeFileSync(settingsPath, corruptContent);
+
+    const fragment = { hooks: { PostToolUse: [{ matcher: 'Edit', hooks: [{ type: 'command', command: 'test' }] }] } };
+    mergeSettings(settingsPath, fragment);
+
+    const backupPath = settingsPath + '.bak';
+    assert.ok(fs.existsSync(backupPath), 'backup file should exist');
+    assert.equal(fs.readFileSync(backupPath, 'utf-8'), corruptContent);
+  });
 });
 
 describe('mergeClaudeMd', () => {
@@ -162,6 +175,21 @@ describe('mergeClaudeMd', () => {
     assert.ok(content.includes('updated'));
     assert.ok(!content.includes('old'));
     assert.ok(content.includes('Footer'));
+  });
+
+  it('preserves user content between duplicate marker pairs', () => {
+    const p = path.join(tmpDir, 'CLAUDE.md');
+    const duplicated = '# My Project\n\n<!-- dev-team:begin -->\nold1\n<!-- dev-team:end -->\n\nUser paragraph\n\n<!-- dev-team:begin -->\nold2\n<!-- dev-team:end -->\n\nUser footer\n';
+    fs.writeFileSync(p, duplicated);
+
+    const result = mergeClaudeMd(p, '<!-- dev-team:begin -->\nnew\n<!-- dev-team:end -->');
+    assert.equal(result, 'replaced');
+
+    const content = fs.readFileSync(p, 'utf-8');
+    assert.ok(content.includes('My Project'), 'should preserve content before first marker');
+    assert.ok(content.includes('new'), 'should have new content');
+    assert.ok(content.includes('User paragraph'), 'should preserve content between pairs');
+    assert.ok(content.includes('User footer'), 'should preserve content after last pair');
   });
 
   it('appends instead of corrupting when begin marker exists but end marker is missing', () => {


### PR DESCRIPTION
## Summary
- mergeClaudeMd: replaces first BEGIN/END pair only, preserves user content between duplicates
- mergeSettings: backs up corrupt settings.json to .bak before overwriting
- update: backs up corrupt dev-team.json to .bak before exiting

## Agent reviews
- **Szabo+Knuth combined**: 1 defect (content drop — fixed), 2 risks (symlink/.bak overwrite — accepted), 3 suggestions (tracked)

## Test plan
- [x] 154 tests pass
- [x] Duplicate markers: user content between pairs preserved
- [x] Backup: corrupt file saved to .bak

Fixes #52, Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)