### PR TITLE
feat: add --version flag to CLI (#60)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc",
     "pretest": "npm run build",
-    "test": "node --test tests/unit/files.test.js tests/unit/hooks.test.js tests/unit/scan.test.js tests/unit/create-agent.test.js tests/integration/fresh-project.test.js tests/integration/idempotency.test.js tests/integration/update.test.js tests/scenarios/node-project.test.js tests/scenarios/python-project.test.js tests/scenarios/upgrade-path.test.js",
+    "test": "node --test tests/unit/files.test.js tests/unit/hooks.test.js tests/unit/scan.test.js tests/unit/create-agent.test.js tests/unit/cli.test.js tests/integration/fresh-project.test.js tests/integration/idempotency.test.js tests/integration/update.test.js tests/scenarios/node-project.test.js tests/scenarios/python-project.test.js tests/scenarios/upgrade-path.test.js",
     "test:unit": "node --test tests/unit/files.test.js tests/unit/hooks.test.js",
     "test:integration": "node --test tests/integration/fresh-project.test.js tests/integration/idempotency.test.js",
     "test:scenarios": "node --test tests/scenarios/node-project.test.js tests/scenarios/python-project.test.js tests/scenarios/upgrade-path.test.js",

--- a/src/bin/dev-team.ts
+++ b/src/bin/dev-team.ts
@@ -1,11 +1,15 @@
 import { run } from "../init";
 import { update } from "../update";
 import { createAgent } from "../create-agent";
+import { getPackageVersion } from "../files";
 
 const args = process.argv.slice(2);
 const command = args[0];
 
-if (command === "init") {
+if (command === "--version" || command === "-v") {
+  console.log(getPackageVersion());
+  process.exit(0);
+} else if (command === "init") {
   run(process.cwd(), args.slice(1)).catch((err: Error) => {
     console.error(`Error: ${err.message}`);
     process.exit(1);

--- a/tests/unit/cli.test.js
+++ b/tests/unit/cli.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+const bin = path.join(__dirname, '..', '..', 'bin', 'dev-team.js');
+const pkg = require('../../package.json');
+
+describe('CLI --version flag', () => {
+  it('prints the version from package.json with --version', () => {
+    const output = execFileSync(process.execPath, [bin, '--version'], {
+      encoding: 'utf-8',
+    });
+    assert.equal(output.trim(), pkg.version);
+  });
+
+  it('prints the version from package.json with -v', () => {
+    const output = execFileSync(process.execPath, [bin, '-v'], {
+      encoding: 'utf-8',
+    });
+    assert.equal(output.trim(), pkg.version);
+  });
+
+  it('exits with code 0', () => {
+    // execFileSync throws on non-zero exit, so reaching here means exit 0
+    execFileSync(process.execPath, [bin, '--version'], {
+      encoding: 'utf-8',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `npx dev-team --version` and `-v` print version from package.json
- 3 new tests in tests/unit/cli.test.js
- 163 tests total on this branch

Fixes #60
🤖 Generated with [Claude Code](https://claude.com/claude-code)