### PR TITLE
fix: add migration system for agent renames in update command (#86)

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -11,9 +11,104 @@ import {
   getPackageVersion,
 } from "./files";
 import type { HookSettings, HookMatcher } from "./files";
+import fs from "fs";
 import { ALL_AGENTS, QUALITY_HOOKS } from "./init";
 
-// getPackageVersion imported from files.ts — shared utility
+interface AgentRename {
+  oldLabel: string;
+  oldFile: string;
+  newLabel: string;
+  newFile: string;
+}
+
+interface Migration {
+  version: string;
+  agentRenames?: AgentRename[];
+}
+
+const MIGRATIONS: Migration[] = [
+  {
+    version: "0.4.0",
+    agentRenames: [
+      {
+        oldLabel: "Architect",
+        oldFile: "dev-team-architect.md",
+        newLabel: "Brooks",
+        newFile: "dev-team-brooks.md",
+      },
+      {
+        oldLabel: "Docs",
+        oldFile: "dev-team-docs.md",
+        newLabel: "Tufte",
+        newFile: "dev-team-tufte.md",
+      },
+      {
+        oldLabel: "Release",
+        oldFile: "dev-team-release.md",
+        newLabel: "Conway",
+        newFile: "dev-team-conway.md",
+      },
+      {
+        oldLabel: "Lead",
+        oldFile: "dev-team-lead.md",
+        newLabel: "Drucker",
+        newFile: "dev-team-drucker.md",
+      },
+    ],
+  },
+];
+
+function runMigrations(prefs: Preferences, fromVersion: string, claudeDir: string): string[] {
+  const log: string[] = [];
+
+  for (const migration of MIGRATIONS) {
+    // Skip migrations for versions already applied
+    if (fromVersion >= migration.version) continue;
+
+    if (migration.agentRenames) {
+      for (const rename of migration.agentRenames) {
+        const agentsDir = path.join(claudeDir, "agents");
+        const memoryDir = path.join(claudeDir, "agent-memory");
+
+        // Rename agent file
+        const oldAgentPath = path.join(agentsDir, rename.oldFile);
+        if (fileExists(oldAgentPath)) {
+          try {
+            fs.unlinkSync(oldAgentPath);
+          } catch {
+            // ignore
+          }
+          log.push(`Renamed agent: ${rename.oldLabel} → ${rename.newLabel}`);
+        }
+
+        // Rename memory directory (preserve calibration data)
+        const oldMemDir = path.join(memoryDir, rename.oldFile.replace(".md", ""));
+        const newMemDir = path.join(memoryDir, rename.newFile.replace(".md", ""));
+        if (
+          fileExists(path.join(oldMemDir, "MEMORY.md")) &&
+          !fileExists(path.join(newMemDir, "MEMORY.md"))
+        ) {
+          try {
+            fs.mkdirSync(newMemDir, { recursive: true });
+            fs.renameSync(path.join(oldMemDir, "MEMORY.md"), path.join(newMemDir, "MEMORY.md"));
+            fs.rmdirSync(oldMemDir);
+          } catch {
+            // Best effort — new memory template will be created if this fails
+          }
+          log.push(`Migrated memory: ${rename.oldLabel} → ${rename.newLabel}`);
+        }
+
+        // Update prefs: replace old label with new
+        const idx = prefs.agents.indexOf(rename.oldLabel);
+        if (idx !== -1) {
+          prefs.agents[idx] = rename.newLabel;
+        }
+      }
+    }
+  }
+
+  return log;
+}
 
 interface Preferences {
   version: string;
@@ -81,6 +176,16 @@ export async function update(targetDir: string): Promise<void> {
     console.log(`Already at latest version (v${packageVersion})`);
   } else {
     console.log(`Upgrading from v${prefs.version} to v${packageVersion}`);
+  }
+
+  // Run version migrations before updating agents
+  const migrationLog = runMigrations(prefs, prefs.version || "0.0.0", claudeDir);
+  if (migrationLog.length > 0) {
+    console.log("Migrations:");
+    for (const entry of migrationLog) {
+      console.log(`  ${entry}`);
+    }
+    console.log("");
   }
 
   console.log(`  Agents: ${prefs.agents.join(", ")}`);

--- a/tests/integration/update.test.js
+++ b/tests/integration/update.test.js
@@ -178,4 +178,52 @@ describe('dev-team update', () => {
     const updatedPrefs = JSON.parse(fs.readFileSync(prefsPath, 'utf-8'));
     assert.ok(updatedPrefs.hooks.includes(removedHook), `${removedHook} should be auto-discovered`);
   });
+
+  it('migrates renamed agents on update', async () => {
+    await run(tmpDir, ['--all']);
+
+    // Simulate pre-v0.4 prefs with old agent names
+    const prefsPath = path.join(tmpDir, '.claude', 'dev-team.json');
+    const prefs = JSON.parse(fs.readFileSync(prefsPath, 'utf-8'));
+    prefs.version = '0.3.1';
+
+    // Replace new names with old names
+    prefs.agents = prefs.agents.map((a) => {
+      if (a === 'Brooks') return 'Architect';
+      if (a === 'Tufte') return 'Docs';
+      if (a === 'Conway') return 'Release';
+      if (a === 'Drucker') return 'Lead';
+      return a;
+    });
+
+    // Create old agent files to simulate old install
+    const agentsDir = path.join(tmpDir, '.claude', 'agents');
+    fs.writeFileSync(path.join(agentsDir, 'dev-team-architect.md'), '---\nname: dev-team-architect\n---');
+    fs.writeFileSync(path.join(agentsDir, 'dev-team-docs.md'), '---\nname: dev-team-docs\n---');
+    fs.writeFileSync(path.join(agentsDir, 'dev-team-release.md'), '---\nname: dev-team-release\n---');
+    fs.writeFileSync(path.join(agentsDir, 'dev-team-lead.md'), '---\nname: dev-team-lead\n---');
+
+    fs.writeFileSync(prefsPath, JSON.stringify(prefs, null, 2));
+
+    await update(tmpDir);
+
+    // Verify old names replaced with new in prefs
+    const updated = JSON.parse(fs.readFileSync(prefsPath, 'utf-8'));
+    assert.ok(updated.agents.includes('Brooks'), 'should have Brooks');
+    assert.ok(updated.agents.includes('Tufte'), 'should have Tufte');
+    assert.ok(updated.agents.includes('Conway'), 'should have Conway');
+    assert.ok(updated.agents.includes('Drucker'), 'should have Drucker');
+    assert.ok(!updated.agents.includes('Architect'), 'should not have old Architect');
+    assert.ok(!updated.agents.includes('Docs'), 'should not have old Docs');
+    assert.ok(!updated.agents.includes('Release'), 'should not have old Release');
+    assert.ok(!updated.agents.includes('Lead'), 'should not have old Lead');
+
+    // Verify old agent files removed
+    assert.ok(!fs.existsSync(path.join(agentsDir, 'dev-team-architect.md')), 'old architect file should be removed');
+    assert.ok(!fs.existsSync(path.join(agentsDir, 'dev-team-docs.md')), 'old docs file should be removed');
+
+    // Verify new agent files exist
+    assert.ok(fs.existsSync(path.join(agentsDir, 'dev-team-brooks.md')), 'new brooks file should exist');
+    assert.ok(fs.existsSync(path.join(agentsDir, 'dev-team-tufte.md')), 'new tufte file should exist');
+  });
 });


### PR DESCRIPTION
## Summary
Update command now handles agent renames via a version-keyed migration system:
- Deletes old agent files, renames memory dirs (preserves calibration), updates prefs
- v0.4.0 migration: Architect→Brooks, Docs→Tufte, Release→Conway, Lead→Drucker
- Extensible MIGRATIONS array for future schema changes

## Test plan
- [x] 155 tests pass
- [x] Migration test: pre-v0.4 prefs → update → old names gone, new present, old files deleted

Fixes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)