### PR TITLE
feat: agent teams onboarding in dev-team init

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -375,6 +375,16 @@ export async function run(targetDir: string, flags: string[] = []): Promise<void
 
   mergeSettings(settingsPath, filteredSettings);
 
+  // Step 8c: Enable agent teams (experimental)
+  const settingsData = JSON.parse(readFile(settingsPath) || "{}");
+  if (!settingsData.env) {
+    settingsData.env = {};
+  }
+  if (!("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" in settingsData.env)) {
+    settingsData.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+  }
+  writeFile(settingsPath, JSON.stringify(settingsData, null, 2) + "\n");
+
   // Step 9: Copy framework skills (auto-discovered from templates/skills/)
   const skillsSrcDir = path.join(templates, "skills");
   const skillDirs = listSubdirectories(skillsSrcDir);
@@ -426,12 +436,14 @@ export async function run(targetDir: string, flags: string[] = []): Promise<void
   const claudeResult = mergeClaudeMd(claudeMdPath, claudeMdTemplate);
 
   // Save preferences
+  const agentTeamsEnabled = settingsData.env?.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS === "1";
   const prefs: Record<string, unknown> = {
     version: getPackageVersion(),
     agents: selectedAgents,
     hooks: selectedHooks,
     issueTracker,
     branchConvention,
+    agentTeams: agentTeamsEnabled,
   };
   if (preset) {
     prefs.preset = preset.label;
@@ -457,6 +469,11 @@ export async function run(targetDir: string, flags: string[] = []): Promise<void
   console.log(
     `  Workflow:  ${issueTracker}${branchConvention !== "None" ? `, branches: ${branchConvention}` : ""}`,
   );
+  if (agentTeamsEnabled) {
+    console.log(
+      "  Agent teams: enabled (experimental — disable with CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=0 if issues arise)",
+    );
+  }
   console.log("");
 
   // Step 12: Optional Deming tooling scan

--- a/src/update.ts
+++ b/src/update.ts
@@ -188,6 +188,7 @@ interface Preferences {
   hooks: string[];
   issueTracker: string;
   branchConvention: string;
+  agentTeams?: boolean;
 }
 
 interface UpdateSummary {
@@ -518,6 +519,20 @@ export async function update(targetDir: string): Promise<void> {
     mergeSettings(settingsPath, filteredSettings);
     summary.settings = true;
   }
+
+  // Step 4b: Enable agent teams if not already set (respect user opt-out)
+  const settingsData = JSON.parse(readFile(settingsPath) || "{}");
+  if (!settingsData.env) {
+    settingsData.env = {};
+  }
+  // Only add if not already set — never re-enable if user explicitly disabled (=0)
+  if (!("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" in settingsData.env)) {
+    settingsData.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+    writeFile(settingsPath, JSON.stringify(settingsData, null, 2) + "\n");
+  }
+  // Update config.json to reflect current agent teams status
+  const agentTeamsEnabled = settingsData.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS === "1";
+  prefs.agentTeams = agentTeamsEnabled;
 
   // Step 5: Update skills (auto-discovered from templates/skills/)
   const skillsDir = path.join(devTeamDir, "skills");

--- a/tests/integration/fresh-project.test.js
+++ b/tests/integration/fresh-project.test.js
@@ -92,6 +92,22 @@ describe("fresh project installation", () => {
     }
   });
 
+  it("enables agent teams in settings.json and config.json", async () => {
+    await run(tmpDir, ["--all"]);
+
+    // settings.json should have agent teams env var
+    const settings = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, ".claude", "settings.json"), "utf-8"),
+    );
+    assert.equal(settings.env?.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS, "1");
+
+    // config.json should record agent teams status
+    const config = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, ".dev-team", "config.json"), "utf-8"),
+    );
+    assert.equal(config.agentTeams, true);
+  });
+
   it("settings.json has valid hook configuration", async () => {
     await run(tmpDir, ["--all"]);
 

--- a/tests/integration/update.test.js
+++ b/tests/integration/update.test.js
@@ -126,6 +126,32 @@ describe("dev-team update", () => {
     assert.ok(alreadyMsg, "should report already at latest version when versions match");
   });
 
+  it("respects user agent teams opt-out during update", async () => {
+    await run(tmpDir, ["--all"]);
+
+    // User explicitly disables agent teams
+    const settingsPath = path.join(tmpDir, ".claude", "settings.json");
+    const settings = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+    settings.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "0";
+    fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+
+    await update(tmpDir);
+
+    // Should NOT re-enable agent teams
+    const updatedSettings = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+    assert.equal(
+      updatedSettings.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS,
+      "0",
+      "should respect user opt-out",
+    );
+
+    // config.json should reflect disabled state
+    const config = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, ".dev-team", "config.json"), "utf-8"),
+    );
+    assert.equal(config.agentTeams, false, "config should reflect disabled state");
+  });
+
   it("preserves shared team learnings", async () => {
     await run(tmpDir, ["--all"]);
 


### PR DESCRIPTION
## Summary
- `dev-team init` enables agent teams by default (CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 in settings.json)
- Records `agentTeams: true` in .dev-team/config.json for agent detection
- `dev-team update` adds env var if missing but respects user opt-out (=0)
- Prints informational note about agent teams in init output
- Added 2 new tests (276 total): agent teams init verification and opt-out respect

## Test plan
- [x] All 276 tests pass (2 new)
- [x] Init creates env var and config entry
- [x] Update does not re-enable if user disabled

Closes #177