### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-03-24
+
+### Changed
+- Generalized Drucker's task completion from PR-merge-specific to deliverable-focused — work is done when the deliverable is delivered, not just when a PR is merged. Projects can still use `/dev-team:merge` if configured, but it is no longer hardcoded as the default (#149).
+- Review skill no longer auto-triggers merge on Approve verdict — reviews report verdicts, they don't take merge actions (#149).
+
+### Internal
+- 262 tests. 8 skills. 12 agents.
+
 ## [0.8.0] - 2026-03-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Adversarial AI agent team for any project — installs Claude Code agents, hooks, and skills that enforce quality through productive friction",
   "main": "dist/init.js",
   "types": "dist/init.d.ts",


### PR DESCRIPTION
## Summary

- Bump version to 0.8.1 in package.json
- Update CHANGELOG.md with v0.8.1 release notes

## Release contents

### Changed
- Generalized Drucker's task completion from PR-merge-specific to deliverable-focused (#149)
- Review skill no longer auto-triggers merge on Approve verdict (#149)

## Test plan

- [x] `npm test` — all 262 tests pass
- [x] Version bump verified in package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)