### PR TITLE
fix: address Copilot review findings from PR #120

### DIFF
--- a/docs/adr/013-active-hook-spawning.md
+++ b/docs/adr/013-active-hook-spawning.md
@@ -2,7 +2,7 @@
 Date: 2026-03-22
 Status: superseded
 
-**Superseded by**: Issue #113 — the tracking file (`dev-team-review-pending.json`) was removed because it caused orphaned-file bugs that blocked commits. The post-change-review hook now relies solely on stateless stdout output and CLAUDE.md directives to enforce agent spawning. The pre-commit gate no longer checks for a tracking file.
+**Superseded by**: Issue #113 — the tracking file (`.dev-team/review-pending.json`) was removed because it caused orphaned-file bugs that blocked commits. The post-change-review hook now relies solely on stateless stdout output and CLAUDE.md directives to enforce agent spawning. The pre-commit gate no longer checks for a tracking file.
 
 ## Context
 Prior to this change, all review hooks were advisory — they printed "Flag for review: @dev-team-szabo" to stdout and exited 0. These messages scrolled past in hook output and were consistently ignored. The result: README went stale across 3 releases, Release agent never reviewed changelogs, Docs agent was never invoked.

--- a/docs/adr/019-parallel-review-waves.md
+++ b/docs/adr/019-parallel-review-waves.md
@@ -2,7 +2,7 @@
 Date: 2026-03-22
 Status: amended
 
-**Amended by**: Issue #113 — the state file (`dev-team-parallel.json`) and Stop hook (`dev-team-parallel-loop.js`) were removed. The parallel orchestration model remains, but state tracking now lives in Drucker's conversation context rather than on disk. The Agent tool's built-in completion notifications provide the sync barrier, eliminating the need for file-based state management.
+**Amended by**: Issue #113 — the state file (`.dev-team/parallel.json`) and Stop hook (`dev-team-parallel-loop.js`) were removed. The parallel orchestration model remains, but state tracking now lives in Drucker's conversation context rather than on disk. The Agent tool's built-in completion notifications provide the sync barrier, eliminating the need for file-based state management.
 
 ## Context
 The `/dev-team:task` skill runs a single-issue loop: one implementing agent, followed by reviewers, iterated until convergence. When multiple independent issues need to be addressed in the same session, they execute sequentially — each issue waits for the previous one to complete its full review cycle. This is slow and wastes available concurrency.

--- a/src/update.ts
+++ b/src/update.ts
@@ -60,12 +60,22 @@ const MIGRATIONS: Migration[] = [
   },
 ];
 
+export function compareSemver(a: string, b: string): number {
+  const pa = a.split(".").map((n) => parseInt(n, 10));
+  const pb = b.split(".").map((n) => parseInt(n, 10));
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] || 0) - (pb[i] || 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
 function runMigrations(prefs: Preferences, fromVersion: string, devTeamDir: string): string[] {
   const log: string[] = [];
 
   for (const migration of MIGRATIONS) {
     // Skip migrations for versions already applied
-    if (fromVersion >= migration.version) continue;
+    if (compareSemver(fromVersion, migration.version) >= 0) continue;
 
     if (migration.agentRenames) {
       for (const rename of migration.agentRenames) {
@@ -245,7 +255,7 @@ export async function update(targetDir: string): Promise<void> {
   const oldPrefsPath = path.join(claudeDir, "dev-team.json");
   const newPrefsPath = path.join(devTeamDir, "config.json");
 
-  const needsMigration = fileExists(oldPrefsPath) && !dirExists(devTeamDir);
+  const needsMigration = fileExists(oldPrefsPath) && !fileExists(newPrefsPath);
 
   if (needsMigration) {
     console.log("Migrating from .claude/ to .dev-team/ directory structure...\n");

--- a/tests/integration/update.test.js
+++ b/tests/integration/update.test.js
@@ -1,19 +1,19 @@
-'use strict';
+"use strict";
 
-const { describe, it, beforeEach, afterEach } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
+const { describe, it, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
 
-const { run } = require('../../dist/init');
-const { update } = require('../../dist/update');
+const { run } = require("../../dist/init");
+const { update, compareSemver } = require("../../dist/update");
 
 let tmpDir;
 let originalCwd;
 
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-team-update-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dev-team-update-"));
   originalCwd = process.cwd();
   process.chdir(tmpDir);
 });
@@ -23,96 +23,98 @@ afterEach(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-describe('dev-team update', () => {
-  it('updates agent files when template content changes', async () => {
+describe("dev-team update", () => {
+  it("updates agent files when template content changes", async () => {
     // Initial install
-    await run(tmpDir, ['--all']);
+    await run(tmpDir, ["--all"]);
 
     // Modify an installed agent to simulate a stale version
-    const agentPath = path.join(tmpDir, '.dev-team', 'agents', 'dev-team-voss.md');
-    fs.writeFileSync(agentPath, 'old content');
+    const agentPath = path.join(tmpDir, ".dev-team", "agents", "dev-team-voss.md");
+    fs.writeFileSync(agentPath, "old content");
 
     // Run update
     await update(tmpDir);
 
     // Agent should be restored to template content
-    const content = fs.readFileSync(agentPath, 'utf-8');
-    assert.ok(content.includes('dev-team-voss'), 'agent should be updated to latest template');
-    assert.ok(!content.includes('old content'), 'old content should be replaced');
+    const content = fs.readFileSync(agentPath, "utf-8");
+    assert.ok(content.includes("dev-team-voss"), "agent should be updated to latest template");
+    assert.ok(!content.includes("old content"), "old content should be replaced");
   });
 
-  it('preserves agent memory files during update', async () => {
-    await run(tmpDir, ['--all']);
+  it("preserves agent memory files during update", async () => {
+    await run(tmpDir, ["--all"]);
 
     // Add custom content to agent memory
-    const memoryPath = path.join(tmpDir, '.dev-team', 'agent-memory', 'dev-team-voss', 'MEMORY.md');
-    fs.writeFileSync(memoryPath, '# Custom learnings\nVoss learned something important.');
+    const memoryPath = path.join(tmpDir, ".dev-team", "agent-memory", "dev-team-voss", "MEMORY.md");
+    fs.writeFileSync(memoryPath, "# Custom learnings\nVoss learned something important.");
 
     await update(tmpDir);
 
     // Memory should be untouched
-    const content = fs.readFileSync(memoryPath, 'utf-8');
-    assert.ok(content.includes('Custom learnings'), 'memory should not be overwritten');
+    const content = fs.readFileSync(memoryPath, "utf-8");
+    assert.ok(content.includes("Custom learnings"), "memory should not be overwritten");
   });
 
-  it('preserves CLAUDE.md content outside dev-team markers', async () => {
+  it("preserves CLAUDE.md content outside dev-team markers", async () => {
     // Create a CLAUDE.md with custom content
-    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), '# My Project\n\nCustom instructions here.\n');
+    fs.writeFileSync(path.join(tmpDir, "CLAUDE.md"), "# My Project\n\nCustom instructions here.\n");
 
-    await run(tmpDir, ['--all']);
+    await run(tmpDir, ["--all"]);
 
     // Verify custom content was preserved after init
-    let content = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf-8');
-    assert.ok(content.includes('My Project'), 'should preserve existing content after init');
+    let content = fs.readFileSync(path.join(tmpDir, "CLAUDE.md"), "utf-8");
+    assert.ok(content.includes("My Project"), "should preserve existing content after init");
 
     await update(tmpDir);
 
     // Still preserved after update
-    content = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf-8');
-    assert.ok(content.includes('My Project'), 'should preserve existing content after update');
-    assert.ok(content.includes('dev-team:begin'), 'should have dev-team markers');
+    content = fs.readFileSync(path.join(tmpDir, "CLAUDE.md"), "utf-8");
+    assert.ok(content.includes("My Project"), "should preserve existing content after update");
+    assert.ok(content.includes("dev-team:begin"), "should have dev-team markers");
   });
 
-  it('updates hook files when template content changes', async () => {
-    await run(tmpDir, ['--all']);
+  it("updates hook files when template content changes", async () => {
+    await run(tmpDir, ["--all"]);
 
     // Modify an installed hook to simulate a stale version
-    const hookPath = path.join(tmpDir, '.dev-team', 'hooks', 'dev-team-safety-guard.js');
-    fs.writeFileSync(hookPath, '// old hook');
+    const hookPath = path.join(tmpDir, ".dev-team", "hooks", "dev-team-safety-guard.js");
+    fs.writeFileSync(hookPath, "// old hook");
 
     await update(tmpDir);
 
-    const content = fs.readFileSync(hookPath, 'utf-8');
-    assert.ok(content.includes('safety-guard'), 'hook should be updated');
-    assert.ok(!content.includes('old hook'), 'old content should be replaced');
+    const content = fs.readFileSync(hookPath, "utf-8");
+    assert.ok(content.includes("safety-guard"), "hook should be updated");
+    assert.ok(!content.includes("old hook"), "old content should be replaced");
   });
 
-  it('updates skill files when template content changes', async () => {
-    await run(tmpDir, ['--all']);
+  it("updates skill files when template content changes", async () => {
+    await run(tmpDir, ["--all"]);
 
-    const skillPath = path.join(tmpDir, '.dev-team', 'skills', 'dev-team-challenge', 'SKILL.md');
-    fs.writeFileSync(skillPath, 'old skill');
+    const skillPath = path.join(tmpDir, ".dev-team", "skills", "dev-team-challenge", "SKILL.md");
+    fs.writeFileSync(skillPath, "old skill");
 
     await update(tmpDir);
 
-    const content = fs.readFileSync(skillPath, 'utf-8');
-    assert.ok(content.includes('challenge'), 'skill should be updated');
+    const content = fs.readFileSync(skillPath, "utf-8");
+    assert.ok(content.includes("challenge"), "skill should be updated");
   });
 
-  it('reports no changes when already up to date', async () => {
-    await run(tmpDir, ['--all']);
+  it("reports no changes when already up to date", async () => {
+    await run(tmpDir, ["--all"]);
 
     // Update with no changes — should not throw
     await update(tmpDir);
   });
 
   it('reports "already at latest version" when version matches', async () => {
-    await run(tmpDir, ['--all']);
+    await run(tmpDir, ["--all"]);
 
     // Capture console output during update
     const logs = [];
     const originalLog = console.log;
-    console.log = (...args) => { logs.push(args.join(' ')); };
+    console.log = (...args) => {
+      logs.push(args.join(" "));
+    };
 
     try {
       await update(tmpDir);
@@ -120,178 +122,324 @@ describe('dev-team update', () => {
       console.log = originalLog;
     }
 
-    const alreadyMsg = logs.find((l) => l.includes('Already at latest version'));
-    assert.ok(alreadyMsg, 'should report already at latest version when versions match');
+    const alreadyMsg = logs.find((l) => l.includes("Already at latest version"));
+    assert.ok(alreadyMsg, "should report already at latest version when versions match");
   });
 
-  it('preserves shared team learnings', async () => {
-    await run(tmpDir, ['--all']);
+  it("preserves shared team learnings", async () => {
+    await run(tmpDir, ["--all"]);
 
-    const learningsPath = path.join(tmpDir, '.dev-team', 'learnings.md');
-    fs.writeFileSync(learningsPath, '# Custom Learnings\nWe use PostgreSQL.');
+    const learningsPath = path.join(tmpDir, ".dev-team", "learnings.md");
+    fs.writeFileSync(learningsPath, "# Custom Learnings\nWe use PostgreSQL.");
 
     await update(tmpDir);
 
-    const content = fs.readFileSync(learningsPath, 'utf-8');
-    assert.ok(content.includes('PostgreSQL'), 'learnings should not be overwritten');
+    const content = fs.readFileSync(learningsPath, "utf-8");
+    assert.ok(content.includes("PostgreSQL"), "learnings should not be overwritten");
   });
 
-  it('updates all agents including those added after initial install', async () => {
-    await run(tmpDir, ['--all']);
+  it("updates all agents including those added after initial install", async () => {
+    await run(tmpDir, ["--all"]);
 
     // Stale every agent file
-    const agentsDir = path.join(tmpDir, '.dev-team', 'agents');
+    const agentsDir = path.join(tmpDir, ".dev-team", "agents");
     const agentFiles = fs.readdirSync(agentsDir);
     for (const f of agentFiles) {
-      fs.writeFileSync(path.join(agentsDir, f), 'stale');
+      fs.writeFileSync(path.join(agentsDir, f), "stale");
     }
 
     await update(tmpDir);
 
     // Every agent should be restored — none should be our sentinel value
     for (const f of agentFiles) {
-      const content = fs.readFileSync(path.join(agentsDir, f), 'utf-8');
-      assert.ok(content.startsWith('---'), `${f} should have been updated (should start with frontmatter)`);
+      const content = fs.readFileSync(path.join(agentsDir, f), "utf-8");
+      assert.ok(
+        content.startsWith("---"),
+        `${f} should have been updated (should start with frontmatter)`,
+      );
     }
   });
 
-  it('upgrades version in prefs when package version is newer', async () => {
+  it("upgrades version in prefs when package version is newer", async () => {
     // Initial install - saves current package version
-    await run(tmpDir, ['--all']);
+    await run(tmpDir, ["--all"]);
 
-    const prefsPath = path.join(tmpDir, '.dev-team', 'config.json');
-    const prefs = JSON.parse(fs.readFileSync(prefsPath, 'utf-8'));
+    const prefsPath = path.join(tmpDir, ".dev-team", "config.json");
+    const prefs = JSON.parse(fs.readFileSync(prefsPath, "utf-8"));
     const currentVersion = prefs.version;
-    assert.ok(currentVersion, 'init should set a version in prefs');
+    assert.ok(currentVersion, "init should set a version in prefs");
 
     // Manually downgrade the version to simulate an older install
-    prefs.version = '0.0.1';
-    fs.writeFileSync(prefsPath, JSON.stringify(prefs, null, 2) + '\n');
+    prefs.version = "0.0.1";
+    fs.writeFileSync(prefsPath, JSON.stringify(prefs, null, 2) + "\n");
 
     // Run update - should detect the version difference and upgrade
     await update(tmpDir);
 
     // Verify version is now current
-    const updatedPrefs = JSON.parse(fs.readFileSync(prefsPath, 'utf-8'));
-    assert.equal(updatedPrefs.version, currentVersion, 'version should be upgraded to current package version');
-    assert.notEqual(updatedPrefs.version, '0.0.1', 'version should no longer be the old value');
+    const updatedPrefs = JSON.parse(fs.readFileSync(prefsPath, "utf-8"));
+    assert.equal(
+      updatedPrefs.version,
+      currentVersion,
+      "version should be upgraded to current package version",
+    );
+    assert.notEqual(updatedPrefs.version, "0.0.1", "version should no longer be the old value");
   });
 
-  it('auto-discovers and installs new hooks not in preferences', async () => {
-    await run(tmpDir, ['--all']);
+  it("auto-discovers and installs new hooks not in preferences", async () => {
+    await run(tmpDir, ["--all"]);
 
     // Remove a hook from preferences to simulate an older install
-    const prefsPath = path.join(tmpDir, '.dev-team', 'config.json');
-    const prefs = JSON.parse(fs.readFileSync(prefsPath, 'utf-8'));
+    const prefsPath = path.join(tmpDir, ".dev-team", "config.json");
+    const prefs = JSON.parse(fs.readFileSync(prefsPath, "utf-8"));
     const removedHook = prefs.hooks.pop(); // Remove last hook
     fs.writeFileSync(prefsPath, JSON.stringify(prefs, null, 2));
 
     // Delete the hook file too
-    const hookFiles = fs.readdirSync(path.join(tmpDir, '.dev-team', 'hooks'));
+    const hookFiles = fs.readdirSync(path.join(tmpDir, ".dev-team", "hooks"));
     const hookCountBefore = hookFiles.length;
 
     await update(tmpDir);
 
     // Hook should be re-added to preferences
-    const updatedPrefs = JSON.parse(fs.readFileSync(prefsPath, 'utf-8'));
+    const updatedPrefs = JSON.parse(fs.readFileSync(prefsPath, "utf-8"));
     assert.ok(updatedPrefs.hooks.includes(removedHook), `${removedHook} should be auto-discovered`);
   });
 
-  it('migrates renamed agents on update', async () => {
-    await run(tmpDir, ['--all']);
+  it("migrates renamed agents on update", async () => {
+    await run(tmpDir, ["--all"]);
 
     // Simulate pre-v0.4 prefs with old agent names
-    const prefsPath = path.join(tmpDir, '.dev-team', 'config.json');
-    const prefs = JSON.parse(fs.readFileSync(prefsPath, 'utf-8'));
-    prefs.version = '0.3.1';
+    const prefsPath = path.join(tmpDir, ".dev-team", "config.json");
+    const prefs = JSON.parse(fs.readFileSync(prefsPath, "utf-8"));
+    prefs.version = "0.3.1";
 
     // Replace new names with old names
     prefs.agents = prefs.agents.map((a) => {
-      if (a === 'Brooks') return 'Architect';
-      if (a === 'Tufte') return 'Docs';
-      if (a === 'Conway') return 'Release';
-      if (a === 'Drucker') return 'Lead';
+      if (a === "Brooks") return "Architect";
+      if (a === "Tufte") return "Docs";
+      if (a === "Conway") return "Release";
+      if (a === "Drucker") return "Lead";
       return a;
     });
 
     // Create old agent files to simulate old install
-    const agentsDir = path.join(tmpDir, '.dev-team', 'agents');
-    fs.writeFileSync(path.join(agentsDir, 'dev-team-architect.md'), '---\nname: dev-team-architect\n---');
-    fs.writeFileSync(path.join(agentsDir, 'dev-team-docs.md'), '---\nname: dev-team-docs\n---');
-    fs.writeFileSync(path.join(agentsDir, 'dev-team-release.md'), '---\nname: dev-team-release\n---');
-    fs.writeFileSync(path.join(agentsDir, 'dev-team-lead.md'), '---\nname: dev-team-lead\n---');
+    const agentsDir = path.join(tmpDir, ".dev-team", "agents");
+    fs.writeFileSync(
+      path.join(agentsDir, "dev-team-architect.md"),
+      "---\nname: dev-team-architect\n---",
+    );
+    fs.writeFileSync(path.join(agentsDir, "dev-team-docs.md"), "---\nname: dev-team-docs\n---");
+    fs.writeFileSync(
+      path.join(agentsDir, "dev-team-release.md"),
+      "---\nname: dev-team-release\n---",
+    );
+    fs.writeFileSync(path.join(agentsDir, "dev-team-lead.md"), "---\nname: dev-team-lead\n---");
 
     fs.writeFileSync(prefsPath, JSON.stringify(prefs, null, 2));
 
     await update(tmpDir);
 
     // Verify old names replaced with new in prefs
-    const updated = JSON.parse(fs.readFileSync(prefsPath, 'utf-8'));
-    assert.ok(updated.agents.includes('Brooks'), 'should have Brooks');
-    assert.ok(updated.agents.includes('Tufte'), 'should have Tufte');
-    assert.ok(updated.agents.includes('Conway'), 'should have Conway');
-    assert.ok(updated.agents.includes('Drucker'), 'should have Drucker');
-    assert.ok(!updated.agents.includes('Architect'), 'should not have old Architect');
-    assert.ok(!updated.agents.includes('Docs'), 'should not have old Docs');
-    assert.ok(!updated.agents.includes('Release'), 'should not have old Release');
-    assert.ok(!updated.agents.includes('Lead'), 'should not have old Lead');
+    const updated = JSON.parse(fs.readFileSync(prefsPath, "utf-8"));
+    assert.ok(updated.agents.includes("Brooks"), "should have Brooks");
+    assert.ok(updated.agents.includes("Tufte"), "should have Tufte");
+    assert.ok(updated.agents.includes("Conway"), "should have Conway");
+    assert.ok(updated.agents.includes("Drucker"), "should have Drucker");
+    assert.ok(!updated.agents.includes("Architect"), "should not have old Architect");
+    assert.ok(!updated.agents.includes("Docs"), "should not have old Docs");
+    assert.ok(!updated.agents.includes("Release"), "should not have old Release");
+    assert.ok(!updated.agents.includes("Lead"), "should not have old Lead");
 
     // Verify old agent files removed
-    assert.ok(!fs.existsSync(path.join(agentsDir, 'dev-team-architect.md')), 'old architect file should be removed');
-    assert.ok(!fs.existsSync(path.join(agentsDir, 'dev-team-docs.md')), 'old docs file should be removed');
+    assert.ok(
+      !fs.existsSync(path.join(agentsDir, "dev-team-architect.md")),
+      "old architect file should be removed",
+    );
+    assert.ok(
+      !fs.existsSync(path.join(agentsDir, "dev-team-docs.md")),
+      "old docs file should be removed",
+    );
 
     // Verify new agent files exist
-    assert.ok(fs.existsSync(path.join(agentsDir, 'dev-team-brooks.md')), 'new brooks file should exist');
-    assert.ok(fs.existsSync(path.join(agentsDir, 'dev-team-tufte.md')), 'new tufte file should exist');
+    assert.ok(
+      fs.existsSync(path.join(agentsDir, "dev-team-brooks.md")),
+      "new brooks file should exist",
+    );
+    assert.ok(
+      fs.existsSync(path.join(agentsDir, "dev-team-tufte.md")),
+      "new tufte file should exist",
+    );
   });
 
-  it('migrates from .claude/ to .dev-team/ on update', async () => {
+  it("migrates from .claude/ to .dev-team/ on update", async () => {
     // Simulate a pre-migration install (files in .claude/)
-    fs.mkdirSync(path.join(tmpDir, '.claude', 'agents'), { recursive: true });
-    fs.mkdirSync(path.join(tmpDir, '.claude', 'hooks'), { recursive: true });
-    fs.mkdirSync(path.join(tmpDir, '.claude', 'agent-memory', 'dev-team-voss'), { recursive: true });
-    fs.writeFileSync(path.join(tmpDir, '.claude', 'agents', 'dev-team-voss.md'), '---\nname: dev-team-voss\n---');
-    fs.writeFileSync(path.join(tmpDir, '.claude', 'hooks', 'dev-team-safety-guard.js'), '#!/usr/bin/env node\n// safety-guard');
-    fs.writeFileSync(path.join(tmpDir, '.claude', 'agent-memory', 'dev-team-voss', 'MEMORY.md'), '# Voss Memory\nCustom learnings here');
-    fs.writeFileSync(path.join(tmpDir, '.claude', 'dev-team-learnings.md'), '# Shared Learnings\nWe use PostgreSQL');
-    fs.writeFileSync(path.join(tmpDir, '.claude', 'dev-team.json'), JSON.stringify({
-      version: '0.4.0',
-      agents: ['Voss'],
-      hooks: ['Safety guard'],
-      issueTracker: 'GitHub Issues',
-      branchConvention: 'feat/123-description',
-    }, null, 2));
-    fs.writeFileSync(path.join(tmpDir, '.claude', 'settings.json'), JSON.stringify({
-      hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'node .claude/hooks/dev-team-safety-guard.js' }] }] },
-    }));
+    fs.mkdirSync(path.join(tmpDir, ".claude", "agents"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, ".claude", "hooks"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, ".claude", "agent-memory", "dev-team-voss"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, ".claude", "agents", "dev-team-voss.md"),
+      "---\nname: dev-team-voss\n---",
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, ".claude", "hooks", "dev-team-safety-guard.js"),
+      "#!/usr/bin/env node\n// safety-guard",
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, ".claude", "agent-memory", "dev-team-voss", "MEMORY.md"),
+      "# Voss Memory\nCustom learnings here",
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, ".claude", "dev-team-learnings.md"),
+      "# Shared Learnings\nWe use PostgreSQL",
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, ".claude", "dev-team.json"),
+      JSON.stringify(
+        {
+          version: "0.4.0",
+          agents: ["Voss"],
+          hooks: ["Safety guard"],
+          issueTracker: "GitHub Issues",
+          branchConvention: "feat/123-description",
+        },
+        null,
+        2,
+      ),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, ".claude", "settings.json"),
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: "Bash",
+              hooks: [{ type: "command", command: "node .claude/hooks/dev-team-safety-guard.js" }],
+            },
+          ],
+        },
+      }),
+    );
 
     await update(tmpDir);
 
     // Files should be in .dev-team/
-    assert.ok(fs.existsSync(path.join(tmpDir, '.dev-team', 'config.json')), 'config should be in .dev-team/');
-    assert.ok(fs.existsSync(path.join(tmpDir, '.dev-team', 'learnings.md')), 'learnings should be in .dev-team/');
-    assert.ok(fs.existsSync(path.join(tmpDir, '.dev-team', 'agent-memory', 'dev-team-voss', 'MEMORY.md')), 'memory should be in .dev-team/');
+    assert.ok(
+      fs.existsSync(path.join(tmpDir, ".dev-team", "config.json")),
+      "config should be in .dev-team/",
+    );
+    assert.ok(
+      fs.existsSync(path.join(tmpDir, ".dev-team", "learnings.md")),
+      "learnings should be in .dev-team/",
+    );
+    assert.ok(
+      fs.existsSync(path.join(tmpDir, ".dev-team", "agent-memory", "dev-team-voss", "MEMORY.md")),
+      "memory should be in .dev-team/",
+    );
 
     // Memory content preserved
-    const memory = fs.readFileSync(path.join(tmpDir, '.dev-team', 'agent-memory', 'dev-team-voss', 'MEMORY.md'), 'utf-8');
-    assert.ok(memory.includes('Custom learnings'), 'memory content should be preserved');
+    const memory = fs.readFileSync(
+      path.join(tmpDir, ".dev-team", "agent-memory", "dev-team-voss", "MEMORY.md"),
+      "utf-8",
+    );
+    assert.ok(memory.includes("Custom learnings"), "memory content should be preserved");
 
     // Learnings content preserved
-    const learnings = fs.readFileSync(path.join(tmpDir, '.dev-team', 'learnings.md'), 'utf-8');
-    assert.ok(learnings.includes('PostgreSQL'), 'learnings content should be preserved');
+    const learnings = fs.readFileSync(path.join(tmpDir, ".dev-team", "learnings.md"), "utf-8");
+    assert.ok(learnings.includes("PostgreSQL"), "learnings content should be preserved");
 
     // Settings.json hook paths rewritten
-    const settings = JSON.parse(fs.readFileSync(path.join(tmpDir, '.claude', 'settings.json'), 'utf-8'));
-    const commands = settings.hooks.PreToolUse.flatMap((e) => (e.hooks || []).map((h) => h.command));
-    assert.ok(commands.some((c) => c.includes('.dev-team/hooks/')), 'hook paths should be rewritten to .dev-team/');
-    assert.ok(!commands.some((c) => c.includes('.claude/hooks/')), 'no hook paths should reference .claude/');
+    const settings = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, ".claude", "settings.json"), "utf-8"),
+    );
+    const commands = settings.hooks.PreToolUse.flatMap((e) =>
+      (e.hooks || []).map((h) => h.command),
+    );
+    assert.ok(
+      commands.some((c) => c.includes(".dev-team/hooks/")),
+      "hook paths should be rewritten to .dev-team/",
+    );
+    assert.ok(
+      !commands.some((c) => c.includes(".claude/hooks/")),
+      "no hook paths should reference .claude/",
+    );
 
     // Old .claude/ files cleaned up
-    assert.ok(!fs.existsSync(path.join(tmpDir, '.claude', 'agents')), 'old agents dir should be removed');
-    assert.ok(!fs.existsSync(path.join(tmpDir, '.claude', 'dev-team.json')), 'old prefs should be removed');
-    assert.ok(!fs.existsSync(path.join(tmpDir, '.claude', 'dev-team-learnings.md')), 'old learnings should be removed');
+    assert.ok(
+      !fs.existsSync(path.join(tmpDir, ".claude", "agents")),
+      "old agents dir should be removed",
+    );
+    assert.ok(
+      !fs.existsSync(path.join(tmpDir, ".claude", "dev-team.json")),
+      "old prefs should be removed",
+    );
+    assert.ok(
+      !fs.existsSync(path.join(tmpDir, ".claude", "dev-team-learnings.md")),
+      "old learnings should be removed",
+    );
 
     // settings.json and settings.local.json should remain
-    assert.ok(fs.existsSync(path.join(tmpDir, '.claude', 'settings.json')), 'settings.json should remain in .claude/');
+    assert.ok(
+      fs.existsSync(path.join(tmpDir, ".claude", "settings.json")),
+      "settings.json should remain in .claude/",
+    );
+  });
+
+  it("migrates when .dev-team/ exists but config.json is missing (partial migration)", async () => {
+    // Simulate partial migration: .dev-team/ dir exists but no config.json
+    fs.mkdirSync(path.join(tmpDir, ".dev-team", "agents"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, ".claude"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, ".claude", "dev-team.json"),
+      JSON.stringify(
+        {
+          version: "0.4.0",
+          agents: ["Voss"],
+          hooks: ["Safety guard"],
+          issueTracker: "GitHub Issues",
+          branchConvention: "feat/123-description",
+        },
+        null,
+        2,
+      ),
+    );
+    fs.writeFileSync(path.join(tmpDir, ".claude", "settings.json"), JSON.stringify({ hooks: {} }));
+
+    await update(tmpDir);
+
+    // Should have migrated despite .dev-team/ already existing
+    assert.ok(
+      fs.existsSync(path.join(tmpDir, ".dev-team", "config.json")),
+      "config.json should exist after partial migration",
+    );
+  });
+});
+
+describe("compareSemver", () => {
+  it("compares equal versions", () => {
+    assert.equal(compareSemver("1.0.0", "1.0.0"), 0);
+  });
+
+  it("compares major versions", () => {
+    assert.ok(compareSemver("2.0.0", "1.0.0") > 0);
+    assert.ok(compareSemver("1.0.0", "2.0.0") < 0);
+  });
+
+  it("compares minor versions", () => {
+    assert.ok(compareSemver("0.10.0", "0.4.0") > 0, "0.10.0 should be greater than 0.4.0");
+    assert.ok(compareSemver("0.4.0", "0.10.0") < 0);
+  });
+
+  it("compares patch versions", () => {
+    assert.ok(compareSemver("0.4.2", "0.4.1") > 0);
+    assert.ok(compareSemver("0.4.1", "0.4.2") < 0);
+  });
+
+  it("handles the bug case: string comparison would get 0.10.0 vs 0.4.0 wrong", () => {
+    // String comparison: "0.4.0" > "0.10.0" (because "4" > "1")
+    // Numeric comparison: 0.10.0 > 0.4.0 (correct)
+    assert.ok(compareSemver("0.10.0", "0.4.0") > 0);
   });
 });


### PR DESCRIPTION
## Summary
- **Migration detection** (`src/update.ts`): Changed `needsMigration` to check for absence of `config.json` instead of absence of `.dev-team/` directory, fixing partial migration failures where the directory exists but config is missing
- **Semver comparison** (`src/update.ts`): Added `compareSemver()` function that parses version strings into numeric tuples instead of using string comparison, fixing mis-ordering (e.g. `0.10.0` vs `0.4.0`)
- **ADR-013** (`docs/adr/013-active-hook-spawning.md`): Standardized path reference to `.dev-team/review-pending.json`
- **ADR-019** (`docs/adr/019-parallel-review-waves.md`): Standardized path reference to `.dev-team/parallel.json`

## Test plan
- [x] Added test for partial migration scenario (`.dev-team/` exists without `config.json`)
- [x] Added 5 unit tests for `compareSemver()` including the specific bug case (`0.10.0` vs `0.4.0`)
- [x] All 215 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)