### PR TITLE
fix: address Copilot findings from v0.7 PRs

### DIFF
--- a/.dev-team/hooks/dev-team-pre-commit-gate.js
+++ b/.dev-team/hooks/dev-team-pre-commit-gate.js
@@ -2,9 +2,9 @@
 
 /**
  * dev-team-pre-commit-gate.js
- * TaskCompleted hook.
+ * Pre-commit hook — memory freshness gate.
  *
- * When a task completes, checks whether memory files need updating.
+ * Runs before each commit. Checks whether memory files need updating.
  * Blocks (exit 1) when implementation files are staged without memory updates.
  * Override: create an empty `.dev-team/.memory-reviewed` file to acknowledge
  * that memory was reviewed and nothing needs updating.
@@ -98,8 +98,8 @@ if (hasImplFiles && !hasMemoryUpdates) {
   let hasOverride = false;
   try {
     const stat = fs.lstatSync(markerPath);
-    // Reject symlinks for safety
-    hasOverride = !stat.isSymbolicLink();
+    // Require regular file — reject symlinks, directories, FIFOs, etc.
+    hasOverride = stat.isFile() && !stat.isSymbolicLink();
   } catch {
     // No marker file
   }

--- a/.dev-team/learnings.md
+++ b/.dev-team/learnings.md
@@ -36,7 +36,7 @@
 - Always run `npm run format` before committing new `.ts` files — oxfmt formatting is checked in CI.
 
 ### Learning capture metrics
-- Non-empty agent memory files: 0 of 12 (target: all agents should have calibration data after first few tasks)
+- Non-empty agent memory files: 0 of 12 active agents (16 memory dirs exist, 4 are legacy pre-rename: architect, docs, lead, release)
 - Last Borges run: not tracked yet (Borges spawning is now enforced via skill definitions)
 - Pre-commit gate: blocks commits without memory updates (override via `.dev-team/.memory-reviewed`)
 - All 7 implementing agents have mandatory Learnings Output section

--- a/src/update.ts
+++ b/src/update.ts
@@ -170,13 +170,19 @@ function migrateFromClaude(targetDir: string): string[] {
     { from: path.join(claudeDir, "skills"), to: path.join(devTeamDir, "skills") },
   ];
 
+  // Protected files that must never be overwritten during migration
+  const protectedPatterns = ["learnings.md", "MEMORY.md"];
+
   for (const { from, to } of dirMappings) {
     if (dirExists(from)) {
       const files = listFilesRecursive(from);
       for (const filePath of files) {
         const relativePath = path.relative(from, filePath);
         const destPath = path.join(to, relativePath);
-        copyFile(filePath, destPath);
+        // Never overwrite existing files in .dev-team/ (partial migration safety)
+        if (!fileExists(destPath)) {
+          copyFile(filePath, destPath);
+        }
       }
       log.push(`Migrated ${path.basename(from)}/ → .dev-team/${path.basename(to)}/`);
     }
@@ -193,7 +199,11 @@ function migrateFromClaude(targetDir: string): string[] {
 
   for (const { from, to } of fileMappings) {
     if (fileExists(from)) {
-      copyFile(from, to);
+      const isProtected = protectedPatterns.some((p) => to.endsWith(p));
+      // Never overwrite protected files (learnings, memory)
+      if (!isProtected || !fileExists(to)) {
+        copyFile(from, to);
+      }
       log.push(`Migrated ${path.basename(from)} → .dev-team/${path.basename(to)}`);
     }
   }

--- a/templates/hooks/dev-team-pre-commit-gate.js
+++ b/templates/hooks/dev-team-pre-commit-gate.js
@@ -2,9 +2,9 @@
 
 /**
  * dev-team-pre-commit-gate.js
- * TaskCompleted hook.
+ * Pre-commit hook — memory freshness gate.
  *
- * When a task completes, checks whether memory files need updating.
+ * Runs before each commit. Checks whether memory files need updating.
  * Blocks (exit 1) when implementation files are staged without memory updates.
  * Override: create an empty `.dev-team/.memory-reviewed` file to acknowledge
  * that memory was reviewed and nothing needs updating.
@@ -98,8 +98,8 @@ if (hasImplFiles && !hasMemoryUpdates) {
   let hasOverride = false;
   try {
     const stat = fs.lstatSync(markerPath);
-    // Reject symlinks for safety
-    hasOverride = !stat.isSymbolicLink();
+    // Require regular file — reject symlinks, directories, FIFOs, etc.
+    hasOverride = stat.isFile() && !stat.isSymbolicLink();
   } catch {
     // No marker file
   }

--- a/tests/evals/README.md
+++ b/tests/evals/README.md
@@ -35,7 +35,7 @@ node tests/evals/eval-runner.js szabo tests/evals/samples/sql-injection.js
 ```
 
 This prints a complete prompt to stdout that includes:
-- The agent's full definition (from `templates/agents/`)
+- The agent's full definition (from `.dev-team/agents/` if present, falling back to `templates/agents/`)
 - The code sample to review
 - Instructions to produce classified findings
 

--- a/tests/evals/eval-runner.js
+++ b/tests/evals/eval-runner.js
@@ -25,7 +25,9 @@
 const fs = require("node:fs");
 const path = require("node:path");
 
-const AGENTS_DIR = path.join(__dirname, "..", "..", "templates", "agents");
+const DEV_TEAM_AGENTS_DIR = path.join(__dirname, "..", "..", ".dev-team", "agents");
+const TEMPLATE_AGENTS_DIR = path.join(__dirname, "..", "..", "templates", "agents");
+const AGENTS_DIR = fs.existsSync(DEV_TEAM_AGENTS_DIR) ? DEV_TEAM_AGENTS_DIR : TEMPLATE_AGENTS_DIR;
 const EXPECTED_DIR = path.join(__dirname, "expected");
 
 function usage() {
@@ -81,7 +83,15 @@ function findExpectedFindings(agentName, sampleFilename) {
   return null;
 }
 
-function constructPrompt(agentDefinition, sample, agentName) {
+function addLineNumbers(content) {
+  return content
+    .split("\n")
+    .map((line, i) => `${String(i + 1).padStart(4)}  ${line}`)
+    .join("\n");
+}
+
+function constructPrompt(agentDefinition, sample) {
+  const numberedCode = addLineNumbers(sample.content);
   return `# Agent Evaluation Prompt
 
 ## Agent Definition
@@ -109,7 +119,7 @@ For each finding, include:
 File: \`${sample.filename}\`
 
 \`\`\`javascript
-${sample.content}
+${numberedCode}
 \`\`\`
 
 ## Instructions
@@ -118,6 +128,7 @@ ${sample.content}
 - Apply your full agent lens (security for Szabo, correctness for Knuth, etc.)
 - Do not assume context beyond what is shown — review the code as presented
 - Produce your findings in the classified format above
+- Line numbers are shown in the left margin — use them in your findings
 `;
 }
 
@@ -134,17 +145,18 @@ function main() {
   const sample = loadSampleCode(samplePath);
   const expected = findExpectedFindings(agentName, sample.filename);
 
-  const prompt = constructPrompt(agentDefinition, sample, agentName);
+  const prompt = constructPrompt(agentDefinition, sample);
 
   // Output the prompt
   console.log(prompt);
 
-  // If expected findings exist, output them as a reference section
+  // If expected findings exist, output them to stderr so copy-pasting the
+  // prompt from stdout doesn't include the answers
   if (expected) {
-    console.log("\n---\n");
-    console.log("# Expected Findings (for comparison after running)");
-    console.log("");
-    console.log(expected);
+    console.error("\n---\n");
+    console.error("# Expected Findings (for comparison after running)");
+    console.error("");
+    console.error(expected);
   }
 
   // Summary to stderr so it does not pollute the prompt on stdout

--- a/tests/evals/expected/knuth-missing-boundary.md
+++ b/tests/evals/expected/knuth-missing-boundary.md
@@ -3,7 +3,7 @@
 ## Must detect
 
 ### [DEFECT] calculateAverage crashes on null/undefined input
-- **Line**: 12
+- **Line**: 13
 - **Issue**: `scores.length` throws TypeError when `scores` is null or undefined
 - **Counter-example**: `calculateAverage(null)` -> TypeError
 
@@ -13,27 +13,27 @@
 - **Counter-example**: `calculateAverage([])` -> NaN
 
 ### [DEFECT] getRange returns undefined values for empty array
-- **Lines**: 24-25
+- **Lines**: 25-26
 - **Issue**: `items[0]` and `items[items.length - 1]` are both `undefined` for empty arrays
 - **Counter-example**: `getRange([])` -> `{ first: undefined, last: undefined }`
 
 ### [DEFECT] getRange crashes on null/undefined input
-- **Line**: 24
+- **Line**: 25
 - **Issue**: Property access on null/undefined throws TypeError
 - **Counter-example**: `getRange(null)` -> TypeError
 
 ### [DEFECT] findTopScorer crashes on empty array
-- **Line**: 33
+- **Line**: 35
 - **Issue**: `users[0]` is `undefined`, then `users[i].score > top.score` throws TypeError
 - **Counter-example**: `findTopScorer([])` -> TypeError on next iteration comparison
 
 ### [DEFECT] findTopScorer crashes on null/undefined input
-- **Line**: 33
+- **Line**: 35
 - **Issue**: Property access on null/undefined throws TypeError
 - **Counter-example**: `findTopScorer(null)` -> TypeError
 
 ### [DEFECT] mergeConfigs crashes on null/undefined input
-- **Line**: 46
+- **Line**: 50
 - **Issue**: `for...of` on null/undefined throws TypeError
 - **Counter-example**: `mergeConfigs(null)` -> TypeError
 

--- a/tests/evals/expected/szabo-sql-injection.md
+++ b/tests/evals/expected/szabo-sql-injection.md
@@ -15,7 +15,7 @@
 - **Fix**: Use parameterized queries with proper LIKE escaping
 
 ### [DEFECT] SQL injection via concatenation in deleteUser (two statements)
-- **Lines**: 33-34
+- **Lines**: 32-33
 - **Issue**: User-supplied `id` is concatenated into two DELETE statements without validation
 - **Attack**: `1 OR 1=1` deletes all users and sessions
 - **Fix**: Validate `id` is an integer, use parameterized queries

--- a/tests/unit/hooks.test.js
+++ b/tests/unit/hooks.test.js
@@ -1010,39 +1010,43 @@ describe("dev-team-pre-commit-gate", () => {
     }
   });
 
-  it("does not allow symlink as .memory-reviewed override", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dev-team-precommit-"));
-    try {
-      execFileSync("git", ["init"], { cwd: tmpDir, encoding: "utf-8" });
-      execFileSync("git", ["config", "user.email", "test@test.com"], {
-        cwd: tmpDir,
-        encoding: "utf-8",
-      });
-      execFileSync("git", ["config", "user.name", "Test"], { cwd: tmpDir, encoding: "utf-8" });
-      fs.writeFileSync(path.join(tmpDir, "handler.js"), "module.exports = {}");
-      execFileSync("git", ["add", "handler.js"], { cwd: tmpDir, encoding: "utf-8" });
+  it(
+    "does not allow symlink as .memory-reviewed override",
+    { skip: process.platform === "win32" },
+    () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dev-team-precommit-"));
+      try {
+        execFileSync("git", ["init"], { cwd: tmpDir, encoding: "utf-8" });
+        execFileSync("git", ["config", "user.email", "test@test.com"], {
+          cwd: tmpDir,
+          encoding: "utf-8",
+        });
+        execFileSync("git", ["config", "user.name", "Test"], { cwd: tmpDir, encoding: "utf-8" });
+        fs.writeFileSync(path.join(tmpDir, "handler.js"), "module.exports = {}");
+        execFileSync("git", ["add", "handler.js"], { cwd: tmpDir, encoding: "utf-8" });
 
-      // Create a symlink as the override marker (should be rejected)
-      fs.mkdirSync(path.join(tmpDir, ".dev-team"), { recursive: true });
-      fs.writeFileSync(path.join(tmpDir, ".dev-team", "real-file"), "");
-      fs.symlinkSync(
-        path.join(tmpDir, ".dev-team", "real-file"),
-        path.join(tmpDir, ".dev-team", ".memory-reviewed"),
-      );
+        // Create a symlink as the override marker (should be rejected)
+        fs.mkdirSync(path.join(tmpDir, ".dev-team"), { recursive: true });
+        fs.writeFileSync(path.join(tmpDir, ".dev-team", "real-file"), "");
+        fs.symlinkSync(
+          path.join(tmpDir, ".dev-team", "real-file"),
+          path.join(tmpDir, ".dev-team", ".memory-reviewed"),
+        );
 
-      execFileSync(process.execPath, [path.join(HOOKS_DIR, hook)], {
-        encoding: "utf-8",
-        timeout: 5000,
-        cwd: tmpDir,
-      });
-      assert.fail("Should exit 1 when override is a symlink");
-    } catch (err) {
-      assert.equal(err.status, 1, "should block with exit 1");
-      assert.ok(err.stderr.includes("BLOCKED"), "should show BLOCKED message");
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
-  });
+        execFileSync(process.execPath, [path.join(HOOKS_DIR, hook)], {
+          encoding: "utf-8",
+          timeout: 5000,
+          cwd: tmpDir,
+        });
+        assert.fail("Should exit 1 when override is a symlink");
+      } catch (err) {
+        assert.equal(err.status, 1, "should block with exit 1");
+        assert.ok(err.stderr.includes("BLOCKED"), "should show BLOCKED message");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("does not block when learnings file is staged", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dev-team-precommit-"));


### PR DESCRIPTION
## Summary

- **Non-destructive migration** (`src/update.ts`): `migrateFromClaude()` now skips files that already exist in `.dev-team/`, preventing overwrite of learnings.md and agent memory during partial migrations
- **Eval runner improvements** (`tests/evals/eval-runner.js`): Prefer `.dev-team/agents/` source, move expected findings to stderr, add line numbers to code samples, remove unused `agentName` param
- **Fix line number references** in expected findings for szabo and knuth evals (off-by-one errors)
- **Windows test skip**: Add `{ skip: process.platform === "win32" }` to symlink test
- **Memory metric clarity**: Distinguish 12 active agents from 16 memory dirs (4 legacy)
- **Pre-commit gate**: Fix docstring from "TaskCompleted hook" to "Pre-commit hook", tighten `.memory-reviewed` override to require `stat.isFile()`

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `npm test` — all 217 tests pass
- [ ] Verify migration non-destructiveness: run update on a project with existing `.dev-team/learnings.md` and confirm it is not overwritten
- [ ] Verify eval runner picks up `.dev-team/agents/` when present

fixes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)