### PR TITLE
docs: fix stale test count and add follow-through learning

### DIFF
--- a/.dev-team/learnings.md
+++ b/.dev-team/learnings.md
@@ -16,6 +16,7 @@
 - Always use `/dev-team:task` for implementation work — dogfood the agents.
 - Spawn review agents as `general-purpose` subagents with the actual agent definition loaded from `.dev-team/agents/dev-team-*.md`. Do NOT use `pr-review-toolkit:*` as proxies — they have different behavior.
 - Don't ask for approval to continue between tasks. Just do the work. Only pause for critical decisions.
+- **Follow through to completion without prompting.** When auto-merge is set or CI is pending, monitor and complete the next step (tag, release, cleanup) without waiting for the user to ask "is it done yet?"
 - **When creating a PR for a tracked issue, link it in the PR body** (e.g., `Closes #NNN`). This lets the platform auto-close the issue on merge. Agents should include this when they know the issue number.
 - Hooks over CLAUDE.md for enforcement (ADR-001). If agents keep flagging the same pattern, it should be a hook.
 - **Improvements must be project-agnostic and target `templates/`.** Never modify `.dev-team/` directly for improvements — those files get overwritten by `dev-team update`. All improvements go into `templates/` and ship in future versions. Project-specific conventions stay in local learnings only.
@@ -30,7 +31,7 @@
 
 ## Quality Benchmarks
 
-- 273 tests total (was 117 at v0.3.0)
+- 217 tests total (was 117 at v0.3.0, was 273 before TS6 migration consolidated some)
 - 12 agents: Voss, Mori, Szabo, Knuth, Beck, Deming, Tufte, Brooks, Conway, Drucker, Borges, Hamilton
 - 7 skills: challenge, task, review, audit, security-status, merge, assess
 - 6 hooks: TDD enforce, safety guard, post-change review, pre-commit gate (blocking), pre-commit lint, watch list


### PR DESCRIPTION
## Summary

- Fix stale test count in learnings.md: 273 → 217
- Add learning: follow through to completion without waiting for user prompts

## Test plan

- [ ] Verify learnings.md is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)