### PR TITLE
feat: review calibration through memory and acceptance tracking

### DIFF
--- a/templates/agents/dev-team-drucker.md
+++ b/templates/agents/dev-team-drucker.md
@@ -125,6 +125,20 @@ If the implementing agent disagrees with a reviewer:
 1. Each side presents their argument (one exchange).
 2. If still unresolved, **escalate to the human** with both perspectives. Do not auto-resolve disagreements.
 
+#### 5c-ii. Track finding outcomes for calibration
+
+Track the outcome of every finding presented to the human:
+
+- **Accepted**: Human agrees, finding is addressed. Record as `accepted` for Borges to reinforce the pattern in agent memory.
+- **Overruled**: Human disagrees and explains why. Record as `overruled` with the human's reasoning. Borges will write an OVERRULED entry to the reviewer's memory.
+- **Ignored**: Human does not address the finding (advisory items). Record as `ignored`.
+
+Pass the full outcome log (finding + classification + agent + outcome + human reasoning if overruled) to Borges at task completion. This is the raw data for calibration metrics and memory evolution. Borges uses it to:
+1. Reinforce accepted patterns in the reviewer's memory
+2. Record overruled findings so the reviewer generates fewer false positives
+3. Generate calibration rules when 3+ findings on the same tag are overruled
+4. Update acceptance rates in `.dev-team/metrics.md`
+
 #### 5d. Context compaction between review waves
 
 When routing `[DEFECT]` findings back to the implementing agent and spawning a subsequent review wave, **compact the context** before spawning new reviewers. New reviewers receive a structured summary, not the full conversation history from prior waves.

--- a/templates/skills/dev-team-review/SKILL.md
+++ b/templates/skills/dev-team-review/SKILL.md
@@ -92,8 +92,11 @@ Before starting the review, check for open security alerts: run `/dev-team:secur
 ### Completion
 
 After the review report is delivered:
-1. You MUST spawn **@dev-team-borges** (Librarian) as the final step. Borges will:
+1. You MUST spawn **@dev-team-borges** (Librarian) as the final step. Pass Borges the **finding outcome log**: every finding with its classification, source agent, and outcome (accepted/overruled/ignored), including reasoning for overrules. Borges will:
    - **Extract structured memory entries** from the review findings (each classified finding becomes a memory entry for the reviewer who produced it)
+   - **Reinforce accepted patterns** and **record overruled findings** for reviewer calibration
+   - **Generate calibration rules** when 3+ findings on the same tag are overruled
+   - **Record metrics** to `.dev-team/metrics.md`
    - Write entries to each participating agent's MEMORY.md using the structured format
    - Update shared learnings in `.dev-team/learnings.md`
    - Check cross-agent coherence

--- a/templates/skills/dev-team-task/SKILL.md
+++ b/templates/skills/dev-team-task/SKILL.md
@@ -94,8 +94,12 @@ Before starting work, check for open security alerts: run `/dev-team:security-st
 When the loop exits:
 1. **Deliver the work**: If changes are on a feature branch, create the PR (body must include `Closes #<issue>`). Ensure the PR is ready to merge: CI green, reviews passed, branch up to date. Then follow the project's merge workflow — use `/dev-team:merge` if the project has it configured, otherwise report readiness. If merge fails (CI failures, merge conflicts, branch protection), report the blocker to the human rather than leaving work unattended.
 2. **Clean up worktree**: If the work was done in a worktree, clean it up after the branch is pushed and the PR is created. Do not wait for merge to clean the worktree.
-3. You MUST spawn **@dev-team-borges** (Librarian) as the final step. Borges will:
+3. You MUST spawn **@dev-team-borges** (Librarian) as the final step. Pass Borges the **finding outcome log**: every finding with its classification, source agent, and outcome (accepted/overruled/ignored), including the human's reasoning for overrules. Borges will:
    - **Extract structured memory entries** from review findings and implementation decisions
+   - **Reinforce accepted patterns** in the reviewer's memory (calibration feedback)
+   - **Record overruled findings** with context so reviewers generate fewer false positives
+   - **Generate calibration rules** when 3+ findings on the same tag are overruled
+   - **Record metrics** to `.dev-team/metrics.md` (acceptance rates, rounds to convergence)
    - Write entries to each participating agent's MEMORY.md using the structured format
    - Update shared learnings in `.dev-team/learnings.md`
    - Check cross-agent coherence


### PR DESCRIPTION
## Summary
- Added finding outcome tracking to Drucker (section 5c-ii): tracks accepted/overruled/ignored for every finding
- Updated task and review skills to pass finding outcome logs to Borges
- Borges uses outcomes to reinforce patterns, record overrules, generate calibration rules, and update metrics

## Test plan
- [x] All 274 tests pass

Closes #165