### PR TITLE
fix: enforce Copilot review check before merging

### DIFF
--- a/.claude/skills/dev-team-merge/SKILL.md
+++ b/.claude/skills/dev-team-merge/SKILL.md
@@ -22,20 +22,29 @@ Before proceeding with merge, **wait for Copilot review to appear** — it takes
 
 ### 1a. Wait for Copilot review
 
-Poll up to 4 times (30s intervals, ~2 minutes total):
+Poll up to 4 times (30s intervals, ~2 minutes total). Check both inline comments AND summary reviews — Copilot can leave either:
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/{number}/comments --jq '[.[] | select(.user.login == "Copilot")] | length'
+# Inline review comments
+gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments --jq '[.[] | select(.user.login == "Copilot")] | length'
+
+# Summary reviews (may exist without inline comments)
+gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews --jq '[.[] | select(.user.login == "Copilot")] | length'
 ```
 
-- If count > 0: Copilot review has arrived, proceed to 1b
-- If count == 0 after 4 polls: Copilot review is absent (may not be configured), proceed to Step 2
+- If either count > 0: Copilot review has arrived, proceed to 1b
+- If both counts == 0 after 4 polls: Copilot review is absent (may not be configured), proceed to Step 2
 - Do NOT set auto-merge before this step completes
+- Use `--paginate` on all API calls to avoid missing results on PRs with many comments
 
 ### 1b. Address Copilot findings
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | select(.user.login == "Copilot") | {id: .id, path: .path, line: .line, body: .body}'
+# Inline comments
+gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | select(.user.login == "Copilot") | {id: .id, path: .path, line: .line, body: .body}'
+
+# Summary reviews
+gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews --jq '.[] | select(.user.login == "Copilot") | {id: .id, state: .state, body: .body}'
 ```
 
 For each Copilot comment:
@@ -49,7 +58,8 @@ For each Copilot comment:
 If you pushed fixes, Copilot may review again. Check once more after CI restarts:
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/{number}/comments --jq '[.[] | select(.user.login == "Copilot")] | length'
+gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments --jq '[.[] | select(.user.login == "Copilot")] | length'
+gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews --jq '[.[] | select(.user.login == "Copilot")] | length'
 ```
 
 If new comments appeared, repeat 1b. Otherwise proceed to Step 2.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,11 +138,11 @@ When the human gives feedback about process, coding style, or tool behavior: wri
 
 **Always use `/dev-team:merge` to merge PRs.** Do not use raw `gh pr merge`.
 
-Before merging any PR, you MUST wait for and address GitHub Copilot review comments:
+Before merging any PR, you MUST wait for and address GitHub Copilot review feedback:
 1. After creating a PR, wait up to 2 minutes for Copilot review to appear
-2. Check: `gh api repos/fredericboyer/dev-team/pulls/{number}/comments --jq '[.[] | select(.user.login == "Copilot")] | length'`
-3. If Copilot has comments, read and address them before merging
-4. Only proceed with merge after Copilot feedback is resolved or confirmed absent
+2. Check for inline review comments: `gh api --paginate repos/fredericboyer/dev-team/pulls/{number}/comments --jq '[.[] | select(.user.login == "Copilot")] | length'`
+3. Check for summary reviews: `gh api --paginate repos/fredericboyer/dev-team/pulls/{number}/reviews --jq '[.[] | select(.user.login == "Copilot")] | length'`
+4. If Copilot has any comments or reviews, read and address them before merging. Only proceed with merge after all Copilot feedback is resolved or both counts are zero.
 
 This applies to all PRs — including those created by background agents.
 


### PR DESCRIPTION
## Summary

- Merge skill now polls for Copilot review (up to 2 min) before setting auto-merge
- Project CLAUDE.md documents the requirement outside dev-team markers
- Both are project-specific artifacts that survive `dev-team update`

Closes #201

## Test plan

- [ ] Verify merge skill Step 1 includes Copilot polling loop
- [ ] Verify project CLAUDE.md has "Project-Specific Workflow" section after dev-team markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)