### PR TITLE
Fix template docs: learnings path, security-status skill, research step

### DIFF
--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -68,6 +68,7 @@ Do NOT skip this. Do NOT treat hook output as optional. If you believe a review 
 - `/dev-team:review` — orchestrated multi-agent parallel review of changes
 - `/dev-team:audit` — full codebase security + quality + tooling audit
 - `/dev-team:merge` — merge a PR with Copilot review handling, auto-merge, CI monitoring, and post-merge actions
+- `/dev-team:security-status` — check code scanning, Dependabot, and secret scanning alerts
 - `/dev-team:assess` — audit knowledge base health (learnings, agent memory, CLAUDE.md)
 
 ### Learnings — where to write what
@@ -81,6 +82,6 @@ All project and process learnings MUST go to in-repo files, NOT to machine-local
 | Formal architecture decisions | `docs/adr/` | ADR format, not learnings |
 | User-specific preferences only | Machine-local memory | Personal style, name, role — things that vary per person, not per project |
 
-When the human gives feedback about process, coding style, or tool behavior: write it to `dev-team-learnings.md`. Only use machine-local memory for things that are truly personal and would not apply to another developer on the same project.
+When the human gives feedback about process, coding style, or tool behavior: write it to `.dev-team/learnings.md`. Only use machine-local memory for things that are truly personal and would not apply to another developer on the same project.
 
 <!-- dev-team:end -->

--- a/templates/agents/dev-team-beck.md
+++ b/templates/agents/dev-team-beck.md
@@ -16,8 +16,9 @@ Your philosophy: "Red, green, refactor — in that order, every time."
 
 Before writing tests:
 1. Spawn Explore subagents in parallel to understand existing test patterns, frameworks, and conventions in the project.
-2. If @dev-team-knuth has produced findings, use them as your starting point — they identify the gaps, you fill them.
-3. Return concise summaries to the main thread, not raw exploration output.
+2. **Research current practices** when choosing test frameworks, assertion libraries, or testing patterns. Check current documentation for the test runner and libraries in use — APIs change between versions, new matchers get added, and best practices evolve. Prefer codebase consistency over newer approaches; flag newer alternatives as `[SUGGESTION]` when they do not fit the existing conventions.
+3. If @dev-team-knuth has produced findings, use them as your starting point — they identify the gaps, you fill them.
+4. Return concise summaries to the main thread, not raw exploration output.
 
 After completing tests:
 1. Run the tests and report results.

--- a/templates/agents/dev-team-conway.md
+++ b/templates/agents/dev-team-conway.md
@@ -16,9 +16,10 @@ Your philosophy: "A release without a changelog is a surprise. A surprise in pro
 
 Before making release decisions:
 1. Spawn Explore subagents in parallel to inventory changes since the last release — commits, PRs merged, breaking changes, dependency updates.
-2. Read package.json/pyproject.toml/Cargo.toml (or equivalent) for the current version.
-3. Check for existing changelogs, release notes, and tagging conventions.
-4. Return concise findings to the main thread.
+2. **Research current practices** when evaluating versioning strategies, changelog formats, or release tooling. Check current documentation for the release tools and package registries in use — publishing APIs, changelog conventions, and CI release workflows evolve. Prefer codebase consistency over newer approaches; flag newer alternatives as `[SUGGESTION]` when they do not fit the existing conventions.
+3. Read package.json/pyproject.toml/Cargo.toml (or equivalent) for the current version.
+4. Check for existing changelogs, release notes, and tagging conventions.
+5. Return concise findings to the main thread.
 
 After completing release work:
 1. Verify all prerequisites are met before tagging.

--- a/templates/agents/dev-team-tufte.md
+++ b/templates/agents/dev-team-tufte.md
@@ -16,8 +16,9 @@ Your philosophy: "If the docs say one thing and the code does another, both are 
 
 Before reviewing or writing documentation:
 1. Spawn Explore subagents in parallel to map the actual behavior — read the implementation, trace the call graph, run the code if needed.
-2. Compare actual behavior against existing documentation. Every claim in the docs must be verifiable in the code.
-3. Return concise findings to the main thread with specific file and line references.
+2. **Research current practices** when recommending documentation tooling, formats, or patterns. Check current documentation standards and toolchain versions — static site generators, API doc generators, and markup formats evolve. Prefer codebase consistency over newer approaches; flag newer alternatives as `[SUGGESTION]` when they do not fit the existing conventions.
+3. Compare actual behavior against existing documentation. Every claim in the docs must be verifiable in the code.
+4. Return concise findings to the main thread with specific file and line references.
 
 After completing documentation work:
 1. Report any code behavior that surprised you — if it surprised you, the docs were probably wrong.


### PR DESCRIPTION
## Summary

- **Fix stale learnings file path** in `templates/CLAUDE.md`: the prose text referenced `dev-team-learnings.md` while the table correctly shows `.dev-team/learnings.md`. Now consistent. (fixes #139)
- **Add `/dev-team:security-status` skill** to the skills list in `templates/CLAUDE.md`. The skill exists in `templates/skills/dev-team-security-status/` but was missing from the documentation. (fixes #140)
- **Add `research-current-practices` step** to Beck, Tufte, and Conway agent templates, matching the pattern established in Deming, Voss, Mori, and Hamilton by #133. All 7 implementing agents now have this step. (fixes #141)

Closes #139, closes #140, closes #141

## Review

- **Szabo** (security): No findings. Documentation-only changes.
- **Knuth** (quality): No findings. All changes verified correct and consistent with existing patterns.
- **Brooks** (architecture): No findings. Pattern completion improves maintainability. No ADR impact.

## Test plan

- [x] `npm test` — 217 tests pass, 0 failures
- [x] Verified learnings path in prose matches the table in `templates/CLAUDE.md`
- [x] Verified `templates/skills/dev-team-security-status/` exists
- [x] Verified all 7 implementing agents now have the research-current-practices step
- [x] Verified new steps follow the same single-line pattern as Voss/Hamilton/Mori

🤖 Generated with [Claude Code](https://claude.com/claude-code)