### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-03-25
+
+### Added
+- **Automated memory formation** -- Borges extracts structured memory entries automatically (#156).
+- **Structured memory entries** -- Type, Source, Tags, Outcome, Context format (#156).
+- **Output validation at handoff points** -- Drucker validates before spawning reviewers (#160).
+- **Complexity-based review triage** -- LIGHT/STANDARD/DEEP review depths (#159).
+- **Judge filtering stage** -- Drucker filters findings before presenting to humans (#161).
+- **Silence-is-golden principle** -- All 12 agents: no-findings is valid (#161).
+- **Legacy memory cleanup** -- dev-team update removes orphan memory dirs (#154).
+- **Workflow skill separation** -- merge and security-status moved to optional skills (#152).
+
+### Changed
+- Templates provide capabilities, not workflow opinions (#152).
+- Framework skills to .dev-team/skills/, workflow skills to .claude/skills/ (#152).
+- Security preamble generalized -- no longer GitHub-specific (#152).
+- Borges writes directly to agent MEMORY.md files (#156).
+- Review depth levels added to Szabo, Knuth, Brooks (#159).
+
+### Internal
+- 274 tests (was 262). 5 framework skills + 2 optional workflow skills. 12 agents.
+
 ## [0.8.1] - 2026-03-24
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Adversarial AI agent team for any project — installs Claude Code agents, hooks, and skills that enforce quality through productive friction",
   "main": "dist/init.js",
   "types": "dist/init.d.ts",


### PR DESCRIPTION
## Summary
Version bump to 0.9.0 and changelog for the v0.9 milestone.

6 issues shipped:
- #152: Audit templates for workflow-specific opinions
- #154: Clean up legacy agent memory directories
- #156: Automate memory formation with structured entries
- #159: Complexity-based triage for review watch lists
- #160: Output validation at agent handoff points
- #161: Judge filtering stage and silence-is-golden

274 tests. 5 framework skills + 2 workflow skills. 12 agents.

Generated with [Claude Code](https://claude.com/claude-code)