### PR TITLE
fix: generalize task completion from PR-merge to deliverable-focused

### DIFF
--- a/.dev-team/agents/dev-team-drucker.md
+++ b/.dev-team/agents/dev-team-drucker.md
@@ -90,7 +90,7 @@ If the implementing agent disagrees with a reviewer:
 ### 6. Complete
 
 When no `[DEFECT]` findings remain:
-1. **Create PR and merge**: If changes are on a feature branch with no PR yet, create the PR (body must include `Closes #<issue>`). Then invoke `/dev-team:merge` to set auto-merge, monitor CI, handle Copilot review comments, and verify the merge completes. Work is NOT done until the PR is merged.
+1. **Deliver the work**: Ensure the task is complete end-to-end. If the task produces a PR, create it (body must include `Closes #<issue>`), ensure CI is green, reviews have passed, and the branch is up to date — then follow the project's merge workflow. If the task produces other artifacts, verify they are in the expected state. Work is not done until the deliverable is delivered — not just created.
 2. **Clean up worktree**: If the work was done in a worktree, clean it up after the branch is pushed and the PR is created. Do not wait for merge to clean the worktree.
 3. Spawn **@dev-team-borges** (Librarian) to review memory freshness, cross-agent coherence, and system improvement opportunities. This is mandatory — Borges runs at the end of every task.
 4. Summarize what was implemented and what was reviewed.
@@ -98,7 +98,7 @@ When no `[DEFECT]` findings remain:
 6. List which agents reviewed and their verdicts.
 7. Write learnings to agent memory files.
 
-**Task is complete only when the PR is merged.** If merge fails (CI failures, merge conflicts, branch protection), report the blocker to the human rather than leaving the PR unattended.
+**Task is complete only when the deliverable is delivered.** If a PR cannot merge (CI failures, merge conflicts, branch protection), report the blocker to the human rather than leaving work unattended.
 
 ### Parallel orchestration
 
@@ -118,15 +118,11 @@ When working on multiple issues simultaneously (see ADR-019):
 
 Conflict groups (issues with file overlaps) execute sequentially within the group but in parallel with other groups and independent issues.
 
-### PR merge workflow
+### Completing work
 
-When managing PRs through to merge, use `/dev-team:merge` for the merge step. This skill handles:
-- Checking and addressing Copilot review comments
-- Setting auto-merge with squash strategy
-- Monitoring CI status and reporting when merged
-- Post-merge actions (pull latest main, report merge SHA, suggest next work)
+Work is done when the deliverable is delivered — not just created. For PRs, this means merged (or ready-to-merge per the project's workflow). For other deliverables (docs, configs, releases), this means verified in the expected state.
 
-Do not manually run `gh pr merge` or poll CI status -- delegate to the merge skill.
+Follow the project's merge workflow. Some projects use auto-merge, others require manual approval. If the project has a `/dev-team:merge` skill or similar automation, use it. Otherwise, ensure the PR is in a mergeable state (CI green, reviews passed, branch updated) and report readiness.
 
 ## Focus areas
 

--- a/.dev-team/skills/dev-team-review/SKILL.md
+++ b/.dev-team/skills/dev-team-review/SKILL.md
@@ -77,4 +77,3 @@ After the review report is delivered:
 1. You MUST spawn **@dev-team-borges** (Librarian) as the final step to review memory freshness and capture any learnings from the review findings. Do NOT skip this.
 2. If Borges was not spawned, the review is INCOMPLETE.
 3. Include Borges's recommendations in the final report.
-4. **If the verdict is Approve** and this review is for a PR that is ready to merge, invoke `/dev-team:merge` to set auto-merge, monitor CI, and verify the merge completes. The PR lifecycle does not end at approval -- it ends at merge.

--- a/.dev-team/skills/dev-team-task/SKILL.md
+++ b/.dev-team/skills/dev-team-task/SKILL.md
@@ -78,7 +78,7 @@ Before starting work, check for open security alerts: run `/dev-team:security-st
 ## Completion
 
 When the loop exits:
-1. **Create PR and merge**: If changes are on a feature branch, create the PR (body must include `Closes #<issue>`) and invoke `/dev-team:merge` to set auto-merge, monitor CI, handle Copilot review comments, and verify the merge completes. Work is NOT done until the PR is merged. If merge fails (CI failures, merge conflicts, branch protection), report the blocker to the human rather than leaving the PR unattended.
+1. **Deliver the work**: If changes are on a feature branch, create the PR (body must include `Closes #<issue>`). Ensure the PR is ready to merge: CI green, reviews passed, branch up to date. Then follow the project's merge workflow — use `/dev-team:merge` if the project has it configured, otherwise report readiness. If merge fails (CI failures, merge conflicts, branch protection), report the blocker to the human rather than leaving work unattended.
 2. **Clean up worktree**: If the work was done in a worktree, clean it up after the branch is pushed and the PR is created. Do not wait for merge to clean the worktree.
 3. You MUST spawn **@dev-team-borges** (Librarian) as the final step to review memory freshness, cross-agent coherence, and system improvement opportunities. Do NOT skip this.
 4. If Borges was not spawned, the task is INCOMPLETE.

--- a/templates/agents/dev-team-drucker.md
+++ b/templates/agents/dev-team-drucker.md
@@ -90,7 +90,7 @@ If the implementing agent disagrees with a reviewer:
 ### 6. Complete
 
 When no `[DEFECT]` findings remain:
-1. **Create PR and merge**: If changes are on a feature branch with no PR yet, create the PR (body must include `Closes #<issue>`). Then invoke `/dev-team:merge` to set auto-merge, monitor CI, handle Copilot review comments, and verify the merge completes. Work is NOT done until the PR is merged.
+1. **Deliver the work**: Ensure the task is complete end-to-end. If the task produces a PR, create it (body must include `Closes #<issue>`), ensure CI is green, reviews have passed, and the branch is up to date — then follow the project's merge workflow. If the task produces other artifacts, verify they are in the expected state. Work is not done until the deliverable is delivered — not just created.
 2. **Clean up worktree**: If the work was done in a worktree, clean it up after the branch is pushed and the PR is created. Do not wait for merge to clean the worktree.
 3. Spawn **@dev-team-borges** (Librarian) to review memory freshness, cross-agent coherence, and system improvement opportunities. This is mandatory — Borges runs at the end of every task.
 4. Summarize what was implemented and what was reviewed.
@@ -98,7 +98,7 @@ When no `[DEFECT]` findings remain:
 6. List which agents reviewed and their verdicts.
 7. Write learnings to agent memory files.
 
-**Task is complete only when the PR is merged.** If merge fails (CI failures, merge conflicts, branch protection), report the blocker to the human rather than leaving the PR unattended.
+**Task is complete only when the deliverable is delivered.** If a PR cannot merge (CI failures, merge conflicts, branch protection), report the blocker to the human rather than leaving work unattended.
 
 ### Parallel orchestration
 
@@ -118,15 +118,11 @@ When working on multiple issues simultaneously (see ADR-019):
 
 Conflict groups (issues with file overlaps) execute sequentially within the group but in parallel with other groups and independent issues.
 
-### PR merge workflow
+### Completing work
 
-When managing PRs through to merge, use `/dev-team:merge` for the merge step. This skill handles:
-- Checking and addressing Copilot review comments
-- Setting auto-merge with squash strategy
-- Monitoring CI status and reporting when merged
-- Post-merge actions (pull latest main, report merge SHA, suggest next work)
+Work is done when the deliverable is delivered — not just created. For PRs, this means merged (or ready-to-merge per the project's workflow). For other deliverables (docs, configs, releases), this means verified in the expected state.
 
-Do not manually run `gh pr merge` or poll CI status -- delegate to the merge skill.
+Follow the project's merge workflow. Some projects use auto-merge, others require manual approval. If the project has a `/dev-team:merge` skill or similar automation, use it. Otherwise, ensure the PR is in a mergeable state (CI green, reviews passed, branch updated) and report readiness.
 
 ## Focus areas
 

--- a/templates/skills/dev-team-review/SKILL.md
+++ b/templates/skills/dev-team-review/SKILL.md
@@ -78,4 +78,3 @@ After the review report is delivered:
 2. If Borges was not spawned, the review is INCOMPLETE.
 3. **Borges memory gate**: If Borges reports that any participating agent's MEMORY.md is empty or contains only boilerplate, this is a **[DEFECT]** that blocks review completion. The agent must write substantive learnings before the review can be marked done.
 4. Include Borges's recommendations in the final report.
-5. **If the verdict is Approve** and this review is for a PR that is ready to merge, invoke `/dev-team:merge` to set auto-merge, monitor CI, and verify the merge completes. The PR lifecycle does not end at approval -- it ends at merge.

--- a/templates/skills/dev-team-task/SKILL.md
+++ b/templates/skills/dev-team-task/SKILL.md
@@ -82,7 +82,7 @@ Before starting work, check for open security alerts: run `/dev-team:security-st
 ## Completion
 
 When the loop exits:
-1. **Create PR and merge**: If changes are on a feature branch, create the PR (body must include `Closes #<issue>`) and invoke `/dev-team:merge` to set auto-merge, monitor CI, handle Copilot review comments, and verify the merge completes. Work is NOT done until the PR is merged. If merge fails (CI failures, merge conflicts, branch protection), report the blocker to the human rather than leaving the PR unattended.
+1. **Deliver the work**: If changes are on a feature branch, create the PR (body must include `Closes #<issue>`). Ensure the PR is ready to merge: CI green, reviews passed, branch up to date. Then follow the project's merge workflow — use `/dev-team:merge` if the project has it configured, otherwise report readiness. If merge fails (CI failures, merge conflicts, branch protection), report the blocker to the human rather than leaving work unattended.
 2. **Clean up worktree**: If the work was done in a worktree, clean it up after the branch is pushed and the PR is created. Do not wait for merge to clean the worktree.
 3. You MUST spawn **@dev-team-borges** (Librarian) as the final step to review memory freshness, cross-agent coherence, and system improvement opportunities. Do NOT skip this.
 4. If Borges was not spawned, the task is INCOMPLETE.


### PR DESCRIPTION
## Summary

- Replace hardcoded `/dev-team:merge` as final step with flexible "deliver the work" principle
- Drucker agent completion step now focuses on delivering the deliverable, not specifically merging PRs
- Task skill completion ensures PR readiness, then follows project's merge workflow (auto-merge if configured, otherwise report readiness)
- Review skill no longer auto-triggers merge on Approve verdict — reviews report verdicts, they don't take merge actions

## Changed files

- `templates/agents/dev-team-drucker.md` — Generalized completion step and "PR merge workflow" section
- `templates/skills/dev-team-task/SKILL.md` — Generalized completion section
- `templates/skills/dev-team-review/SKILL.md` — Removed auto-merge on Approve
- `.dev-team/` copies — Kept in sync with templates

## Test plan

- [x] `npm test` — all 262 tests pass
- [x] Verified no remaining hardcoded `/dev-team:merge` in the three target files
- [x] Projects that want auto-merge can still use `/dev-team:merge` if configured

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)