### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-03-24
+
+### Added
+- `/dev-team:merge` skill — PR merge monitoring workflow with Copilot review handling, auto-merge, and CI status tracking (#122)
+- `/dev-team:assess` skill — knowledge base health auditing for learnings, agent memory, and CLAUDE.md (#129)
+- Agent eval framework spike — test samples and runner for evaluating agent behavior (#123)
+- Borges enforcement tightened — mandatory at end of every task/review/audit, blocks without memory updates (#124)
+
+### Changed
+- Migrated from `.claude/` to `.dev-team/` directory for all dev-team config, agents, hooks, skills, and memory (#120)
+- Removed stateful hooks, replaced with conversation context approach (#116)
+- Migrated to TypeScript 6.0 with node16 module resolution (#131)
+- Meta assess-learnings skill, learnings, and gitignore cleanup (#134)
+
+### Fixed
+- Copilot review findings from PR #120 addressed (#121)
+- Copilot findings from v0.7 PRs addressed (#126)
+
+### Dependencies
+- Bump actions/checkout from 4 to 6 (#108)
+- Bump actions/setup-node from 4 to 6 (#109)
+
 ## [0.6.0] - 2026-03-23
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fredericboyer/dev-team",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "bin": {
         "dev-team": "bin/dev-team.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Adversarial AI agent team for any project — installs Claude Code agents, hooks, and skills that enforce quality through productive friction",
   "main": "dist/init.js",
   "types": "dist/init.d.ts",


### PR DESCRIPTION
## Summary

Closes #128

- Bump version from 0.6.0 to 0.7.0 in package.json and package-lock.json
- Update CHANGELOG.md with all changes since v0.6.0

### Release highlights

**New features:**
- `/dev-team:merge` skill — PR merge monitoring with Copilot review handling, auto-merge, CI tracking (#122)
- `/dev-team:assess` skill — knowledge base health auditing (#129)
- Agent eval framework spike — test samples and runner (#123)
- Borges enforcement tightened — mandatory end-of-workflow, blocks without memory updates (#124)

**Breaking changes:**
- Migrated from `.claude/` to `.dev-team/` directory for all config (#120)
- Removed stateful hooks, replaced with conversation context (#116)

**Infrastructure:**
- TypeScript 6.0 with node16 module resolution (#131)
- actions/checkout v4 -> v6 (#108), actions/setup-node v4 -> v6 (#109)

**Fixes:**
- Copilot review findings addressed (#121, #126)

refs #130, #132

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (0 failures)
- [x] Version in package.json matches 0.7.0
- [ ] After merge, tag `v0.7.0` triggers release workflow to publish to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)