### PR TITLE
feat: agent calibration metrics tracking

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -320,6 +320,13 @@ export async function run(targetDir: string, flags: string[] = []): Promise<void
     copyFile(learningsSrc, learningsDest);
   }
 
+  // Step 8b: Create metrics log
+  const metricsSrc = path.join(templates, "dev-team-metrics.md");
+  const metricsDest = path.join(devTeamDir, "metrics.md");
+  if (!fileExists(metricsDest)) {
+    copyFile(metricsSrc, metricsDest);
+  }
+
   // Step 7: Copy hooks
   let hookCount = 0;
 
@@ -442,7 +449,9 @@ export async function run(targetDir: string, flags: string[] = []): Promise<void
       `  Workflow:  ${installedWorkflowSkills.join(", ")} (optional, in .claude/skills/)`,
     );
   }
-  console.log(`  Memory:    ${selectedAgents.length} agent memories + shared learnings`);
+  console.log(
+    `  Memory:    ${selectedAgents.length} agent memories + shared learnings + metrics log`,
+  );
   console.log(`  CLAUDE.md: ${claudeResult}`);
   console.log(`  Settings:  ${settingsPath}`);
   console.log(

--- a/src/update.ts
+++ b/src/update.ts
@@ -580,6 +580,13 @@ export async function update(targetDir: string): Promise<void> {
     copyFile(learningsSrc, learningsDest);
   }
 
+  // Step 7b: Create metrics log (only if missing — never overwrite user data)
+  const metricsSrc = path.join(templates, "dev-team-metrics.md");
+  const metricsDest = path.join(devTeamDir, "metrics.md");
+  if (!fileExists(metricsDest) && fileExists(metricsSrc)) {
+    copyFile(metricsSrc, metricsDest);
+  }
+
   // Step 8: Save updated preferences (stamp current package version)
   prefs.version = packageVersion;
   writeFile(prefsPath, JSON.stringify(prefs, null, 2) + "\n");

--- a/templates/agents/dev-team-borges.md
+++ b/templates/agents/dev-team-borges.md
@@ -21,6 +21,7 @@ You are spawned **at the end of every task** — after implementation and review
 You **write directly** to:
 - `.dev-team/learnings.md` — shared team facts (benchmarks, conventions, tech debt)
 - `.dev-team/agent-memory/*/MEMORY.md` — structured memory entries extracted from review findings and implementation decisions
+- `.dev-team/metrics.md` — calibration metrics recorded after each task cycle
 
 Memory formation is **automated, not optional**. You extract entries from the task output — you do not wait for agents to write their own memories. Empty agent memory after a completed task is a system failure that you prevent.
 
@@ -128,7 +129,30 @@ Based on what happened during this task:
 3. Did agents flag the same issue multiple times across sessions? → Recommend a hook
 4. Were there coordination failures between agents? → Recommend a workflow change
 
-### 5. Cross-agent coherence
+### 5. Record calibration metrics
+
+After each task cycle, append a metrics entry to `.dev-team/metrics.md`:
+
+```markdown
+### [YYYY-MM-DD] Task: <issue or PR reference>
+- **Agents**: implementing: <agent>, reviewers: <agent1, agent2, ...>
+- **Rounds**: <number of review waves to convergence>
+- **Findings**:
+  - <agent>: <N> DEFECT (<accepted>/<overruled>), <N> RISK, <N> SUGGESTION
+- **Acceptance rate**: <accepted findings / total findings>%
+- **Duration**: <approximate task duration>
+```
+
+**What to track:**
+- Which agents were spawned (implementing + reviewers)
+- Findings per agent per round, classified by type (DEFECT, RISK, SUGGESTION)
+- Outcome per finding: accepted, overruled, or ignored
+- Number of review rounds to convergence
+- Overall acceptance rate: accepted / total findings
+
+**Alerting:** When an agent's rolling acceptance rate (last 10 entries) drops below 50%, flag it as `[RISK]` in your report. This indicates the agent is generating more noise than signal and may need prompt tuning.
+
+### 6. Cross-agent coherence
 
 Check for contradictions between agent memories:
 - Does Szabo's memory contradict Voss's architectural decisions?

--- a/templates/dev-team-metrics.md
+++ b/templates/dev-team-metrics.md
@@ -1,0 +1,18 @@
+# Agent Calibration Metrics
+<!-- Appendable log of per-task agent performance metrics. -->
+<!-- Borges records an entry after each task cycle. -->
+<!-- Used by /dev-team:assess to track acceptance rates and signal quality over time. -->
+
+## Format
+<!-- Each entry follows this structure:
+### [YYYY-MM-DD] Task: <issue or PR reference>
+- **Agents**: implementing: <agent>, reviewers: <agent1, agent2, ...>
+- **Rounds**: <number of review waves to convergence>
+- **Findings**:
+  - <agent>: <N> DEFECT (<accepted>/<overruled>), <N> RISK, <N> SUGGESTION
+- **Acceptance rate**: <accepted findings / total findings>%
+- **Duration**: <approximate task duration>
+-->
+
+## Entries
+

--- a/templates/skills/dev-team-assess/SKILL.md
+++ b/templates/skills/dev-team-assess/SKILL.md
@@ -22,6 +22,7 @@ This skill audits **only update-safe files** — files that survive `dev-team up
    - All `.dev-team/agent-memory/*/MEMORY.md` files (use Glob to discover them)
    - The project's `CLAUDE.md` (root of repo)
    - `.dev-team/config.json` (to know which agents are installed)
+   - `.dev-team/metrics.md` (if it exists — calibration metrics log)
 
 2. If `$ARGUMENTS` specifies a focus area (e.g., "learnings", "memory", "claude.md"), scope the audit to that area only. Otherwise, audit all three.
 
@@ -91,6 +92,24 @@ Check the project's `CLAUDE.md` for:
 ### Learnings promotion
 - Mature learnings that have been stable for multiple sessions and should be promoted to `CLAUDE.md` instructions
 
+## Phase 4: Calibration metrics audit (`.dev-team/metrics.md`)
+
+If `.dev-team/metrics.md` exists and contains entries, analyze:
+
+### Acceptance rates per agent
+- Calculate rolling acceptance rate (last 10 entries) for each reviewer agent
+- Flag agents with acceptance rate below 50% — they may be generating more noise than signal
+- Identify trend direction: improving, stable, or degrading
+
+### Signal quality
+- Are DEFECT findings being overruled frequently? This suggests over-flagging
+- Are SUGGESTION findings dominating? This suggests agents are not calibrated to the project's conventions
+- Are review rounds consistently high (3+)? This suggests systemic quality issues or miscalibrated reviewers
+
+### Delegation patterns
+- Which implementing agents are used most frequently?
+- Are reviewers consistently finding issues in specific domains? This may indicate an implementing agent needs calibration
+
 ## Report
 
 Produce a structured health report:
@@ -145,6 +164,7 @@ Provide a simple health score:
 | Learnings | healthy / needs attention / unhealthy | count by severity |
 | Agent Memory | healthy / needs attention / unhealthy | count by severity |
 | CLAUDE.md | healthy / needs attention / unhealthy | count by severity |
+| Metrics | healthy / needs attention / unhealthy | count by severity |
 | **Overall** | **status** | **total** |
 
 Thresholds:

--- a/tests/integration/fresh-project.test.js
+++ b/tests/integration/fresh-project.test.js
@@ -66,6 +66,7 @@ describe("fresh project installation", () => {
       fs.existsSync(path.join(tmpDir, ".dev-team", "agent-memory", "dev-team-beck", "MEMORY.md")),
     );
     assert.ok(fs.existsSync(path.join(tmpDir, ".dev-team", "learnings.md")));
+    assert.ok(fs.existsSync(path.join(tmpDir, ".dev-team", "metrics.md")));
 
     // Settings (stays in .claude/)
     assert.ok(fs.existsSync(path.join(tmpDir, ".claude", "settings.json")));


### PR DESCRIPTION
## Summary
- Added `.dev-team/metrics.md` template for structured metrics logging
- Borges now records per-task metrics: agents, findings, acceptance rates, rounds to convergence
- Updated `/dev-team:assess` with Phase 4 metrics audit (acceptance rates, signal quality, delegation patterns)
- `dev-team init` and `dev-team update` create metrics.md (never overwrite existing data)
- Added test for metrics.md creation during init

## Test plan
- [x] All 274 tests pass
- [x] Fresh project test verifies metrics.md is created

Closes #164