### PR TITLE
fix: broken HTML comments in memory templates and falsy bug in hook

### DIFF
--- a/templates/agent-memory/dev-team-beck/MEMORY.md
+++ b/templates/agent-memory/dev-team-beck/MEMORY.md
@@ -1,10 +1,10 @@
 # Agent Memory: Beck (Test Implementer)
-<\!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Borges extracts structured entries automatically after each task. -->
+<!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Borges extracts structured entries automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -15,12 +15,12 @@
 -->
 
 ## Calibration Rules
-<\!-- Auto-generated when 3+ findings on the same tag are overruled. -->
-<\!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
+<!-- Auto-generated when 3+ findings on the same tag are overruled. -->
+<!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 
 ## Archive
-<\!-- Entries older than 90 days without verification are moved here by Borges. -->
-<\!-- Not loaded into agent context but preserved for reference. -->
+<!-- Entries older than 90 days without verification are moved here by Borges. -->
+<!-- Not loaded into agent context but preserved for reference. -->

--- a/templates/agent-memory/dev-team-borges/MEMORY.md
+++ b/templates/agent-memory/dev-team-borges/MEMORY.md
@@ -1,10 +1,10 @@
 # Agent Memory: Borges (Librarian)
-<\!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Borges extracts structured entries automatically after each task. -->
+<!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Borges extracts structured entries automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -15,12 +15,12 @@
 -->
 
 ## Calibration Rules
-<\!-- Auto-generated when 3+ findings on the same tag are overruled. -->
-<\!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
+<!-- Auto-generated when 3+ findings on the same tag are overruled. -->
+<!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 
 ## Archive
-<\!-- Entries older than 90 days without verification are moved here by Borges. -->
-<\!-- Not loaded into agent context but preserved for reference. -->
+<!-- Entries older than 90 days without verification are moved here by Borges. -->
+<!-- Not loaded into agent context but preserved for reference. -->

--- a/templates/agent-memory/dev-team-brooks/MEMORY.md
+++ b/templates/agent-memory/dev-team-brooks/MEMORY.md
@@ -1,10 +1,10 @@
 # Agent Memory: Brooks (Architect)
-<\!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Borges extracts structured entries automatically after each task. -->
+<!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Borges extracts structured entries automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -15,12 +15,12 @@
 -->
 
 ## Calibration Rules
-<\!-- Auto-generated when 3+ findings on the same tag are overruled. -->
-<\!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
+<!-- Auto-generated when 3+ findings on the same tag are overruled. -->
+<!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 
 ## Archive
-<\!-- Entries older than 90 days without verification are moved here by Borges. -->
-<\!-- Not loaded into agent context but preserved for reference. -->
+<!-- Entries older than 90 days without verification are moved here by Borges. -->
+<!-- Not loaded into agent context but preserved for reference. -->

--- a/templates/agent-memory/dev-team-conway/MEMORY.md
+++ b/templates/agent-memory/dev-team-conway/MEMORY.md
@@ -1,10 +1,10 @@
 # Agent Memory: Conway (Release Manager)
-<\!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Borges extracts structured entries automatically after each task. -->
+<!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Borges extracts structured entries automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -15,12 +15,12 @@
 -->
 
 ## Calibration Rules
-<\!-- Auto-generated when 3+ findings on the same tag are overruled. -->
-<\!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
+<!-- Auto-generated when 3+ findings on the same tag are overruled. -->
+<!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 
 ## Archive
-<\!-- Entries older than 90 days without verification are moved here by Borges. -->
-<\!-- Not loaded into agent context but preserved for reference. -->
+<!-- Entries older than 90 days without verification are moved here by Borges. -->
+<!-- Not loaded into agent context but preserved for reference. -->

--- a/templates/agent-memory/dev-team-deming/MEMORY.md
+++ b/templates/agent-memory/dev-team-deming/MEMORY.md
@@ -1,10 +1,10 @@
 # Agent Memory: Deming (Tooling Optimizer)
-<\!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Borges extracts structured entries automatically after each task. -->
+<!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Borges extracts structured entries automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -15,12 +15,12 @@
 -->
 
 ## Calibration Rules
-<\!-- Auto-generated when 3+ findings on the same tag are overruled. -->
-<\!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
+<!-- Auto-generated when 3+ findings on the same tag are overruled. -->
+<!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 
 ## Archive
-<\!-- Entries older than 90 days without verification are moved here by Borges. -->
-<\!-- Not loaded into agent context but preserved for reference. -->
+<!-- Entries older than 90 days without verification are moved here by Borges. -->
+<!-- Not loaded into agent context but preserved for reference. -->

--- a/templates/agent-memory/dev-team-drucker/MEMORY.md
+++ b/templates/agent-memory/dev-team-drucker/MEMORY.md
@@ -1,10 +1,10 @@
 # Agent Memory: Drucker (Orchestrator)
-<\!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Borges extracts structured entries automatically after each task. -->
+<!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Borges extracts structured entries automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -15,12 +15,12 @@
 -->
 
 ## Calibration Rules
-<\!-- Auto-generated when 3+ findings on the same tag are overruled. -->
-<\!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
+<!-- Auto-generated when 3+ findings on the same tag are overruled. -->
+<!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 
 ## Archive
-<\!-- Entries older than 90 days without verification are moved here by Borges. -->
-<\!-- Not loaded into agent context but preserved for reference. -->
+<!-- Entries older than 90 days without verification are moved here by Borges. -->
+<!-- Not loaded into agent context but preserved for reference. -->

--- a/templates/agent-memory/dev-team-hamilton/MEMORY.md
+++ b/templates/agent-memory/dev-team-hamilton/MEMORY.md
@@ -1,10 +1,10 @@
 # Agent Memory: Hamilton (Infrastructure Engineer)
-<\!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Borges extracts structured entries automatically after each task. -->
+<!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Borges extracts structured entries automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -15,12 +15,12 @@
 -->
 
 ## Calibration Rules
-<\!-- Auto-generated when 3+ findings on the same tag are overruled. -->
-<\!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
+<!-- Auto-generated when 3+ findings on the same tag are overruled. -->
+<!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 
 ## Archive
-<\!-- Entries older than 90 days without verification are moved here by Borges. -->
-<\!-- Not loaded into agent context but preserved for reference. -->
+<!-- Entries older than 90 days without verification are moved here by Borges. -->
+<!-- Not loaded into agent context but preserved for reference. -->

--- a/templates/agent-memory/dev-team-knuth/MEMORY.md
+++ b/templates/agent-memory/dev-team-knuth/MEMORY.md
@@ -1,10 +1,10 @@
 # Agent Memory: Knuth (Quality Auditor)
-<\!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Borges extracts structured entries automatically after each task. -->
+<!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Borges extracts structured entries automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -15,12 +15,12 @@
 -->
 
 ## Calibration Rules
-<\!-- Auto-generated when 3+ findings on the same tag are overruled. -->
-<\!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
+<!-- Auto-generated when 3+ findings on the same tag are overruled. -->
+<!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 
 ## Archive
-<\!-- Entries older than 90 days without verification are moved here by Borges. -->
-<\!-- Not loaded into agent context but preserved for reference. -->
+<!-- Entries older than 90 days without verification are moved here by Borges. -->
+<!-- Not loaded into agent context but preserved for reference. -->

--- a/templates/agent-memory/dev-team-mori/MEMORY.md
+++ b/templates/agent-memory/dev-team-mori/MEMORY.md
@@ -1,10 +1,10 @@
 # Agent Memory: Mori (Frontend/UI Engineer)
-<\!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Borges extracts structured entries automatically after each task. -->
+<!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Borges extracts structured entries automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -15,12 +15,12 @@
 -->
 
 ## Calibration Rules
-<\!-- Auto-generated when 3+ findings on the same tag are overruled. -->
-<\!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
+<!-- Auto-generated when 3+ findings on the same tag are overruled. -->
+<!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 
 ## Archive
-<\!-- Entries older than 90 days without verification are moved here by Borges. -->
-<\!-- Not loaded into agent context but preserved for reference. -->
+<!-- Entries older than 90 days without verification are moved here by Borges. -->
+<!-- Not loaded into agent context but preserved for reference. -->

--- a/templates/agent-memory/dev-team-szabo/MEMORY.md
+++ b/templates/agent-memory/dev-team-szabo/MEMORY.md
@@ -1,10 +1,10 @@
 # Agent Memory: Szabo (Security Auditor)
-<\!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Borges extracts structured entries automatically after each task. -->
+<!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Borges extracts structured entries automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -15,12 +15,12 @@
 -->
 
 ## Calibration Rules
-<\!-- Auto-generated when 3+ findings on the same tag are overruled. -->
-<\!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
+<!-- Auto-generated when 3+ findings on the same tag are overruled. -->
+<!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 
 ## Archive
-<\!-- Entries older than 90 days without verification are moved here by Borges. -->
-<\!-- Not loaded into agent context but preserved for reference. -->
+<!-- Entries older than 90 days without verification are moved here by Borges. -->
+<!-- Not loaded into agent context but preserved for reference. -->

--- a/templates/agent-memory/dev-team-tufte/MEMORY.md
+++ b/templates/agent-memory/dev-team-tufte/MEMORY.md
@@ -1,10 +1,10 @@
 # Agent Memory: Tufte (Documentation Engineer)
-<\!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Borges extracts structured entries automatically after each task. -->
+<!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Borges extracts structured entries automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -15,12 +15,12 @@
 -->
 
 ## Calibration Rules
-<\!-- Auto-generated when 3+ findings on the same tag are overruled. -->
-<\!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
+<!-- Auto-generated when 3+ findings on the same tag are overruled. -->
+<!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 
 ## Archive
-<\!-- Entries older than 90 days without verification are moved here by Borges. -->
-<\!-- Not loaded into agent context but preserved for reference. -->
+<!-- Entries older than 90 days without verification are moved here by Borges. -->
+<!-- Not loaded into agent context but preserved for reference. -->

--- a/templates/agent-memory/dev-team-voss/MEMORY.md
+++ b/templates/agent-memory/dev-team-voss/MEMORY.md
@@ -1,10 +1,10 @@
 # Agent Memory: Voss (Backend Engineer)
-<\!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
-<\!-- First 200 lines are loaded into agent context. Keep concise. -->
-<\!-- Borges extracts structured entries automatically after each task. -->
+<!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
+<!-- First 200 lines are loaded into agent context. Keep concise. -->
+<!-- Borges extracts structured entries automatically after each task. -->
 
 ## Structured Entries
-<\!-- Format:
+<!-- Format:
 ### [YYYY-MM-DD] Finding summary
 - **Type**: DEFECT | RISK | SUGGESTION | OVERRULED | PATTERN | DECISION
 - **Source**: PR #NNN or task description
@@ -15,12 +15,12 @@
 -->
 
 ## Calibration Rules
-<\!-- Auto-generated when 3+ findings on the same tag are overruled. -->
-<\!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
+<!-- Auto-generated when 3+ findings on the same tag are overruled. -->
+<!-- Format: "Reduce severity for [tag] findings — overruled N times (reason)" -->
 
 ## Calibration Log
-<\!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+<!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 
 ## Archive
-<\!-- Entries older than 90 days without verification are moved here by Borges. -->
-<\!-- Not loaded into agent context but preserved for reference. -->
+<!-- Entries older than 90 days without verification are moved here by Borges. -->
+<!-- Not loaded into agent context but preserved for reference. -->

--- a/templates/hooks/dev-team-post-change-review.js
+++ b/templates/hooks/dev-team-post-change-review.js
@@ -241,11 +241,11 @@ function scoreComplexity(toolInput, filePath) {
   let score = 0;
 
   // Lines changed
-  const oldStr = toolInput.old_string || "";
-  const newStr = toolInput.new_string || toolInput.content || "";
+  const oldStr = toolInput.old_string ?? "";
+  const newStr = toolInput.new_string ?? toolInput.content ?? "";
   const oldLines = oldStr ? oldStr.split("\n").length : 0;
   const newLines = newStr ? newStr.split("\n").length : 0;
-  const linesChanged = Math.abs(newLines - oldLines) + Math.min(oldLines, newLines);
+  const linesChanged = oldLines + newLines;
   score += Math.min(linesChanged, 50); // Cap at 50 to avoid single large file dominating
 
   // Complexity indicators in the new content


### PR DESCRIPTION
## Summary

- Fix `<\!--` → `<!--` in all 12 agent memory templates (broken by PR #174)
- Fix `||` → `??` for empty-string handling in post-change review hook (PR #172)
- Fix linesChanged formula undercounting replacements (PR #172)

Originally PR #182, recreated fresh due to merge conflicts from v0.10.

## Test plan

- [ ] Memory templates render HTML comments correctly
- [ ] Post-change review hook handles block deletions (empty new_string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)