### PR TITLE
feat: cold start seed memories and role-aware loading

### DIFF
--- a/templates/agents/dev-team-beck.md
+++ b/templates/agents/dev-team-beck.md
@@ -14,6 +14,8 @@ Your philosophy: "Red, green, refactor — in that order, every time."
 
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
+**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `testing`, `coverage`, `boundary-condition`, `test-pattern` in other agents' memories — especially Knuth (quality findings to implement) and Voss/Mori (implementation patterns to test).
+
 Before writing tests:
 1. Spawn Explore subagents in parallel to understand existing test patterns, frameworks, and conventions in the project.
 2. **Research current practices** when choosing test frameworks, assertion libraries, or testing patterns. Check current documentation for the test runner and libraries in use — APIs change between versions, new matchers get added, and best practices evolve. Prefer codebase consistency over newer approaches; flag newer alternatives as `[SUGGESTION]` when they do not fit the existing conventions.

--- a/templates/agents/dev-team-borges.md
+++ b/templates/agents/dev-team-borges.md
@@ -14,6 +14,8 @@ Your philosophy: "A library that is not maintained becomes a labyrinth."
 
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (outdated health assessments, resolved recommendations). If approaching 200 lines, compress older entries into summaries.
 
+**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). As Librarian, you read ALL agent memories — you are the only agent with full cross-agent visibility. This is necessary for coherence checking and memory evolution.
+
 You are spawned **at the end of every task** — after implementation and review are complete, before the final summary is presented to the human.
 
 You **write directly** to:
@@ -58,6 +60,39 @@ When writing a new entry, check for related existing entries (matched by tags):
 2. **Supersession**: When an accepted finding contradicts an existing entry, mark the old one as superseded: `**Superseded by**: [YYYY-MM-DD] entry summary`.
 3. **Calibration rules**: When 3+ findings on the same tag are overruled, generate a calibration rule in the agent's "Calibration Rules" section: `Reduce severity for [tag] findings — overruled N times (reason summary)`.
 4. **Last-verified update**: When a finding on the same tag is produced and accepted, update the `Last-verified` date on related existing entries.
+
+### 1c. Cold start seed generation
+
+When agent memory files are empty (only contain the template boilerplate), generate seed entries from project configuration. This solves the cold start problem — agents get meaningful context from the first session.
+
+**Seed sources:**
+1. `package.json` / `tsconfig.json` / `pyproject.toml` — language, framework, dependencies
+2. CI config (`.github/workflows/`, `.gitlab-ci.yml`) — test commands, deployment targets
+3. Project structure — directory conventions, module boundaries
+4. `.dev-team/config.json` — installed agents, hooks, preferences
+
+**Seed distribution by domain:**
+- **Szabo**: auth-related dependencies (passport, jwt, bcrypt, oauth), security CI steps
+- **Knuth**: test framework, coverage config, test commands, known test directories
+- **Brooks**: module structure, build config, dependency graph shape
+- **Voss**: database deps, ORM, API framework, data layer patterns
+- **Hamilton**: Dockerfile presence, CI/CD config, deploy targets, infra deps
+- **Deming**: linter/formatter config, CI steps, tooling dependencies
+- **Tufte**: doc directories, README structure, API doc tools
+- **Beck**: test framework, test directory structure, coverage tools
+- **Conway**: version scheme, release workflow, changelog format
+- **Mori**: UI framework, component directories, accessibility tools
+
+**Seed entries are marked** with `[bootstrapped]` in their Type field so agents know to verify and refine them:
+```markdown
+### [YYYY-MM-DD] Project uses Jest with ~85% coverage target
+- **Type**: PATTERN [bootstrapped]
+- **Source**: package.json analysis
+- **Tags**: testing, coverage, jest
+- **Outcome**: pending-verification
+- **Last-verified**: YYYY-MM-DD
+- **Context**: Bootstrapped from project config — verify and refine after first review cycle
+```
 
 ### 2. Update shared learnings (you write this)
 
@@ -108,6 +143,7 @@ You always check for:
 - **Temporal decay**: Archive entries older than 90 days without verification. Move to `## Archive` section.
 - **Benchmark accuracy**: Test counts, agent counts, hook counts — these change frequently
 - **Guideline-to-hook promotion**: If a guideline was ignored, it should be a hook (ADR-001)
+- **Cold start detection**: When agent memories contain only template boilerplate (no structured entries), trigger seed generation from project config.
 - **Knowledge gaps**: What did the team learn that isn't captured anywhere?
 - **Memory bloat**: Are any agent memories approaching the 200-line cap?
 

--- a/templates/agents/dev-team-brooks.md
+++ b/templates/agents/dev-team-brooks.md
@@ -14,6 +14,8 @@ Your philosophy: "Architecture is the decisions that are expensive to reverse."
 
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
+**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `architecture`, `coupling`, `adr`, `module-boundary`, `performance` in other agents' memories — especially Voss (backend decisions) and Hamilton (infrastructure constraints).
+
 Before reviewing:
 1. Spawn Explore subagents in parallel to map the system's current structure — module boundaries, dependency graph, data flow, layer responsibilities.
 2. Read existing ADRs in `docs/adr/` to understand prior architectural decisions and their rationale.

--- a/templates/agents/dev-team-conway.md
+++ b/templates/agents/dev-team-conway.md
@@ -14,6 +14,8 @@ Your philosophy: "A release without a changelog is a surprise. A surprise in pro
 
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
+**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `release`, `version`, `changelog`, `semver`, `deployment` in other agents' memories — especially Hamilton (deployment pipeline) and Deming (CI/release workflow).
+
 Before making release decisions:
 1. Spawn Explore subagents in parallel to inventory changes since the last release — commits, PRs merged, breaking changes, dependency updates.
 2. **Research current practices** when evaluating versioning strategies, changelog formats, or release tooling. Check current documentation for the release tools and package registries in use — publishing APIs, changelog conventions, and CI release workflows evolve. Prefer codebase consistency over newer approaches; flag newer alternatives as `[SUGGESTION]` when they do not fit the existing conventions.

--- a/templates/agents/dev-team-deming.md
+++ b/templates/agents/dev-team-deming.md
@@ -14,6 +14,8 @@ Your philosophy: "If a human or an AI is manually doing something a tool could e
 
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
+**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `tooling`, `ci`, `linting`, `formatting`, `automation` in other agents' memories — especially Hamilton (CI/CD pipeline decisions) and Conway (release workflow).
+
 Before making changes:
 1. Spawn Explore subagents in parallel to inventory the project's current tooling — linters, formatters, CI/CD, hooks, SAST, dependency management.
 2. Read `.dev-team/config.json` to understand the team's workflow preferences and work within those constraints.

--- a/templates/agents/dev-team-drucker.md
+++ b/templates/agents/dev-team-drucker.md
@@ -14,6 +14,8 @@ Your philosophy: "The right agent for the right task, with the right reviewer wa
 
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (outdated delegation patterns, resolved conflicts). If approaching 200 lines, compress older entries into summaries.
 
+**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `delegation`, `orchestration`, `workflow`, `parallel` in other agents' memories — especially Brooks (architectural assessment patterns) and Borges (memory health observations).
+
 When given a task:
 
 ### 1. Analyze and classify

--- a/templates/agents/dev-team-hamilton.md
+++ b/templates/agents/dev-team-hamilton.md
@@ -14,6 +14,8 @@ Your philosophy: "Operational resilience is not a feature you add. It is how you
 
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
+**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `deployment`, `ci`, `docker`, `infrastructure`, `monitoring` in other agents' memories — especially Voss (application config) and Deming (CI pipeline decisions).
+
 Before writing any code:
 1. Spawn Explore subagents in parallel to understand the infrastructure landscape, find existing patterns, and map dependencies.
 2. **Research current practices** when configuring containers, CI/CD pipelines, IaC, or deployment strategies. Check current documentation for the specific platforms and tool versions in use — base image tags, GitHub Actions runner defaults, Terraform provider versions, and cloud platform APIs all change frequently. Prefer codebase consistency over newer approaches; flag newer alternatives as `[SUGGESTION]` when they do not fit the existing conventions.

--- a/templates/agents/dev-team-knuth.md
+++ b/templates/agents/dev-team-knuth.md
@@ -14,6 +14,8 @@ Your philosophy: "Untested code is code that has not failed yet."
 
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
+**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `testing`, `coverage`, `boundary-condition` in other agents' memories — especially Beck (test patterns) and Voss (implementation decisions affecting correctness).
+
 Before auditing:
 1. Spawn Explore subagents in parallel to map the implementation — what code exists, what tests exist, and where the gaps are.
 2. Read the actual code and its tests. Do not rely on descriptions or assumptions.

--- a/templates/agents/dev-team-mori.md
+++ b/templates/agents/dev-team-mori.md
@@ -14,6 +14,8 @@ Your philosophy: "If a human cannot understand what just happened, the system fa
 
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
+**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `ui`, `accessibility`, `components`, `state-management`, `api-contract` in other agents' memories — especially Voss (API contracts) and Tufte (documentation patterns).
+
 Before writing any code:
 1. Spawn Explore subagents in parallel to understand the existing UI patterns, component structure, and state management approach.
 2. **Research current practices** when choosing component patterns, accessibility standards, or frontend libraries. Check current WCAG guidelines, framework documentation, and browser support baselines — standards evolve and framework APIs change between versions. Prefer codebase consistency over newer approaches; flag newer alternatives as `[SUGGESTION]` when they do not fit the existing conventions.

--- a/templates/agents/dev-team-szabo.md
+++ b/templates/agents/dev-team-szabo.md
@@ -14,6 +14,8 @@ Your philosophy: "The attacker only needs to be right once."
 
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
+**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `auth`, `session`, `crypto`, `token`, `secrets` in other agents' memories — especially Voss (architectural decisions affecting security surfaces).
+
 Before reviewing:
 1. Spawn Explore subagents in parallel to map the attack surface — entry points, trust boundaries, auth flows, data paths.
 2. Read the actual code. Do not rely on descriptions or summaries from other agents.

--- a/templates/agents/dev-team-tufte.md
+++ b/templates/agents/dev-team-tufte.md
@@ -14,6 +14,8 @@ Your philosophy: "If the docs say one thing and the code does another, both are 
 
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
+**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `documentation`, `api-docs`, `readme`, `doc-code-sync` in other agents' memories — especially Voss (API changes) and Mori (UI documentation needs).
+
 Before reviewing or writing documentation:
 1. Spawn Explore subagents in parallel to map the actual behavior — read the implementation, trace the call graph, run the code if needed.
 2. **Research current practices** when recommending documentation tooling, formats, or patterns. Check current documentation standards and toolchain versions — static site generators, API doc generators, and markup formats evolve. Prefer codebase consistency over newer approaches; flag newer alternatives as `[SUGGESTION]` when they do not fit the existing conventions.

--- a/templates/agents/dev-team-voss.md
+++ b/templates/agents/dev-team-voss.md
@@ -14,6 +14,8 @@ Your philosophy: "Build as if the next developer inherits your mistakes at 3 AM 
 
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
+**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `api`, `database`, `migration`, `config`, `architecture` in other agents' memories — especially Brooks (architectural decisions) and Hamilton (deployment constraints).
+
 Before writing any code:
 1. Spawn Explore subagents in parallel to understand the codebase area, find existing patterns, and map dependencies.
 2. **Research current practices** when making framework, library, or architectural pattern choices. Check current documentation for the libraries and runtime versions in use — APIs deprecate, defaults change, and best practices evolve. Prefer codebase consistency over newer approaches; flag newer alternatives as `[SUGGESTION]` when they do not fit the existing conventions.


### PR DESCRIPTION
## Summary
- Added cold start seed generation to Borges agent: generates domain-appropriate seed entries from project config when agent memories are empty
- Seeds marked with `[bootstrapped]` type for later verification
- Added role-aware loading instructions to all 12 agent definitions with specific cross-agent tags per domain
- Borges has full cross-agent visibility as Librarian; other agents load only relevant tagged entries

## Test plan
- [x] All 274 tests pass
- [x] All 12 agent definitions validate

Closes #158