### PR TITLE
fix: reduce CI matrix to Node 22 only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [18, 20, 22]
+        node-version: [22]
     steps:
       - uses: actions/checkout@v6
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/fredericboyer/dev-team#readme",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
## Summary
- Reduced CI build matrix from 9 jobs (3 OS x 3 Node versions) to 3 jobs (3 OS x Node 22 only)
- Bumped `engines.node` from `>=18.0.0` to `>=22.0.0`
- Node 18 is EOL, Node 20 is maintenance-only — Node 22 is active LTS

## Test plan
- [x] All existing tests pass
- [x] CI runs on reduced matrix

Closes #171