### PR TITLE
feat: enable Drucker to parallelize via agent teams

### DIFF
--- a/docs/adr/019-parallel-review-waves.md
+++ b/docs/adr/019-parallel-review-waves.md
@@ -44,6 +44,19 @@ The parallel task is complete when:
 2. Borges has run across all branches
 3. Drucker confirms all branches are complete in conversation context (no external state file needed)
 
+## Agent Teams Enhancement (v0.10)
+
+When Claude Code agent teams are enabled (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`), the parallel model is enhanced with native peer-to-peer communication:
+
+- **Team lead mode**: Drucker operates as team lead, decomposing work into a shared task list
+- **Peer communication**: Teammates (implementing agents) communicate directly via mailbox, not through Drucker
+- **Shared task list**: Native dependency tracking and self-claiming replace conversation-context tracking
+- **File ownership**: Explicit per-domain file ownership prevents editing conflicts
+
+The fundamental phases (0-4) remain the same. Agent teams provide a more efficient execution substrate but do not change the orchestration model.
+
+**Fallback**: When agent teams are disabled, the standard worktree subagent model (described above) is used. A shared context scratchpad (`.dev-team/parallel-context.md`) provides cross-agent context in fallback mode.
+
 ## Consequences
 - Independent issues execute in parallel, reducing wall-clock time roughly proportionally to the number of independent issues
 - Reviews are batched, which reduces context-switch overhead for the human reviewing the results

--- a/templates/agents/dev-team-drucker.md
+++ b/templates/agents/dev-team-drucker.md
@@ -201,6 +201,41 @@ Work is done when the deliverable is delivered — not just created. For PRs, th
 
 Follow the project's merge workflow. Some projects use auto-merge, others require manual approval. If the project has a `/dev-team:merge` skill or similar automation, use it. Otherwise, ensure the PR is in a mergeable state (CI green, reviews passed, branch updated) and report readiness.
 
+### Agent teams mode (experimental)
+
+When Claude Code agent teams are enabled (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in `.claude/settings.json`), Drucker operates as a **team lead** instead of spawning subagents sequentially.
+
+**Detection:** Check if agent teams are available by reading `.dev-team/config.json` for `"agentTeams": true`. If enabled, use team lead mode for milestone-level batches (3+ issues). For single issues, standard subagent mode is simpler and preferred.
+
+**Team lead workflow:**
+1. Decompose the milestone into a shared task list with dependencies
+2. Assign file ownership to prevent two teammates editing the same file
+3. Spawn implementing teammates (3-5 sweet spot) with their agent definitions
+4. Teammates self-claim tasks and implement independently
+5. After implementation tasks complete, spawn reviewer teammates
+6. Reviewers message implementers directly with findings
+7. Borges runs as final teammate extracting memories
+
+**File ownership conventions:**
+| Domain | Default owner | Files |
+|--------|--------------|-------|
+| Backend/API | Voss | `src/`, `lib/`, application code |
+| Infrastructure | Hamilton | `Dockerfile`, `.github/workflows/`, IaC |
+| Tooling/config | Deming | `package.json`, linter configs, build scripts |
+| Documentation | Tufte | `docs/`, `*.md`, `README` |
+| Tests | Beck | `tests/`, `__tests__/`, `*.test.*` |
+| Frontend | Mori | `components/`, `pages/`, UI code |
+| Release | Conway | `CHANGELOG.md`, version files |
+
+**Constraints:**
+- No nested teams — keep it flat
+- 3-5 teammates per batch (more causes quadratic communication overhead)
+- 5-6 tasks per teammate maximum
+- Explicit file ownership prevents conflicts
+
+**Fallback (when agent teams disabled):**
+When agent teams are not available, parallel work uses worktree subagents (standard mode). Before parallel work, write `.dev-team/parallel-context.md` with the batch plan, constraints, and naming conventions. Each implementing agent reads this before starting. After implementation, agents append key decisions made. Brooks uses these summaries during review to catch cross-branch inconsistencies. Delete the scratchpad after the batch completes.
+
 ## Focus areas
 
 You always check for:

--- a/templates/skills/dev-team-task/SKILL.md
+++ b/templates/skills/dev-team-task/SKILL.md
@@ -60,6 +60,8 @@ The convergence check happens in conversation context: count iterations, check f
 
 When multiple issues are being addressed in a single session, the task loop switches to parallel orchestration (see ADR-019). Drucker coordinates all phases in conversation context.
 
+**Mode selection:** If agent teams are enabled (check `.dev-team/config.json` for `"agentTeams": true`), use team lead mode for batches of 3+ issues. Otherwise, use standard worktree subagent mode. For single issues, always use standard mode.
+
 ### Phase 0: Brooks pre-assessment (batch)
 Spawn @dev-team-brooks once with all issues. Brooks identifies:
 - **File independence**: which issues touch overlapping files (conflict groups that must run sequentially)


### PR DESCRIPTION
## Summary
- Added agent teams team lead mode to Drucker for milestone-level parallel execution
- Defined file ownership conventions per agent domain to prevent edit conflicts
- Added fallback shared context scratchpad for when agent teams are disabled
- Updated task skill with mode selection (agent teams vs worktree subagents)
- Amended ADR-019 with agent teams enhancement

## Test plan
- [x] All 274 tests pass
- [x] All 12 agent definitions validate

Closes #173