### PR TITLE
feat: close agent invocation gaps from process audit (#88)

### DIFF
--- a/templates/hooks/dev-team-post-change-review.js
+++ b/templates/hooks/dev-team-post-change-review.js
@@ -171,6 +171,11 @@ if (isCodeFile && !isTestFile) {
   flags.push("@dev-team-knuth (new or changed code path to audit)");
 }
 
+// Flag Beck for test file changes (test quality review)
+if (isTestFile && isCodeFile) {
+  flags.push("@dev-team-beck (test file changed — review test quality)");
+}
+
 if (flags.length === 0) {
   process.exit(0);
 }

--- a/templates/skills/dev-team-audit/SKILL.md
+++ b/templates/skills/dev-team-audit/SKILL.md
@@ -83,3 +83,9 @@ Same grouping. Include actionable recommendations.
 ### Recommended next steps
 
 Numbered list of concrete actions, ordered by priority. Each action should reference the specific finding it addresses.
+
+### Completion
+
+After the audit report is delivered:
+1. Spawn **@dev-team-borges** (Librarian) to review memory freshness and capture learnings from the audit findings. This is mandatory.
+2. Include Borges's recommendations in the final report.

--- a/templates/skills/dev-team-review/SKILL.md
+++ b/templates/skills/dev-team-review/SKILL.md
@@ -66,3 +66,9 @@ Group by severity:
 - **Request changes** — `[DEFECT]` findings must be resolved.
 
 State the verdict clearly. List what must be fixed for approval if requesting changes.
+
+### Completion
+
+After the review report is delivered:
+1. Spawn **@dev-team-borges** (Librarian) to review memory freshness and capture any learnings from the review findings. This is mandatory.
+2. Include Borges's recommendations in the final report.


### PR DESCRIPTION
## Summary
Process audit identified 3 gaps in agent invocation:
1. **Beck** never flagged by hooks → now flagged when test files change
2. **Borges** not spawned after /dev-team:review → now mandatory at completion
3. **Borges** not spawned after /dev-team:audit → now mandatory at completion

All 11 agents now have at least one automatic trigger.

Fixes #88
🤖 Generated with [Claude Code](https://claude.com/claude-code)