### PR TITLE
Tighten learning loop — enforce Borges and memory updates (#117)

### DIFF
--- a/.dev-team/agents/dev-team-beck.md
+++ b/.dev-team/agents/dev-team-beck.md
@@ -66,3 +66,10 @@ After completing work, write key learnings to your MEMORY.md:
 - Flaky test patterns identified and avoided
 - Over-mocking patterns identified and refactored
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST output a "Learnings" section in your response:
+- What was surprising or non-obvious about this task?
+- What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+- Where should this be recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)

--- a/.dev-team/agents/dev-team-conway.md
+++ b/.dev-team/agents/dev-team-conway.md
@@ -65,3 +65,10 @@ After completing work, write key learnings to your MEMORY.md:
 - Common release blockers encountered
 - Changelog formatting preferences
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST output a "Learnings" section in your response:
+- What was surprising or non-obvious about this task?
+- What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+- Where should this be recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)

--- a/.dev-team/agents/dev-team-deming.md
+++ b/.dev-team/agents/dev-team-deming.md
@@ -80,3 +80,10 @@ After completing work, write key learnings to your MEMORY.md:
 - CI/CD optimizations applied
 - Onboarding friction points identified
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST output a "Learnings" section in your response:
+- What was surprising or non-obvious about this task?
+- What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+- Where should this be recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)

--- a/.dev-team/agents/dev-team-hamilton.md
+++ b/.dev-team/agents/dev-team-hamilton.md
@@ -1,16 +1,5 @@
 ---
 name: dev-team-hamilton
-<<<<<<< HEAD
-description: Operations reviewer. Use to audit infrastructure, deployment configs, observability, availability patterns, and operational resilience. Read-only — does not modify code.
-tools: Read, Grep, Glob, Bash, Agent
-model: opus
-memory: project
----
-
-You are Hamilton, an operations reviewer named after Margaret Hamilton — director of MIT's Instrumentation Laboratory Software Engineering Division, who led Apollo flight software development. She coined the term "software engineering." Her Apollo 11 1202 alarm recovery is the canonical example of operational resilience under pressure.
-
-Your philosophy: "The system that has not been designed for failure will fail in ways no one designed for."
-=======
 description: Infrastructure engineer. Use for Dockerfiles, docker-compose, CI/CD workflows, Terraform/Pulumi/CloudFormation, Helm/k8s, IaC, deployment configs, health checks, monitoring/observability config, and .env templates.
 tools: Read, Edit, Write, Bash, Grep, Glob, Agent
 model: sonnet
@@ -20,20 +9,11 @@ memory: project
 You are Hamilton, an infrastructure engineer named after Margaret Hamilton (Apollo flight software lead). She built the Apollo guidance software with error detection and recovery engineered in from the start — not bolted on after the fact. You bring that same philosophy to infrastructure.
 
 Your philosophy: "Operational resilience is not a feature you add. It is how you build."
->>>>>>> 98a9f74 (feat: replace Hamilton reviewer with infrastructure implementing agent)
 
 ## How you work
 
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
-<<<<<<< HEAD
-Before reviewing:
-1. Spawn Explore subagents in parallel to map the operational surface — deployment configs, health checks, logging patterns, monitoring hooks, secret management.
-2. Read the actual code. Do not rely on descriptions or summaries from other agents.
-3. Return concise findings to the main thread with specific file and line references.
-
-You are **read-only**. You audit and report. You do not modify code. Implementation agents (Voss, Deming) make the fixes.
-=======
 Before writing any code:
 1. Spawn Explore subagents in parallel to understand the infrastructure landscape, find existing patterns, and map dependencies.
 2. Look ahead — trace what services, ports, volumes, and networks will be affected and spawn parallel subagents to analyze each dependency before you start.
@@ -42,47 +22,10 @@ Before writing any code:
 After completing implementation:
 1. Report cross-domain impacts: flag changes for @dev-team-voss (application config affected), @dev-team-szabo (security surface changed), @dev-team-knuth (coverage gaps to audit).
 2. Spawn @dev-team-szabo and @dev-team-knuth as background reviewers.
->>>>>>> 98a9f74 (feat: replace Hamilton reviewer with infrastructure implementing agent)
 
 ## Focus areas
 
 You always check for:
-<<<<<<< HEAD
-
-### Availability
-- **Health check adequacy**: Are health and readiness probes defined? Do they check meaningful dependencies, not just return 200?
-- **Graceful degradation**: When a dependency fails, does the system degrade or crash? Is there fallback behavior?
-- **Retry patterns and circuit breakers**: Are transient failures retried with backoff? Are persistent failures circuit-broken to prevent cascade?
-- **Failover and redundancy**: Are single points of failure identified and mitigated?
-
-### Observability
-- **Logging adequacy and structure**: Are logs structured (JSON)? Do they include correlation IDs? Are they at appropriate levels?
-- **Monitoring hooks**: Are metrics exported for key operations (latency, throughput, error rate)?
-- **Alerting surface**: Can operators detect problems before users do? Are error paths instrumented?
-- **Debugging information in error paths**: When something fails, can an operator diagnose the root cause from logs alone?
-
-### Deployment
-- **Container config quality**: Are resource limits set? Is the image size reasonable? Are layers optimized for cache efficiency?
-- **IaC correctness**: Are infrastructure definitions idempotent? Do they handle drift?
-- **Environment configuration safety**: Are environment-specific values externalized? Are defaults safe?
-- **Secret management in deployment configs**: Are secrets injected at runtime, not baked into images or checked into version control?
-
-### Portability
-- **Platform-specific assumptions in infra code**: Does the deployment assume a specific cloud provider, OS, or runtime version without documenting it?
-- **Environment variable handling**: Are required variables validated at startup? Are missing variables caught early with clear errors?
-- **Path separator assumptions**: Does the code assume Unix-style paths in deployment scripts?
-- **Cross-environment consistency**: Can the same deployment config work across dev, staging, and production with only environment variables changing?
-
-## Challenge style
-
-You construct **operational failure scenarios** — tracing the failure through the operational stack from trigger to user impact:
-
-- "When this container hits its memory limit, the health check will fail, but there is no readiness probe to prevent traffic routing during restart — users will see 502s for ~30 seconds."
-- "This service logs errors to stdout but the logging driver is not configured for structured output. When the on-call engineer searches for this error at 3 AM, they will get unstructured text mixed with application output and no correlation ID to trace the request."
-- "The deployment rolls forward but there is no rollback strategy defined. If the new version has a data migration that is not backward-compatible, rolling back will corrupt the database."
-
-Concrete, production-focused. Every finding traces from root cause to user or operator impact.
-=======
 - **Health checks**: Every service must have a health check. No deployment config without liveness and readiness probes.
 - **Resource limits**: Containers without CPU/memory limits are production incidents waiting to happen. Always set them.
 - **Graceful degradation**: What happens when a dependency is unavailable? Infrastructure must handle partial failures without cascading.
@@ -102,7 +45,6 @@ You construct operational failure scenarios. When reviewing or implementing, you
 - "What happens when this service starts before its database is ready?"
 
 Always provide a concrete operational scenario, never abstract concerns.
->>>>>>> 98a9f74 (feat: replace Hamilton reviewer with infrastructure implementing agent)
 
 ## Challenge protocol
 
@@ -121,15 +63,14 @@ Rules:
 
 ## Learning
 
-<<<<<<< HEAD
-After completing a review, write key learnings to your MEMORY.md:
-- Operational patterns identified in this codebase
-- Infrastructure decisions the team made and their rationale
-- Availability risks found and remediated (watch for regressions)
-- Deployment patterns mapped
-=======
 After completing work, write key learnings to your MEMORY.md:
 - Infrastructure patterns discovered in this codebase
 - Conventions the team has established for deployment and operations
->>>>>>> 98a9f74 (feat: replace Hamilton reviewer with infrastructure implementing agent)
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST output a "Learnings" section in your response:
+- What was surprising or non-obvious about this task?
+- What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+- Where should this be recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)

--- a/.dev-team/agents/dev-team-mori.md
+++ b/.dev-team/agents/dev-team-mori.md
@@ -65,3 +65,10 @@ After completing work, write key learnings to your MEMORY.md:
 - Accessibility issues found and resolved (do not re-flag)
 - Component patterns the team prefers
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST output a "Learnings" section in your response:
+- What was surprising or non-obvious about this task?
+- What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+- Where should this be recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)

--- a/.dev-team/agents/dev-team-tufte.md
+++ b/.dev-team/agents/dev-team-tufte.md
@@ -80,3 +80,10 @@ After completing work, write key learnings to your MEMORY.md:
 - Areas where docs chronically drift from code
 - Conventions the team has adopted for doc style and structure
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST output a "Learnings" section in your response:
+- What was surprising or non-obvious about this task?
+- What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+- Where should this be recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)

--- a/.dev-team/agents/dev-team-voss.md
+++ b/.dev-team/agents/dev-team-voss.md
@@ -65,3 +65,10 @@ After completing work, write key learnings to your MEMORY.md:
 - Patterns discovered in this codebase
 - Conventions the team has established
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST output a "Learnings" section in your response:
+- What was surprising or non-obvious about this task?
+- What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+- Where should this be recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)

--- a/.dev-team/hooks/dev-team-pre-commit-gate.js
+++ b/.dev-team/hooks/dev-team-pre-commit-gate.js
@@ -5,7 +5,9 @@
  * TaskCompleted hook.
  *
  * When a task completes, checks whether memory files need updating.
- * Advisory (exit 0) — reminds but does not block.
+ * Blocks (exit 1) when implementation files are staged without memory updates.
+ * Override: create an empty `.dev-team/.memory-reviewed` file to acknowledge
+ * that memory was reviewed and nothing needs updating.
  */
 
 "use strict";
@@ -80,8 +82,7 @@ if (files.length === 0) {
   process.exit(0);
 }
 
-// Memory freshness check (advisory only)
-const reminders = [];
+// Memory freshness check (blocking unless overridden)
 
 const hasImplFiles = files.some(
   (f) => /\.(js|ts|jsx|tsx|py|rb|go|java|rs)$/.test(f) && !/\.(test|spec)\./.test(f),
@@ -92,6 +93,27 @@ const hasMemoryUpdates = files.some(
 );
 
 if (hasImplFiles && !hasMemoryUpdates) {
+  // Check for .memory-reviewed override marker
+  const markerPath = path.join(process.cwd(), ".dev-team", ".memory-reviewed");
+  let hasOverride = false;
+  try {
+    const stat = fs.lstatSync(markerPath);
+    // Reject symlinks for safety
+    hasOverride = !stat.isSymbolicLink();
+  } catch {
+    // No marker file
+  }
+
+  if (hasOverride) {
+    // Override acknowledged — clean up the marker file after this commit
+    try {
+      fs.unlinkSync(markerPath);
+    } catch {
+      // Best effort — don't fail the hook over cleanup
+    }
+    process.exit(0);
+  }
+
   let unstagedMemory = false;
   try {
     const unstaged = cachedGitDiff(["diff", "--name-only"], 2000);
@@ -104,18 +126,19 @@ if (hasImplFiles && !hasMemoryUpdates) {
   }
 
   if (unstagedMemory) {
-    reminders.push(
-      "Memory files were updated but not staged — run `git add .dev-team/learnings.md .dev-team/agent-memory/` if learnings should be included",
+    console.error(
+      "[dev-team pre-commit] BLOCKED: Memory files were updated but not staged. " +
+        "Run `git add .dev-team/learnings.md .dev-team/agent-memory/` to include learnings, " +
+        "or create an empty `.dev-team/.memory-reviewed` file to acknowledge that memory was reviewed.",
     );
   } else {
-    reminders.push(
-      "Update .dev-team/learnings.md or agent memory with any patterns, conventions, or decisions from this work",
+    console.error(
+      "[dev-team pre-commit] BLOCKED: Implementation files staged without memory updates. " +
+        "Update .dev-team/learnings.md or agent memory with any patterns, conventions, or decisions from this work. " +
+        "If no learnings apply, create an empty `.dev-team/.memory-reviewed` file to acknowledge.",
     );
   }
-}
-
-if (reminders.length > 0) {
-  console.log(`[dev-team pre-commit] Before committing, consider: ${reminders.join("; ")}`);
+  process.exit(1);
 }
 
 process.exit(0);

--- a/.dev-team/learnings.md
+++ b/.dev-team/learnings.md
@@ -10,12 +10,13 @@
 
 ## Process
 
-- **Security check at session start.** Run `/dev-team:security-status` at the beginning of every session to check code scanning, Dependabot, and secret scanning alerts. Also run before releases.
 - **Before merging a PR, ALWAYS check for Copilot review comments** (`gh api repos/{owner}/{repo}/pulls/{pr}/reviews` and `gh api repos/{owner}/{repo}/pulls/{pr}/comments`). Address any findings before merging.
 - Always use `/dev-team:task` for implementation work — dogfood the agents.
-- Spawn review agents as `general-purpose` subagents with the actual agent definition loaded from `.claude/agents/dev-team-*.md`. Do NOT use `pr-review-toolkit:*` as proxies — they have different behavior.
+- Spawn review agents as `general-purpose` subagents with the actual agent definition loaded from `.dev-team/agents/dev-team-*.md`. Do NOT use `pr-review-toolkit:*` as proxies — they have different behavior.
 - Don't ask for approval to continue between tasks. Just do the work. Only pause for critical decisions.
 - Hooks over CLAUDE.md for enforcement (ADR-001). If agents keep flagging the same pattern, it should be a hook.
+- Security check at session start is now enforced via skill preambles (task/review/audit). No longer needs manual reminder.
+- "Be vocal about learnings" is now enforced via mandatory Learnings Output section in all implementing agent definitions.
 
 ## Known Tech Debt
 
@@ -27,10 +28,16 @@
 - 273 tests total (was 117 at v0.3.0)
 - 12 agents: Voss, Mori, Szabo, Knuth, Beck, Deming, Tufte, Brooks, Conway, Drucker, Borges, Hamilton
 - 5 skills: challenge, task, review, audit, security-status
-- 6 hooks: TDD enforce, safety guard, post-change review, pre-commit gate, pre-commit lint, watch list
+- 6 hooks: TDD enforce, safety guard, post-change review, pre-commit gate (blocking), pre-commit lint, watch list
 - 3 always-on reviewers: Szabo (security), Knuth (correctness), Brooks (architecture + quality attributes)
 - CI: 3 OS x 3 Node versions + lint + format + agent validation + hook validation.
 - Always run `npm run format` before committing new `.ts` files — oxfmt formatting is checked in CI.
+
+### Learning capture metrics
+- Non-empty agent memory files: 0 of 12 (target: all agents should have calibration data after first few tasks)
+- Last Borges run: not tracked yet (Borges spawning is now enforced via skill definitions)
+- Pre-commit gate: blocks commits without memory updates (override via `.dev-team/.memory-reviewed`)
+- All 7 implementing agents have mandatory Learnings Output section
 
 ## Overruled Challenges
 <!-- When the human overrules an agent, record why — prevents re-flagging -->

--- a/.dev-team/skills/dev-team-audit/SKILL.md
+++ b/.dev-team/skills/dev-team-audit/SKILL.md
@@ -84,8 +84,13 @@ Same grouping. Include actionable recommendations.
 
 Numbered list of concrete actions, ordered by priority. Each action should reference the specific finding it addresses.
 
+### Security preamble
+
+Before starting the audit, check for open security alerts: run `/dev-team:security-status` if available, or check `gh api repos/{owner}/{repo}/code-scanning/alerts?state=open` and `gh api repos/{owner}/{repo}/dependabot/alerts?state=open`. Include these in the audit scope.
+
 ### Completion
 
 After the audit report is delivered:
-1. Spawn **@dev-team-borges** (Librarian) to review memory freshness and capture learnings from the audit findings. This is mandatory.
-2. Include Borges's recommendations in the final report.
+1. You MUST spawn **@dev-team-borges** (Librarian) as the final step to review memory freshness and capture learnings from the audit findings. Do NOT skip this.
+2. If Borges was not spawned, the audit is INCOMPLETE.
+3. Include Borges's recommendations in the final report.

--- a/.dev-team/skills/dev-team-review/SKILL.md
+++ b/.dev-team/skills/dev-team-review/SKILL.md
@@ -67,8 +67,13 @@ Group by severity:
 
 State the verdict clearly. List what must be fixed for approval if requesting changes.
 
+### Security preamble
+
+Before starting the review, check for open security alerts: run `/dev-team:security-status` if available, or check `gh api repos/{owner}/{repo}/code-scanning/alerts?state=open` and `gh api repos/{owner}/{repo}/dependabot/alerts?state=open`. Flag any critical findings in the review report.
+
 ### Completion
 
 After the review report is delivered:
-1. Spawn **@dev-team-borges** (Librarian) to review memory freshness and capture any learnings from the review findings. This is mandatory.
-2. Include Borges's recommendations in the final report.
+1. You MUST spawn **@dev-team-borges** (Librarian) as the final step to review memory freshness and capture any learnings from the review findings. Do NOT skip this.
+2. If Borges was not spawned, the review is INCOMPLETE.
+3. Include Borges's recommendations in the final report.

--- a/.dev-team/skills/dev-team-task/SKILL.md
+++ b/.dev-team/skills/dev-team-task/SKILL.md
@@ -71,10 +71,15 @@ Parallel mode is complete when:
 1. All branches have zero `[DEFECT]` findings, OR the per-branch iteration limit (default: 10) is reached
 2. Borges has run across all branches
 
+## Security preamble
+
+Before starting work, check for open security alerts: run `/dev-team:security-status` if available, or check `gh api repos/{owner}/{repo}/code-scanning/alerts?state=open` and `gh api repos/{owner}/{repo}/dependabot/alerts?state=open`. Flag any critical findings before proceeding.
+
 ## Completion
 
 When the loop exits:
-1. Spawn **@dev-team-borges** (Librarian) to review memory freshness, cross-agent coherence, and system improvement opportunities. This is mandatory.
-2. Summarize what was accomplished across all iterations.
-3. Report any remaining `[RISK]` or `[SUGGESTION]` items, including Borges's recommendations.
-4. Write key learnings to agent MEMORY.md files.
+1. You MUST spawn **@dev-team-borges** (Librarian) as the final step to review memory freshness, cross-agent coherence, and system improvement opportunities. Do NOT skip this.
+2. If Borges was not spawned, the task is INCOMPLETE.
+3. Summarize what was accomplished across all iterations.
+4. Report any remaining `[RISK]` or `[SUGGESTION]` items, including Borges's recommendations.
+5. Write key learnings to agent MEMORY.md files.

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ coverage/
 
 # Runtime state files (created by task loop, not committed)
 .dev-team/task.json
+.dev-team/.memory-reviewed
 
 # npm
 npm-debug.log*

--- a/templates/agents/dev-team-beck.md
+++ b/templates/agents/dev-team-beck.md
@@ -66,3 +66,10 @@ After completing work, write key learnings to your MEMORY.md:
 - Flaky test patterns identified and avoided
 - Over-mocking patterns identified and refactored
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST output a "Learnings" section in your response:
+- What was surprising or non-obvious about this task?
+- What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+- Where should this be recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)

--- a/templates/agents/dev-team-conway.md
+++ b/templates/agents/dev-team-conway.md
@@ -65,3 +65,10 @@ After completing work, write key learnings to your MEMORY.md:
 - Common release blockers encountered
 - Changelog formatting preferences
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST output a "Learnings" section in your response:
+- What was surprising or non-obvious about this task?
+- What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+- Where should this be recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)

--- a/templates/agents/dev-team-deming.md
+++ b/templates/agents/dev-team-deming.md
@@ -80,3 +80,10 @@ After completing work, write key learnings to your MEMORY.md:
 - CI/CD optimizations applied
 - Onboarding friction points identified
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST output a "Learnings" section in your response:
+- What was surprising or non-obvious about this task?
+- What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+- Where should this be recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)

--- a/templates/agents/dev-team-hamilton.md
+++ b/templates/agents/dev-team-hamilton.md
@@ -67,3 +67,10 @@ After completing work, write key learnings to your MEMORY.md:
 - Infrastructure patterns discovered in this codebase
 - Conventions the team has established for deployment and operations
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST output a "Learnings" section in your response:
+- What was surprising or non-obvious about this task?
+- What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+- Where should this be recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)

--- a/templates/agents/dev-team-mori.md
+++ b/templates/agents/dev-team-mori.md
@@ -65,3 +65,10 @@ After completing work, write key learnings to your MEMORY.md:
 - Accessibility issues found and resolved (do not re-flag)
 - Component patterns the team prefers
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST output a "Learnings" section in your response:
+- What was surprising or non-obvious about this task?
+- What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+- Where should this be recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)

--- a/templates/agents/dev-team-tufte.md
+++ b/templates/agents/dev-team-tufte.md
@@ -80,3 +80,10 @@ After completing work, write key learnings to your MEMORY.md:
 - Areas where docs chronically drift from code
 - Conventions the team has adopted for doc style and structure
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST output a "Learnings" section in your response:
+- What was surprising or non-obvious about this task?
+- What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+- Where should this be recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)

--- a/templates/agents/dev-team-voss.md
+++ b/templates/agents/dev-team-voss.md
@@ -65,3 +65,10 @@ After completing work, write key learnings to your MEMORY.md:
 - Patterns discovered in this codebase
 - Conventions the team has established
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST output a "Learnings" section in your response:
+- What was surprising or non-obvious about this task?
+- What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+- Where should this be recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)

--- a/templates/hooks/dev-team-pre-commit-gate.js
+++ b/templates/hooks/dev-team-pre-commit-gate.js
@@ -5,7 +5,9 @@
  * TaskCompleted hook.
  *
  * When a task completes, checks whether memory files need updating.
- * Advisory (exit 0) — reminds but does not block.
+ * Blocks (exit 1) when implementation files are staged without memory updates.
+ * Override: create an empty `.dev-team/.memory-reviewed` file to acknowledge
+ * that memory was reviewed and nothing needs updating.
  */
 
 "use strict";
@@ -80,8 +82,7 @@ if (files.length === 0) {
   process.exit(0);
 }
 
-// Memory freshness check (advisory only)
-const reminders = [];
+// Memory freshness check (blocking unless overridden)
 
 const hasImplFiles = files.some(
   (f) => /\.(js|ts|jsx|tsx|py|rb|go|java|rs)$/.test(f) && !/\.(test|spec)\./.test(f),
@@ -92,6 +93,27 @@ const hasMemoryUpdates = files.some(
 );
 
 if (hasImplFiles && !hasMemoryUpdates) {
+  // Check for .memory-reviewed override marker
+  const markerPath = path.join(process.cwd(), ".dev-team", ".memory-reviewed");
+  let hasOverride = false;
+  try {
+    const stat = fs.lstatSync(markerPath);
+    // Reject symlinks for safety
+    hasOverride = !stat.isSymbolicLink();
+  } catch {
+    // No marker file
+  }
+
+  if (hasOverride) {
+    // Override acknowledged — clean up the marker file after this commit
+    try {
+      fs.unlinkSync(markerPath);
+    } catch {
+      // Best effort — don't fail the hook over cleanup
+    }
+    process.exit(0);
+  }
+
   let unstagedMemory = false;
   try {
     const unstaged = cachedGitDiff(["diff", "--name-only"], 2000);
@@ -104,18 +126,19 @@ if (hasImplFiles && !hasMemoryUpdates) {
   }
 
   if (unstagedMemory) {
-    reminders.push(
-      "Memory files were updated but not staged — run `git add .dev-team/learnings.md .dev-team/agent-memory/` if learnings should be included",
+    console.error(
+      "[dev-team pre-commit] BLOCKED: Memory files were updated but not staged. " +
+        "Run `git add .dev-team/learnings.md .dev-team/agent-memory/` to include learnings, " +
+        "or create an empty `.dev-team/.memory-reviewed` file to acknowledge that memory was reviewed.",
     );
   } else {
-    reminders.push(
-      "Update .dev-team/learnings.md or agent memory with any patterns, conventions, or decisions from this work",
+    console.error(
+      "[dev-team pre-commit] BLOCKED: Implementation files staged without memory updates. " +
+        "Update .dev-team/learnings.md or agent memory with any patterns, conventions, or decisions from this work. " +
+        "If no learnings apply, create an empty `.dev-team/.memory-reviewed` file to acknowledge.",
     );
   }
-}
-
-if (reminders.length > 0) {
-  console.log(`[dev-team pre-commit] Before committing, consider: ${reminders.join("; ")}`);
+  process.exit(1);
 }
 
 process.exit(0);

--- a/templates/skills/dev-team-audit/SKILL.md
+++ b/templates/skills/dev-team-audit/SKILL.md
@@ -84,8 +84,13 @@ Same grouping. Include actionable recommendations.
 
 Numbered list of concrete actions, ordered by priority. Each action should reference the specific finding it addresses.
 
+### Security preamble
+
+Before starting the audit, check for open security alerts: run `/dev-team:security-status` if available, or check `gh api repos/{owner}/{repo}/code-scanning/alerts?state=open` and `gh api repos/{owner}/{repo}/dependabot/alerts?state=open`. Include these in the audit scope.
+
 ### Completion
 
 After the audit report is delivered:
-1. Spawn **@dev-team-borges** (Librarian) to review memory freshness and capture learnings from the audit findings. This is mandatory.
-2. Include Borges's recommendations in the final report.
+1. You MUST spawn **@dev-team-borges** (Librarian) as the final step to review memory freshness and capture learnings from the audit findings. Do NOT skip this.
+2. If Borges was not spawned, the audit is INCOMPLETE.
+3. Include Borges's recommendations in the final report.

--- a/templates/skills/dev-team-review/SKILL.md
+++ b/templates/skills/dev-team-review/SKILL.md
@@ -67,8 +67,13 @@ Group by severity:
 
 State the verdict clearly. List what must be fixed for approval if requesting changes.
 
+### Security preamble
+
+Before starting the review, check for open security alerts: run `/dev-team:security-status` if available, or check `gh api repos/{owner}/{repo}/code-scanning/alerts?state=open` and `gh api repos/{owner}/{repo}/dependabot/alerts?state=open`. Flag any critical findings in the review report.
+
 ### Completion
 
 After the review report is delivered:
-1. Spawn **@dev-team-borges** (Librarian) to review memory freshness and capture any learnings from the review findings. This is mandatory.
-2. Include Borges's recommendations in the final report.
+1. You MUST spawn **@dev-team-borges** (Librarian) as the final step to review memory freshness and capture any learnings from the review findings. Do NOT skip this.
+2. If Borges was not spawned, the review is INCOMPLETE.
+3. Include Borges's recommendations in the final report.

--- a/templates/skills/dev-team-task/SKILL.md
+++ b/templates/skills/dev-team-task/SKILL.md
@@ -71,10 +71,15 @@ Parallel mode is complete when:
 1. All branches have zero `[DEFECT]` findings, OR the per-branch iteration limit (default: 10) is reached
 2. Borges has run across all branches
 
+## Security preamble
+
+Before starting work, check for open security alerts: run `/dev-team:security-status` if available, or check `gh api repos/{owner}/{repo}/code-scanning/alerts?state=open` and `gh api repos/{owner}/{repo}/dependabot/alerts?state=open`. Flag any critical findings before proceeding.
+
 ## Completion
 
 When the loop exits:
-1. Spawn **@dev-team-borges** (Librarian) to review memory freshness, cross-agent coherence, and system improvement opportunities. This is mandatory.
-2. Summarize what was accomplished across all iterations.
-3. Report any remaining `[RISK]` or `[SUGGESTION]` items, including Borges's recommendations.
-4. Write key learnings to agent MEMORY.md files.
+1. You MUST spawn **@dev-team-borges** (Librarian) as the final step to review memory freshness, cross-agent coherence, and system improvement opportunities. Do NOT skip this.
+2. If Borges was not spawned, the task is INCOMPLETE.
+3. Summarize what was accomplished across all iterations.
+4. Report any remaining `[RISK]` or `[SUGGESTION]` items, including Borges's recommendations.
+5. Write key learnings to agent MEMORY.md files.

--- a/tests/unit/hooks.test.js
+++ b/tests/unit/hooks.test.js
@@ -950,7 +950,7 @@ describe("dev-team-pre-commit-gate", () => {
     }
   });
 
-  it("reminds to update memory when code is staged without memory files", () => {
+  it("blocks when code is staged without memory files", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dev-team-precommit-"));
     try {
       execFileSync("git", ["init"], { cwd: tmpDir, encoding: "utf-8" });
@@ -962,18 +962,89 @@ describe("dev-team-pre-commit-gate", () => {
       fs.writeFileSync(path.join(tmpDir, "handler.js"), "module.exports = {}");
       execFileSync("git", ["add", "handler.js"], { cwd: tmpDir, encoding: "utf-8" });
 
-      const stdout = execFileSync(process.execPath, [path.join(HOOKS_DIR, hook)], {
+      execFileSync(process.execPath, [path.join(HOOKS_DIR, hook)], {
         encoding: "utf-8",
         timeout: 5000,
         cwd: tmpDir,
       });
-      assert.ok(stdout.includes("learnings.md"), "should remind about learnings");
+      assert.fail("Should exit 1 when impl files staged without memory updates");
+    } catch (err) {
+      assert.equal(err.status, 1, "should block with exit 1");
+      assert.ok(err.stderr.includes("BLOCKED"), "should show BLOCKED message");
+      assert.ok(err.stderr.includes("learnings.md"), "should mention learnings");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 
-  it("does not remind about memory when learnings file is staged", () => {
+  it("allows commit with .memory-reviewed override", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dev-team-precommit-"));
+    try {
+      execFileSync("git", ["init"], { cwd: tmpDir, encoding: "utf-8" });
+      execFileSync("git", ["config", "user.email", "test@test.com"], {
+        cwd: tmpDir,
+        encoding: "utf-8",
+      });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: tmpDir, encoding: "utf-8" });
+      fs.writeFileSync(path.join(tmpDir, "handler.js"), "module.exports = {}");
+      execFileSync("git", ["add", "handler.js"], { cwd: tmpDir, encoding: "utf-8" });
+
+      // Create the override marker
+      fs.mkdirSync(path.join(tmpDir, ".dev-team"), { recursive: true });
+      fs.writeFileSync(path.join(tmpDir, ".dev-team", ".memory-reviewed"), "");
+
+      const stdout = execFileSync(process.execPath, [path.join(HOOKS_DIR, hook)], {
+        encoding: "utf-8",
+        timeout: 5000,
+        cwd: tmpDir,
+      });
+      assert.equal(stdout, "", "should not output anything with override");
+
+      // Marker file should be cleaned up
+      assert.ok(
+        !fs.existsSync(path.join(tmpDir, ".dev-team", ".memory-reviewed")),
+        "should delete marker file after use",
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not allow symlink as .memory-reviewed override", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dev-team-precommit-"));
+    try {
+      execFileSync("git", ["init"], { cwd: tmpDir, encoding: "utf-8" });
+      execFileSync("git", ["config", "user.email", "test@test.com"], {
+        cwd: tmpDir,
+        encoding: "utf-8",
+      });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: tmpDir, encoding: "utf-8" });
+      fs.writeFileSync(path.join(tmpDir, "handler.js"), "module.exports = {}");
+      execFileSync("git", ["add", "handler.js"], { cwd: tmpDir, encoding: "utf-8" });
+
+      // Create a symlink as the override marker (should be rejected)
+      fs.mkdirSync(path.join(tmpDir, ".dev-team"), { recursive: true });
+      fs.writeFileSync(path.join(tmpDir, ".dev-team", "real-file"), "");
+      fs.symlinkSync(
+        path.join(tmpDir, ".dev-team", "real-file"),
+        path.join(tmpDir, ".dev-team", ".memory-reviewed"),
+      );
+
+      execFileSync(process.execPath, [path.join(HOOKS_DIR, hook)], {
+        encoding: "utf-8",
+        timeout: 5000,
+        cwd: tmpDir,
+      });
+      assert.fail("Should exit 1 when override is a symlink");
+    } catch (err) {
+      assert.equal(err.status, 1, "should block with exit 1");
+      assert.ok(err.stderr.includes("BLOCKED"), "should show BLOCKED message");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not block when learnings file is staged", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dev-team-precommit-"));
     try {
       execFileSync("git", ["init"], { cwd: tmpDir, encoding: "utf-8" });
@@ -995,16 +1066,13 @@ describe("dev-team-pre-commit-gate", () => {
         timeout: 5000,
         cwd: tmpDir,
       });
-      assert.ok(
-        !stdout.includes("learnings.md"),
-        "should not remind when learnings are staged",
-      );
+      assert.equal(stdout, "", "should not block when learnings are staged");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 
-  it("does not remind about memory when agent memory is staged", () => {
+  it("does not block when agent memory is staged", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dev-team-precommit-"));
     try {
       execFileSync("git", ["init"], { cwd: tmpDir, encoding: "utf-8" });
@@ -1031,10 +1099,7 @@ describe("dev-team-pre-commit-gate", () => {
         timeout: 5000,
         cwd: tmpDir,
       });
-      assert.ok(
-        !stdout.includes("dev-team-learnings"),
-        "should not remind when agent memory is staged",
-      );
+      assert.equal(stdout, "", "should not block when agent memory is staged");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- All 7 implementing agents now have mandatory "Learnings Output" section
- Borges spawning enforced (not optional) in task/review/audit skills
- Pre-commit gate blocks when impl files staged without memory updates
- `.memory-reviewed` override for intentional skip (with symlink rejection)

## Details
Closes #117. The learning system had infrastructure but no closure — all 16 agent memory files were empty, Borges spawning was "mandatory" but not enforced. This PR closes the loop.

**Agent definitions** (14 files): Every implementing agent (Voss, Mori, Hamilton, Beck, Deming, Tufte, Conway) must output learnings after completing work.

**Skills** (6 files): Task, review, and audit skills now say "You MUST spawn Borges. If Borges was not spawned, the work is INCOMPLETE."

**Pre-commit gate** (2 files): Changed from advisory (exit 0) to blocking (exit 1). Override: `touch .dev-team/.memory-reviewed` to acknowledge.

## Test plan
- [x] Pre-commit gate blocks without memory updates
- [x] `.memory-reviewed` override works (exit 0, marker deleted)
- [x] Symlink as `.memory-reviewed` rejected
- [x] 211 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)