### PR TITLE
test: comprehensive coverage pass — 15 new tests (#57)

### DIFF
--- a/tests/integration/update.test.js
+++ b/tests/integration/update.test.js
@@ -106,6 +106,24 @@ describe('dev-team update', () => {
     await update(tmpDir);
   });
 
+  it('reports "already at latest version" when version matches', async () => {
+    await run(tmpDir, ['--all']);
+
+    // Capture console output during update
+    const logs = [];
+    const originalLog = console.log;
+    console.log = (...args) => { logs.push(args.join(' ')); };
+
+    try {
+      await update(tmpDir);
+    } finally {
+      console.log = originalLog;
+    }
+
+    const alreadyMsg = logs.find((l) => l.includes('Already at latest version'));
+    assert.ok(alreadyMsg, 'should report already at latest version when versions match');
+  });
+
   it('preserves shared team learnings', async () => {
     await run(tmpDir, ['--all']);
 

--- a/tests/unit/create-agent.test.js
+++ b/tests/unit/create-agent.test.js
@@ -90,4 +90,25 @@ describe('createAgent', () => {
     assert.ok(content.includes('model: sonnet'), 'should default to sonnet');
     assert.ok(content.includes('memory: project'), 'should have memory: project');
   });
+
+  it('lowercases uppercase characters in name', () => {
+    createAgent(tmpDir, 'MyAgent');
+
+    const agentPath = path.join(tmpDir, '.claude', 'agents', 'dev-team-myagent.md');
+    assert.ok(fs.existsSync(agentPath), 'agent file should exist with lowercased name');
+
+    const content = fs.readFileSync(agentPath, 'utf-8');
+    assert.ok(content.includes('name: dev-team-myagent'), 'frontmatter should have lowercased name');
+    assert.ok(content.includes('Myagent'), 'body should have title-cased display name');
+  });
+
+  it('handles name that is just "dev-team-" prefix with nothing after', () => {
+    createAgent(tmpDir, 'dev-team-');
+
+    const agentPath = path.join(tmpDir, '.claude', 'agents', 'dev-team-.md');
+    assert.ok(fs.existsSync(agentPath), 'agent file should exist even with empty suffix');
+
+    const content = fs.readFileSync(agentPath, 'utf-8');
+    assert.ok(content.includes('name: dev-team-'), 'should have name with trailing dash');
+  });
 });

--- a/tests/unit/hooks.test.js
+++ b/tests/unit/hooks.test.js
@@ -235,6 +235,16 @@ describe('dev-team-tdd-enforce', () => {
     assert.equal(result.code, 0);
   });
 
+  it('normalizes Windows backslash paths to forward slashes', () => {
+    const result = runHook(hook, { file_path: 'C:\\app\\.github\\workflows\\ci.yml' });
+    assert.equal(result.code, 0, 'should skip config file even with Windows backslash path');
+  });
+
+  it('skips test file with Windows backslash path', () => {
+    const result = runHook(hook, { file_path: 'C:\\app\\tests\\unit\\handler.test.js' });
+    assert.equal(result.code, 0, 'should skip test file with Windows backslash path');
+  });
+
   it('blocks on malformed JSON input (fail closed, exit 2)', () => {
     try {
       execFileSync(process.execPath, [path.join(HOOKS_DIR, hook), 'not-json'], {
@@ -600,6 +610,37 @@ describe('dev-team-pre-commit-lint', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it('detects ruff from pyproject.toml when no package.json exists', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-team-lint-'));
+    try {
+      // Create pyproject.toml with ruff config but no package.json
+      fs.writeFileSync(
+        path.join(tmpDir, 'pyproject.toml'),
+        '[tool.ruff]\nline-length = 88\n',
+      );
+
+      const input = JSON.stringify({ tool_input: { command: 'git commit -m "test"' } });
+      // ruff binary likely not installed, so exec will fail on the check.
+      // The hook should attempt to run ruff and then block (exit 2) because
+      // the ruff command fails. This proves pyproject.toml detection is working.
+      try {
+        execFileSync(process.execPath, [path.join(HOOKS_DIR, hook), input], {
+          encoding: 'utf-8',
+          timeout: 10000,
+          cwd: tmpDir,
+        });
+        // If ruff is actually installed and passes, that is also fine
+        assert.ok(true, 'ruff checks passed (ruff installed)');
+      } catch (err) {
+        // Exit 2 means it detected ruff and tried to run it (blocked on failure)
+        assert.equal(err.status, 2, 'should block when ruff check fails');
+        assert.ok(err.stderr.includes('BLOCKED'), 'should show BLOCKED message');
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ─── Watch List ──────────────────────────────────────────────────────────────
@@ -696,6 +737,44 @@ describe('dev-team-watch-list', () => {
       cwd: tmpDir,
     });
     assert.equal(stdout, '');
+  });
+
+  it('skips malformed entry missing agents key', () => {
+    const prefs = {
+      watchLists: [
+        { pattern: 'src/db/', reason: 'database code changed' },
+        { pattern: 'src/api/', agents: ['dev-team-voss'], reason: 'api changed' },
+      ],
+    };
+    fs.writeFileSync(path.join(tmpDir, '.claude', 'dev-team.json'), JSON.stringify(prefs));
+
+    const input = JSON.stringify({ tool_input: { file_path: '/app/src/db/schema.ts' } });
+    const stdout = execFileSync(process.execPath, [path.join(HOOKS_DIR, hook), input], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      cwd: tmpDir,
+    });
+    // The malformed entry (missing agents) should be skipped, no crash
+    assert.ok(!stdout.includes('@dev-team-codd'), 'should not match entry without agents');
+  });
+
+  it('skips entry with invalid regex pattern', () => {
+    const prefs = {
+      watchLists: [
+        { pattern: '[invalid(regex', agents: ['dev-team-codd'], reason: 'bad regex' },
+        { pattern: 'src/api/', agents: ['dev-team-voss'], reason: 'api changed' },
+      ],
+    };
+    fs.writeFileSync(path.join(tmpDir, '.claude', 'dev-team.json'), JSON.stringify(prefs));
+
+    const input = JSON.stringify({ tool_input: { file_path: '/app/src/api/users.ts' } });
+    const stdout = execFileSync(process.execPath, [path.join(HOOKS_DIR, hook), input], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      cwd: tmpDir,
+    });
+    // Invalid regex should be skipped gracefully, valid entry should still match
+    assert.ok(stdout.includes('@dev-team-voss'), 'should still match valid entries after invalid regex');
   });
 });
 

--- a/tests/unit/scan.test.js
+++ b/tests/unit/scan.test.js
@@ -67,6 +67,28 @@ describe('scanProject', () => {
     assert.ok(missing.length >= 4, `expected at least 4 missing categories, got ${missing.length}`);
   });
 
+  it('detects both linter and formatter when both configs exist', () => {
+    fs.writeFileSync(path.join(tmpDir, '.eslintrc.json'), '{}');
+    fs.writeFileSync(path.join(tmpDir, '.prettierrc'), '{}');
+    const findings = scanProject(tmpDir);
+    const linter = findings.find((f) => f.category === 'linter');
+    const formatter = findings.find((f) => f.category === 'formatter');
+    assert.equal(linter.status, 'found');
+    assert.ok(linter.tool.includes('ESLint'));
+    assert.equal(formatter.status, 'found');
+    assert.ok(formatter.tool.includes('Prettier'));
+  });
+
+  it('handles package.json with empty scripts key', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ scripts: {} }),
+    );
+    const findings = scanProject(tmpDir);
+    const linter = findings.find((f) => f.category === 'linter');
+    assert.equal(linter.status, 'missing', 'linter should be missing with empty scripts');
+  });
+
   it('detects lint script in package.json when no config file exists', () => {
     fs.writeFileSync(
       path.join(tmpDir, 'package.json'),
@@ -76,6 +98,25 @@ describe('scanProject', () => {
     const linter = findings.find((f) => f.category === 'linter');
     assert.equal(linter.status, 'found');
     assert.ok(linter.tool.includes('npm lint'));
+  });
+
+  it('detects Biome as both linter and formatter from single config', () => {
+    fs.writeFileSync(path.join(tmpDir, 'biome.json'), '{}');
+    const findings = scanProject(tmpDir);
+    const linter = findings.find((f) => f.category === 'linter');
+    const formatter = findings.find((f) => f.category === 'formatter');
+    assert.equal(linter.status, 'found');
+    assert.ok(linter.tool.includes('Biome'));
+    assert.equal(formatter.status, 'found');
+    assert.ok(formatter.tool.includes('Biome'));
+  });
+
+  it('detects pyproject.toml as linter config', () => {
+    fs.writeFileSync(path.join(tmpDir, 'pyproject.toml'), '[tool.ruff]\n');
+    const findings = scanProject(tmpDir);
+    const linter = findings.find((f) => f.category === 'linter');
+    assert.equal(linter.status, 'found');
+    assert.ok(linter.tool.includes('ruff'));
   });
 });
 
@@ -186,6 +227,25 @@ describe('enforcement gap detection', () => {
       'expected no enforcement findings without package.json',
     );
   });
+
+  it('flags gap when CI scripts exist but settings.json is empty', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ scripts: { lint: 'eslint .' } }),
+    );
+    fs.mkdirSync(path.join(tmpDir, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.claude', 'settings.json'),
+      JSON.stringify({}),
+    );
+    const findings = scanProject(tmpDir);
+    const gaps = findings.filter(
+      (f) => f.category === 'enforcement' && f.status === 'gap',
+    );
+    assert.ok(gaps.length > 0, 'expected enforcement gap with empty settings');
+    const lintGap = gaps.find((f) => f.tool === 'lint');
+    assert.ok(lintGap, 'expected a gap for lint with empty settings');
+  });
 });
 
 describe('parseCiScripts', () => {
@@ -213,6 +273,24 @@ describe('parseCiScripts', () => {
 
   it('returns empty array for invalid JSON', () => {
     fs.writeFileSync(path.join(tmpDir, 'package.json'), 'not json');
+    const scripts = parseCiScripts(tmpDir);
+    assert.deepEqual(scripts, []);
+  });
+
+  it('returns empty array when scripts key is empty', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ scripts: {} }),
+    );
+    const scripts = parseCiScripts(tmpDir);
+    assert.deepEqual(scripts, []);
+  });
+
+  it('returns empty array when all scripts are non-CI-relevant', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ scripts: { dev: 'nodemon', start: 'node .' } }),
+    );
     const scripts = parseCiScripts(tmpDir);
     assert.deepEqual(scripts, []);
   });


### PR DESCRIPTION
## Summary
15 new tests across scan, create-agent, update, hooks:
- Scan: multi-match, empty scripts, biome detection, enforcement gaps
- Create-agent: uppercase normalization, bare prefix edge case  
- Update: already-at-latest-version message
- Hooks: watch-list malformed entries, tdd-enforce Windows paths, pre-commit-lint ruff detection

170 tests total. No source code changes — tests only.

Fixes #57
🤖 Generated with [Claude Code](https://claude.com/claude-code)