### PR TITLE
feat: add doctor and status CLI commands (#61, #62)

### DIFF
--- a/src/bin/dev-team.ts
+++ b/src/bin/dev-team.ts
@@ -1,6 +1,8 @@
 import { run } from "../init";
 import { update } from "../update";
 import { createAgent } from "../create-agent";
+import { doctor } from "../doctor";
+import { status } from "../status";
 import { getPackageVersion } from "../files";
 
 const args = process.argv.slice(2);
@@ -21,6 +23,10 @@ if (command === "--version" || command === "-v") {
   });
 } else if (command === "create-agent") {
   createAgent(process.cwd(), args[1]);
+} else if (command === "doctor") {
+  doctor(process.cwd());
+} else if (command === "status") {
+  status(process.cwd());
 } else {
   console.log("dev-team — Adversarial AI agent team for any project\n");
   console.log("Usage:");
@@ -31,6 +37,9 @@ if (command === "--version" || command === "-v") {
   console.log("  npx dev-team init --preset data       Data pipeline (backend, quality, tooling)");
   console.log("  npx dev-team update                  Update agents, hooks, and skills to latest");
   console.log("  npx dev-team create-agent <name>     Scaffold a new custom agent");
+  console.log("  npx dev-team doctor                  Check installation health");
+  console.log("  npx dev-team status                  Show installed agents, hooks, and memory");
+  console.log("  npx dev-team --version               Print version");
   console.log("");
   process.exit(command === "--help" || command === "-h" ? 0 : 1);
 }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,0 +1,110 @@
+import path from "path";
+import { fileExists, dirExists, readFile } from "./files";
+
+interface CheckResult {
+  name: string;
+  pass: boolean;
+  detail: string;
+}
+
+export function doctor(targetDir: string): void {
+  console.log("\ndev-team doctor — Installation health check\n");
+
+  const claudeDir = path.join(targetDir, ".claude");
+  const results: CheckResult[] = [];
+
+  // 1. dev-team.json exists and is valid
+  const prefsPath = path.join(claudeDir, "dev-team.json");
+  const prefsContent = readFile(prefsPath);
+  let prefs: { version?: string; agents?: string[]; hooks?: string[] } | null = null;
+  if (!prefsContent) {
+    results.push({ name: "dev-team.json", pass: false, detail: "Not found" });
+  } else {
+    try {
+      prefs = JSON.parse(prefsContent);
+      results.push({ name: "dev-team.json", pass: true, detail: `v${prefs!.version}` });
+    } catch {
+      results.push({ name: "dev-team.json", pass: false, detail: "Invalid JSON" });
+    }
+  }
+
+  // 2. Agent files exist
+  if (prefs?.agents) {
+    const agentsDir = path.join(claudeDir, "agents");
+    for (const label of prefs.agents) {
+      // Convert label to filename pattern
+      const fileName = `dev-team-${label.toLowerCase()}.md`;
+      const exists = fileExists(path.join(agentsDir, fileName));
+      results.push({
+        name: `Agent: ${label}`,
+        pass: exists,
+        detail: exists ? fileName : `${fileName} missing`,
+      });
+    }
+  }
+
+  // 3. Hook files exist
+  if (prefs?.hooks) {
+    const hooksDir = path.join(claudeDir, "hooks");
+    const hookFileMap: Record<string, string> = {
+      "TDD enforcement": "dev-team-tdd-enforce.js",
+      "Safety guard": "dev-team-safety-guard.js",
+      "Post-change review": "dev-team-post-change-review.js",
+      "Pre-commit gate": "dev-team-pre-commit-gate.js",
+      "Task loop": "dev-team-task-loop.js",
+      "Watch list": "dev-team-watch-list.js",
+      "Pre-commit lint": "dev-team-pre-commit-lint.js",
+    };
+    for (const label of prefs.hooks) {
+      const fileName = hookFileMap[label];
+      if (!fileName) {
+        results.push({ name: `Hook: ${label}`, pass: false, detail: "Unknown hook" });
+        continue;
+      }
+      const exists = fileExists(path.join(hooksDir, fileName));
+      results.push({
+        name: `Hook: ${label}`,
+        pass: exists,
+        detail: exists ? fileName : `${fileName} missing`,
+      });
+    }
+  }
+
+  // 4. CLAUDE.md has dev-team markers
+  const claudeMdPath = path.join(targetDir, "CLAUDE.md");
+  const claudeMd = readFile(claudeMdPath);
+  if (!claudeMd) {
+    results.push({ name: "CLAUDE.md", pass: false, detail: "Not found" });
+  } else if (!claudeMd.includes("<!-- dev-team:begin -->")) {
+    results.push({ name: "CLAUDE.md", pass: false, detail: "Missing dev-team markers" });
+  } else {
+    results.push({ name: "CLAUDE.md", pass: true, detail: "Markers present" });
+  }
+
+  // 5. Agent memory directories
+  if (prefs?.agents) {
+    const memoryDir = path.join(claudeDir, "agent-memory");
+    for (const label of prefs.agents) {
+      const dirName = `dev-team-${label.toLowerCase()}`;
+      const memPath = path.join(memoryDir, dirName, "MEMORY.md");
+      const exists = fileExists(memPath);
+      results.push({
+        name: `Memory: ${label}`,
+        pass: exists,
+        detail: exists ? "MEMORY.md present" : "MEMORY.md missing",
+      });
+    }
+  }
+
+  // Print results
+  const passed = results.filter((r) => r.pass).length;
+  const failed = results.filter((r) => !r.pass).length;
+
+  for (const r of results) {
+    const icon = r.pass ? "  OK" : "  FAIL";
+    console.log(`${icon}  ${r.name} — ${r.detail}`);
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,0 +1,83 @@
+import path from "path";
+import fs from "fs";
+import { fileExists, readFile, listSubdirectories } from "./files";
+
+export function status(targetDir: string): void {
+  const claudeDir = path.join(targetDir, ".claude");
+  const prefsPath = path.join(claudeDir, "dev-team.json");
+
+  const prefsContent = readFile(prefsPath);
+  if (!prefsContent) {
+    console.error("Not a dev-team project. Run `npx dev-team init` first.");
+    process.exit(1);
+  }
+
+  let prefs: Record<string, unknown>;
+  try {
+    prefs = JSON.parse(prefsContent);
+  } catch {
+    console.error("dev-team.json is corrupted.");
+    process.exit(1);
+  }
+
+  console.log("\ndev-team status\n");
+
+  // Version and preset
+  console.log(`  Version:  v${prefs.version}`);
+  if (prefs.preset) {
+    console.log(`  Preset:   ${prefs.preset}`);
+  }
+
+  // Agents
+  const agents = (prefs.agents as string[]) || [];
+  console.log(`  Agents:   ${agents.join(", ")} (${agents.length})`);
+
+  // Hooks
+  const hooks = (prefs.hooks as string[]) || [];
+  console.log(`  Hooks:    ${hooks.join(", ")} (${hooks.length})`);
+
+  // Skills (auto-discovered)
+  const skillsDir = path.join(claudeDir, "skills");
+  const skills = listSubdirectories(skillsDir).map((s) => s.replace("dev-team-", ""));
+  console.log(`  Skills:   ${skills.length > 0 ? skills.join(", ") : "none"} (${skills.length})`);
+
+  // Workflow
+  if (prefs.issueTracker) {
+    console.log(`  Tracker:  ${prefs.issueTracker}`);
+  }
+  if (prefs.branchConvention && prefs.branchConvention !== "None") {
+    console.log(`  Branches: ${prefs.branchConvention}`);
+  }
+
+  // Memory status
+  console.log("\n  Memory:");
+  const memoryDir = path.join(claudeDir, "agent-memory");
+  for (const label of agents) {
+    const dirName = `dev-team-${label.toLowerCase()}`;
+    const memPath = path.join(memoryDir, dirName, "MEMORY.md");
+    if (fileExists(memPath)) {
+      try {
+        const stat = fs.statSync(memPath);
+        const hasContent = stat.size > 200; // Template is ~200 bytes
+        console.log(`    ${label}: ${hasContent ? "has learnings" : "empty (template only)"}`);
+      } catch {
+        console.log(`    ${label}: unknown`);
+      }
+    } else {
+      console.log(`    ${label}: no memory file`);
+    }
+  }
+
+  // Shared learnings
+  const learningsPath = path.join(claudeDir, "dev-team-learnings.md");
+  if (fileExists(learningsPath)) {
+    try {
+      const stat = fs.statSync(learningsPath);
+      console.log(`    Shared learnings: ${stat.size > 300 ? "has content" : "template only"}`);
+    } catch {
+      console.log(`    Shared learnings: unknown`);
+    }
+  }
+
+  console.log("");
+}


### PR DESCRIPTION
## Summary
Two new CLI commands:
- `npx dev-team doctor` — installation health check (prefs, agents, hooks, CLAUDE.md, memory)
- `npx dev-team status` — show version, agents, hooks, skills, memory status

## Test plan
- [x] 174 tests pass
- [x] Doctor smoke test: all checks pass on project's own installation
- [x] Status smoke test: shows correct counts and memory status

Fixes #61, Fixes #62
🤖 Generated with [Claude Code](https://claude.com/claude-code)