### PR TITLE
fix: critical Copilot feedback from merged PRs #172 and #174

### DIFF
--- a/templates/agent-memory/dev-team-beck/MEMORY.md
+++ b/templates/agent-memory/dev-team-beck/MEMORY.md
@@ -1,9 +1,9 @@
 # Agent Memory: Beck (Test Implementer)
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Entries use structured format: Borges extracts these automatically after each task. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Entries use structured format: Borges extracts these automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -13,5 +13,5 @@
 -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 

--- a/templates/agent-memory/dev-team-borges/MEMORY.md
+++ b/templates/agent-memory/dev-team-borges/MEMORY.md
@@ -1,9 +1,9 @@
 # Agent Memory: Borges (Librarian)
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Entries use structured format: Borges extracts these automatically after each task. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Entries use structured format: Borges extracts these automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -13,5 +13,5 @@
 -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 

--- a/templates/agent-memory/dev-team-brooks/MEMORY.md
+++ b/templates/agent-memory/dev-team-brooks/MEMORY.md
@@ -1,9 +1,9 @@
 # Agent Memory: Brooks (Architect)
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Entries use structured format: Borges extracts these automatically after each task. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Entries use structured format: Borges extracts these automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -13,5 +13,5 @@
 -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 

--- a/templates/agent-memory/dev-team-conway/MEMORY.md
+++ b/templates/agent-memory/dev-team-conway/MEMORY.md
@@ -1,9 +1,9 @@
 # Agent Memory: Conway (Release Manager)
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Entries use structured format: Borges extracts these automatically after each task. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Entries use structured format: Borges extracts these automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -13,5 +13,5 @@
 -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 

--- a/templates/agent-memory/dev-team-deming/MEMORY.md
+++ b/templates/agent-memory/dev-team-deming/MEMORY.md
@@ -1,9 +1,9 @@
 # Agent Memory: Deming (Tooling & DX Optimizer)
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Entries use structured format: Borges extracts these automatically after each task. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Entries use structured format: Borges extracts these automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -13,5 +13,5 @@
 -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 

--- a/templates/agent-memory/dev-team-drucker/MEMORY.md
+++ b/templates/agent-memory/dev-team-drucker/MEMORY.md
@@ -1,9 +1,9 @@
 # Agent Memory: Drucker (Orchestrator)
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Entries use structured format: Borges extracts these automatically after each task. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Entries use structured format: Borges extracts these automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -13,5 +13,5 @@
 -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 

--- a/templates/agent-memory/dev-team-hamilton/MEMORY.md
+++ b/templates/agent-memory/dev-team-hamilton/MEMORY.md
@@ -1,9 +1,9 @@
 # Agent Memory: Hamilton (Infrastructure Engineer)
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Entries use structured format: Borges extracts these automatically after each task. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Entries use structured format: Borges extracts these automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -13,5 +13,5 @@
 -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 

--- a/templates/agent-memory/dev-team-knuth/MEMORY.md
+++ b/templates/agent-memory/dev-team-knuth/MEMORY.md
@@ -1,9 +1,9 @@
 # Agent Memory: Knuth (Quality Auditor)
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Entries use structured format: Borges extracts these automatically after each task. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Entries use structured format: Borges extracts these automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -13,5 +13,5 @@
 -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 

--- a/templates/agent-memory/dev-team-mori/MEMORY.md
+++ b/templates/agent-memory/dev-team-mori/MEMORY.md
@@ -1,9 +1,9 @@
 # Agent Memory: Mori (Frontend/UI Engineer)
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Entries use structured format: Borges extracts these automatically after each task. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Entries use structured format: Borges extracts these automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -13,5 +13,5 @@
 -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 

--- a/templates/agent-memory/dev-team-szabo/MEMORY.md
+++ b/templates/agent-memory/dev-team-szabo/MEMORY.md
@@ -1,9 +1,9 @@
 # Agent Memory: Szabo (Security Auditor)
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Entries use structured format: Borges extracts these automatically after each task. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Entries use structured format: Borges extracts these automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -13,5 +13,5 @@
 -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 

--- a/templates/agent-memory/dev-team-tufte/MEMORY.md
+++ b/templates/agent-memory/dev-team-tufte/MEMORY.md
@@ -1,9 +1,9 @@
 # Agent Memory: Tufte (Documentation Engineer)
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Entries use structured format: Borges extracts these automatically after each task. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Entries use structured format: Borges extracts these automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -13,5 +13,5 @@
 -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 

--- a/templates/agent-memory/dev-team-voss/MEMORY.md
+++ b/templates/agent-memory/dev-team-voss/MEMORY.md
@@ -1,9 +1,9 @@
 # Agent Memory: Voss (Backend Engineer)
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Entries use structured format: Borges extracts these automatically after each task. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Entries use structured format: Borges extracts these automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -13,5 +13,5 @@
 -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 

--- a/templates/hooks/dev-team-post-change-review.js
+++ b/templates/hooks/dev-team-post-change-review.js
@@ -241,11 +241,11 @@ function scoreComplexity(toolInput, filePath) {
   let score = 0;
 
   // Lines changed
-  const oldStr = toolInput.old_string || "";
-  const newStr = toolInput.new_string || toolInput.content || "";
+  const oldStr = toolInput.old_string ?? "";
+  const newStr = toolInput.new_string ?? toolInput.content ?? "";
   const oldLines = oldStr ? oldStr.split("\n").length : 0;
   const newLines = newStr ? newStr.split("\n").length : 0;
-  const linesChanged = Math.abs(newLines - oldLines) + Math.min(oldLines, newLines);
+  const linesChanged = oldLines + newLines;
   score += Math.min(linesChanged, 50); // Cap at 50 to avoid single large file dominating
 
   // Complexity indicators in the new content


### PR DESCRIPTION
## Summary
Retroactive audit of Copilot feedback on merged PRs #169-#175 identified three critical issues that need fixing now:

- **Broken HTML comments in all 12 agent memory templates** (PR #174): `<\!--` with escaped exclamation marks renders as literal text instead of HTML comments, making the template instructions visible to end users
- **Empty-string bug in post-change-review hook** (PR #172): `||` operator treats intentionally empty `new_string` (block deletion via Edit) as falsy, causing incorrect complexity scoring. Fixed with `??` (nullish coalescing)
- **Incorrect linesChanged formula** (PR #172): `Math.abs(newLines - oldLines) + Math.min(oldLines, newLines)` always equals `Math.max()`, undercounting replacements where both sides are large. Changed to `oldLines + newLines`

### Retroactive audit summary (PRs #169-#175)

| PR | Finding | Severity | Action |
|----|---------|----------|--------|
| #172 | `\|\|` vs `??` empty-string bug in hook | Critical | Fixed in this PR |
| #172 | linesChanged formula incorrect | Important | Fixed in this PR |
| #174 | Broken HTML comments in 12 memory templates | Critical | Fixed in this PR |
| #169 | Legacy MEMORY.md heuristic may misclassify templates | Important | Issue needed |
| #170 | `git diff` without refs ambiguity in validation | Important | Issue needed |
| #174 | `src/status.ts` size heuristic outdated | Important | Issue needed |
| #174 | `src/create-agent.ts` uses old MEMORY.md template | Important | Issue needed |
| #175 | Missing test assertion for security-status skill | Important | Issue needed |
| #175 | Skill name mismatch: `security-status` vs `dev-team:security-status` | Important | Issue needed |
| #172 | Performance: regex match allocation in hook | Minor | Skipped |
| #174 | Calibration Log description mismatch | Minor | Skipped |
| #175 | Borges table description inconsistency | Minor | Skipped |
| #169 | Missing test for template-only legacy content | Minor | Skipped |

## Test plan
- [ ] Verify agent memory templates render `<!--` as proper HTML comments (not visible text)
- [ ] Verify hook correctly scores an Edit with empty `new_string` (deletion)
- [ ] Verify `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)