### PR TITLE
feat: add ADR-023 for cross-model reviewer assignment

### DIFF
--- a/.dev-team/agents/dev-team-brooks.md
+++ b/.dev-team/agents/dev-team-brooks.md
@@ -3,6 +3,7 @@ name: dev-team-brooks
 description: Architect and quality attribute reviewer. Use to review architectural decisions, challenge coupling and dependency direction, validate changes against ADRs, and assess quality attributes (performance, maintainability, scalability). Always-on for all non-test code changes. Read-only — does not modify code.
 tools: Read, Grep, Glob, Bash, Agent
 model: opus
+cross_model: # recommended when multi-model runtime available (ADR-023)
 memory: project
 ---
 

--- a/.dev-team/agents/dev-team-knuth.md
+++ b/.dev-team/agents/dev-team-knuth.md
@@ -3,6 +3,7 @@ name: dev-team-knuth
 description: Quality auditor. Use to audit code for correctness gaps, missing test coverage, boundary conditions, and unproven assumptions. Read-only — identifies what is missing or unproven, does not write code or tests.
 tools: Read, Grep, Glob, Bash, Agent
 model: opus
+cross_model: # recommended when multi-model runtime available (ADR-023)
 memory: project
 ---
 

--- a/.dev-team/agents/dev-team-szabo.md
+++ b/.dev-team/agents/dev-team-szabo.md
@@ -3,6 +3,7 @@ name: dev-team-szabo
 description: Security auditor. Use to review code for vulnerabilities, audit auth flows, analyze attack surfaces, and assess dependency risks. Read-only — does not modify code.
 tools: Read, Grep, Glob, Bash, Agent
 model: opus
+cross_model: # recommended when multi-model runtime available (ADR-023)
 memory: project
 ---
 

--- a/docs/adr/023-cross-model-reviewer-assignment.md
+++ b/docs/adr/023-cross-model-reviewer-assignment.md
@@ -1,0 +1,72 @@
+# ADR-023: Cross-model reviewer assignment for high-risk changes
+Date: 2026-03-24
+Status: proposed
+
+## Context
+
+All dev-team agents currently run on the same model family (Claude). ADR-008 differentiates by tier (Opus for analysis, Sonnet for implementation), but all tiers are from the same vendor. Research on Multi-Agent Debate (MAD) from ICLR/NeurIPS 2025 found that same-model adversarial debate consistently underperforms simpler approaches — devil's advocate patterns performed worst, adding rounds/agents showed no gains, and token consumption was 2-3x higher. However, **heterogeneous models from different vendors showed improvement**.
+
+This aligns with the "Rise of AI Teammates in SE 3.0" finding that cross-vendor review provides stronger diversity than same-vendor adversarial prompting. The implication for dev-team is clear: reviewer agents (Szabo, Knuth, Brooks) challenging each other on the same model family may hit a diversity ceiling. Different model families have different training biases, blind spots, and reasoning patterns — a vulnerability that Claude misses may be caught by a model trained on different data.
+
+Research synthesis recommendation R19 rates this P3 (future) because it is blocked on multi-model runtime support in Claude Code. Agent definitions currently specify `model: opus` or `model: sonnet`, which maps to Claude model tiers. There is no mechanism to specify a non-Claude model.
+
+## Decision
+
+Support cross-model reviewer assignment as an **aspirational capability** with the following design:
+
+### Agent definition `model` field extension
+
+The existing `model` field in agent frontmatter (ADR-008) will be extended to support vendor-qualified model identifiers when the runtime supports it:
+
+```yaml
+# Current (Claude-only, tier-based)
+model: opus
+
+# Future (cross-model, vendor-qualified)
+model: opus
+cross_model: openai:o3      # Preferred alternative model for cross-validation
+```
+
+The `cross_model` field is:
+- **Optional** — agents without it run on their ADR-008 assigned tier as today
+- **Ignored** by current runtimes that only support Claude models
+- **Recommended** for reviewer agents (Szabo, Knuth, Brooks) on high-risk changes
+- **Not recommended** for implementing agents — cross-model implementation introduces consistency risks in code style and convention adherence
+
+### Integration with ADR-008 model tiers
+
+ADR-008's model assignment strategy remains the primary mechanism:
+- Opus for read-only analysis agents (Szabo, Knuth, Brooks)
+- Opus for the orchestrator (Drucker)
+- Sonnet for implementation agents
+
+Cross-model assignment is an **overlay**, not a replacement. The `model` field remains the default. `cross_model` is activated only when:
+1. The runtime supports non-Claude models
+2. The change is classified as high-risk (security-sensitive, auth, crypto, or DEEP review depth)
+3. The orchestrator (Drucker) explicitly requests cross-model validation
+
+### When to use cross-model validation
+
+Cross-model validation is recommended for:
+- Security-sensitive changes (Szabo's domain): auth flows, token handling, crypto, session management
+- Architectural boundary changes (Brooks's domain): module boundaries, dependency direction changes, new public APIs
+- Changes triggering DEEP review depth from complexity-based triage (R8)
+
+Cross-model validation is NOT recommended for:
+- LIGHT review depth changes (typo fixes, comment updates)
+- Implementation tasks (code generation should remain single-model for consistency)
+- Documentation-only changes
+
+### Activation mechanism
+
+When multi-model runtime is available, the orchestrator (Drucker) can request cross-model validation by passing the `cross_model` preference when spawning a reviewer agent. The runtime resolves the model identifier to an available provider. If the cross-model provider is unavailable, the agent falls back to its primary `model` assignment silently.
+
+## Consequences
+
+- Reviewer agent definitions gain a `cross_model` field documenting the recommended alternative model — this serves as documentation of intent even before runtime support exists
+- No behavioral change today — the field is aspirational and ignored by current runtimes
+- When runtime support arrives, Drucker can activate cross-model validation without agent definition changes
+- ADR-008's tier strategy is preserved as the default; cross-model is an additive capability
+- Cost implications: cross-model validation doubles reviewer cost for activated changes (acceptable for high-risk only)
+- Vendor lock-in is reduced: the architecture explicitly plans for multi-vendor model usage
+- Risk: model API differences (token limits, tool calling conventions) may require adapter logic — this is a runtime concern, not an agent definition concern

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -47,3 +47,4 @@ What becomes easier or more difficult?
 | [020](020-quality-attribute-assessment.md) | Quality attribute assessment via expanded Brooks agent | accepted |
 | [021](021-typescript-6-module-resolution.md) | TypeScript 6.0 with nodenext module resolution | accepted |
 | [022](022-agent-proliferation-governance.md) | Agent proliferation governance | accepted |
+| [023](023-cross-model-reviewer-assignment.md) | Cross-model reviewer assignment for high-risk changes | proposed |

--- a/templates/agents/dev-team-brooks.md
+++ b/templates/agents/dev-team-brooks.md
@@ -3,6 +3,7 @@ name: dev-team-brooks
 description: Architect and quality attribute reviewer. Use to review architectural decisions, challenge coupling and dependency direction, validate changes against ADRs, and assess quality attributes (performance, maintainability, scalability). Always-on for all non-test code changes. Read-only — does not modify code.
 tools: Read, Grep, Glob, Bash, Agent
 model: opus
+cross_model: # recommended when multi-model runtime available (ADR-023)
 memory: project
 ---
 

--- a/templates/agents/dev-team-knuth.md
+++ b/templates/agents/dev-team-knuth.md
@@ -3,6 +3,7 @@ name: dev-team-knuth
 description: Quality auditor. Use to audit code for correctness gaps, missing test coverage, boundary conditions, and unproven assumptions. Read-only — identifies what is missing or unproven, does not write code or tests.
 tools: Read, Grep, Glob, Bash, Agent
 model: opus
+cross_model: # recommended when multi-model runtime available (ADR-023)
 memory: project
 ---
 

--- a/templates/agents/dev-team-szabo.md
+++ b/templates/agents/dev-team-szabo.md
@@ -3,6 +3,7 @@ name: dev-team-szabo
 description: Security auditor. Use to review code for vulnerabilities, audit auth flows, analyze attack surfaces, and assess dependency risks. Read-only — does not modify code.
 tools: Read, Grep, Glob, Bash, Agent
 model: opus
+cross_model: # recommended when multi-model runtime available (ADR-023)
 memory: project
 ---
 


### PR DESCRIPTION
## Summary

- Add ADR-023 documenting the decision to support cross-model reviewer assignment when multi-model runtime becomes available
- Extend reviewer agent definitions (Szabo, Knuth, Brooks) with `cross_model` field in both `.dev-team/agents/` and `templates/agents/`
- Research-backed: MAD (ICLR/NeurIPS 2025) found heterogeneous models improve adversarial review while same-model debate does not

## Details

**Current state**: All agents run on the same model family (Claude), differentiated only by tier (Opus/Sonnet per ADR-008).

**Future state**: Reviewer agents can be assigned alternative models via `cross_model` field for high-risk changes (security, architectural boundaries, DEEP review depth).

**Status**: Aspirational — blocked on multi-model runtime support in Claude Code. The `cross_model` field is ignored by current runtimes but documents intent.

Closes #168

## Test plan

- [x] All 308 tests pass (`npm test`)
- [ ] Verify ADR-023 is indexed in `docs/adr/README.md`
- [ ] Verify `cross_model` field present in all 6 reviewer agent definitions
- [ ] Confirm no behavioral change — field is documentation-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)