### PR TITLE
chore: release v0.6.0

### DIFF
--- a/.claude/dev-team-learnings.md
+++ b/.claude/dev-team-learnings.md
@@ -24,10 +24,11 @@
 
 ## Quality Benchmarks
 
-- 117 tests: 25 unit (files), 62 unit (hooks + watch list), 9 unit (scan), 7 integration (update), 3 integration (presets), 11 scenario
-- 10 agents: Voss, Mori, Szabo, Knuth, Beck, Deming, Docs, Architect, Release, Lead
-- 4 skills: challenge, task, review, audit
+- 273 tests total (was 117 at v0.3.0)
+- 12 agents: Voss, Mori, Szabo, Knuth, Beck, Deming, Tufte, Brooks, Conway, Drucker, Borges, Hamilton
+- 5 skills: challenge, task, review, audit, security-status
 - 6 hooks: TDD enforce, safety guard, post-change review, pre-commit gate, task loop, watch list
+- 3 always-on reviewers: Szabo (security), Knuth (correctness), Brooks (architecture + quality attributes)
 - CI: 3 OS x 3 Node versions + lint + format + agent validation + hook validation.
 - Always run `npm run format` before committing new `.ts` files — oxfmt formatting is checked in CI.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-03-23
+
+### Added
+- Hamilton agent (`@dev-team-hamilton`) — new infrastructure implementing agent covering Dockerfiles, IaC, CI/CD, Kubernetes, deployment, health checks, and monitoring. Named after Margaret Hamilton. Replaces Voss's infrastructure scope.
+- `/dev-team:security-status` skill — proactive GitHub security signal monitoring (code scanning, Dependabot, secret scanning). 5 skills total.
+- NFR ownership codified — all 9 standard NFR dimensions mapped to explicit agent ownership: Mori (API compatibility), Voss (data compatibility), Deming (portability).
+- Dependabot enabled for npm and GitHub Actions version updates.
+- CodeQL explicit workflow permissions added to CI.
+- ADR-020: Brooks always-on for all code changes, evaluating quality attributes alongside structural review.
+- Tufte doc-drift detection — Tufte now triggers on significant implementation changes (not just doc file changes) to catch missing or stale documentation.
+- Parallel review wave enforcement (#93, ADR-019) — mechanical enforcement with state machine, sync barriers, and phase transition tracking.
+- Git context caching hardened (#94, ADR-018) — atomic temp+rename writes, symlink prevention via `lstatSync`, `0o600` file permissions.
+- Branch protection migrated to GitHub rulesets with required status checks.
+- 273 tests total (was 117).
+
+### Changed
+- Brooks is now always-on for all code changes (was architecture files only), evaluating performance, maintainability, and scalability. Design principle: "depth justifies separation, breadth justifies consolidation."
+- Voss scope narrowed to backend and application config; infrastructure scope transferred to Hamilton.
+- Reviewers always-on: Szabo (security, deep) + Knuth (correctness, deep) + Brooks (architecture + quality attributes, broad). Was 2, now 3.
+- Agents: 12 total (was 11). Added Hamilton.
+
 ## [0.5.0] - 2026-03-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Adversarial AI agent team for any project — installs Claude Code agents, hooks, and skills that enforce quality through productive friction",
   "main": "dist/init.js",
   "types": "dist/init.d.ts",


### PR DESCRIPTION
## Release v0.6.0

Version bump, changelog, and quality benchmarks update.

### Highlights
- **12 agents** (added Hamilton — Infrastructure Engineer)
- **3 always-on reviewers** (Szabo + Knuth + Brooks with quality attributes)
- **5 skills** (added `/dev-team:security-status`)
- **273 tests** (was 117)
- **ADR-020** — Quality attribute assessment via expanded Brooks
- **NFR ownership** codified across all agents
- **Parallel review wave enforcement** with mechanical sync barriers
- **Git context caching hardened** with atomic writes + symlink prevention
- **Dependabot + CodeQL** configured
- **GitHub rulesets** replacing branch protection

See CHANGELOG.md for full details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)