### PR TITLE
feat: clean up legacy agent memory directories during update

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -60,6 +60,66 @@ const MIGRATIONS: Migration[] = [
   },
 ];
 
+/**
+ * Known legacy agent memory directory names from pre-rename agents.
+ * Maps old directory name to the current agent directory name.
+ */
+const LEGACY_MEMORY_DIRS: Record<string, string> = {
+  "dev-team-architect": "dev-team-brooks",
+  "dev-team-docs": "dev-team-tufte",
+  "dev-team-lead": "dev-team-drucker",
+  "dev-team-release": "dev-team-conway",
+};
+
+/**
+ * Cleans up legacy agent memory directories from pre-rename agents.
+ * Merges any content from legacy dirs into the new agent's memory,
+ * then removes the legacy directories.
+ */
+export function cleanupLegacyMemoryDirs(devTeamDir: string): string[] {
+  const log: string[] = [];
+  const memoryDir = path.join(devTeamDir, "agent-memory");
+
+  if (!dirExists(memoryDir)) return log;
+
+  for (const [legacyDir, currentDir] of Object.entries(LEGACY_MEMORY_DIRS)) {
+    const legacyPath = path.join(memoryDir, legacyDir);
+    if (!dirExists(legacyPath)) continue;
+
+    const legacyMemoryPath = path.join(legacyPath, "MEMORY.md");
+    const currentMemoryPath = path.join(memoryDir, currentDir, "MEMORY.md");
+
+    // If legacy dir has content and current dir exists, merge content
+    if (fileExists(legacyMemoryPath) && fileExists(currentMemoryPath)) {
+      const legacyContent = readFile(legacyMemoryPath);
+      const currentContent = readFile(currentMemoryPath);
+
+      // Only merge if legacy has substantive content (not just boilerplate)
+      if (legacyContent && legacyContent.trim().split("\n").length > 5) {
+        const mergedContent =
+          (currentContent || "") + "\n\n## Migrated from " + legacyDir + "\n\n" + legacyContent;
+        writeFile(currentMemoryPath, mergedContent);
+        log.push(`Merged memory: ${legacyDir} → ${currentDir}`);
+      }
+    } else if (fileExists(legacyMemoryPath) && !fileExists(currentMemoryPath)) {
+      // Move legacy content to current location
+      fs.mkdirSync(path.join(memoryDir, currentDir), { recursive: true });
+      fs.renameSync(legacyMemoryPath, currentMemoryPath);
+      log.push(`Moved memory: ${legacyDir} → ${currentDir}`);
+    }
+
+    // Remove the legacy directory
+    try {
+      fs.rmSync(legacyPath, { recursive: true });
+      log.push(`Removed legacy directory: ${legacyDir}/`);
+    } catch {
+      // Best effort
+    }
+  }
+
+  return log;
+}
+
 export function compareSemver(a: string, b: string): number {
   const pa = a.split(".").map((n) => parseInt(n, 10));
   const pb = b.split(".").map((n) => parseInt(n, 10));
@@ -314,6 +374,16 @@ export async function update(targetDir: string): Promise<void> {
   if (agentMigrationLog.length > 0) {
     console.log("Migrations:");
     for (const entry of agentMigrationLog) {
+      console.log(`  ${entry}`);
+    }
+    console.log("");
+  }
+
+  // Clean up legacy agent memory directories from pre-rename agents
+  const legacyCleanupLog = cleanupLegacyMemoryDirs(devTeamDir);
+  if (legacyCleanupLog.length > 0) {
+    console.log("Legacy cleanup:");
+    for (const entry of legacyCleanupLog) {
       console.log(`  ${entry}`);
     }
     console.log("");

--- a/tests/integration/update.test.js
+++ b/tests/integration/update.test.js
@@ -7,7 +7,7 @@ const path = require("path");
 const os = require("os");
 
 const { run } = require("../../dist/init");
-const { update, compareSemver } = require("../../dist/update");
+const { update, compareSemver, cleanupLegacyMemoryDirs } = require("../../dist/update");
 
 let tmpDir;
 let originalCwd;
@@ -414,6 +414,114 @@ describe("dev-team update", () => {
       fs.existsSync(path.join(tmpDir, ".dev-team", "config.json")),
       "config.json should exist after partial migration",
     );
+  });
+});
+
+describe("cleanupLegacyMemoryDirs", () => {
+  it("removes empty legacy memory directories", async () => {
+    await run(tmpDir, ["--all"]);
+
+    // Create legacy directories with boilerplate content
+    const legacyDir = path.join(tmpDir, ".dev-team", "agent-memory", "dev-team-architect");
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyDir, "MEMORY.md"), "# Agent Memory\n<!-- boilerplate -->\n");
+
+    const log = cleanupLegacyMemoryDirs(path.join(tmpDir, ".dev-team"));
+
+    assert.ok(!fs.existsSync(legacyDir), "legacy directory should be removed");
+    assert.ok(
+      log.some((l) => l.includes("dev-team-architect")),
+      "should log cleanup",
+    );
+  });
+
+  it("merges substantive legacy content into current agent memory", async () => {
+    await run(tmpDir, ["--all"]);
+
+    // Create legacy directory with substantive content (more than 5 lines)
+    const legacyDir = path.join(tmpDir, ".dev-team", "agent-memory", "dev-team-architect");
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(legacyDir, "MEMORY.md"),
+      "# Architect Memory\n## Patterns\n- Pattern 1\n- Pattern 2\n- Pattern 3\n- Pattern 4\n",
+    );
+
+    const log = cleanupLegacyMemoryDirs(path.join(tmpDir, ".dev-team"));
+
+    // Legacy dir should be removed
+    assert.ok(!fs.existsSync(legacyDir), "legacy directory should be removed");
+
+    // Content should be merged into Brooks (new name for Architect)
+    const brooksMemory = fs.readFileSync(
+      path.join(tmpDir, ".dev-team", "agent-memory", "dev-team-brooks", "MEMORY.md"),
+      "utf-8",
+    );
+    assert.ok(
+      brooksMemory.includes("Migrated from dev-team-architect"),
+      "should contain migration marker",
+    );
+    assert.ok(brooksMemory.includes("Pattern 1"), "should contain merged content");
+  });
+
+  it("moves legacy content when current agent memory does not exist", async () => {
+    await run(tmpDir, ["--all"]);
+
+    // Delete the current Brooks memory and create a legacy architect one
+    const brooksDir = path.join(tmpDir, ".dev-team", "agent-memory", "dev-team-brooks");
+    fs.rmSync(brooksDir, { recursive: true });
+
+    const legacyDir = path.join(tmpDir, ".dev-team", "agent-memory", "dev-team-architect");
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(legacyDir, "MEMORY.md"),
+      "# Architect Memory\nImportant learnings here.\n",
+    );
+
+    const log = cleanupLegacyMemoryDirs(path.join(tmpDir, ".dev-team"));
+
+    assert.ok(!fs.existsSync(legacyDir), "legacy directory should be removed");
+    assert.ok(fs.existsSync(path.join(brooksDir, "MEMORY.md")), "memory should be moved to Brooks");
+    const content = fs.readFileSync(path.join(brooksDir, "MEMORY.md"), "utf-8");
+    assert.ok(content.includes("Important learnings"), "content should be preserved");
+  });
+
+  it("handles all four known legacy renames", async () => {
+    await run(tmpDir, ["--all"]);
+
+    const legacyNames = [
+      "dev-team-architect",
+      "dev-team-docs",
+      "dev-team-lead",
+      "dev-team-release",
+    ];
+
+    for (const name of legacyNames) {
+      const dir = path.join(tmpDir, ".dev-team", "agent-memory", name);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "MEMORY.md"), "# Legacy\nBoilerplate\n");
+    }
+
+    cleanupLegacyMemoryDirs(path.join(tmpDir, ".dev-team"));
+
+    for (const name of legacyNames) {
+      assert.ok(
+        !fs.existsSync(path.join(tmpDir, ".dev-team", "agent-memory", name)),
+        `${name} should be removed`,
+      );
+    }
+  });
+
+  it("runs during update automatically", async () => {
+    await run(tmpDir, ["--all"]);
+
+    // Create a legacy directory
+    const legacyDir = path.join(tmpDir, ".dev-team", "agent-memory", "dev-team-architect");
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyDir, "MEMORY.md"), "# Legacy\nBoilerplate\n");
+
+    await update(tmpDir);
+
+    assert.ok(!fs.existsSync(legacyDir), "legacy directory should be cleaned up during update");
   });
 });
 


### PR DESCRIPTION
## Summary
- Detects orphan memory directories from pre-v0.4 agent renames (Architect, Docs, Lead, Release)
- Merges substantive content from legacy dirs into current agent memory
- Removes legacy directories after migration
- Runs automatically during `dev-team update`

## Test plan
- [x] 5 new tests covering: empty cleanup, content merge, content move, all four renames, integration with update
- [x] All 267 tests pass (was 262)

Closes #154

Generated with [Claude Code](https://claude.com/claude-code)