### PR TITLE
fix: populate cold start seed entries for all 12 agent memories

### DIFF
--- a/.dev-team/agent-memory/dev-team-beck/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-beck/MEMORY.md
@@ -3,10 +3,40 @@
 
 ## Test Patterns and Conventions
 
+### [2026-03-24] Node.js built-in test runner with assert module — no third-party framework
+- **Type**: PATTERN [bootstrapped]
+- **Source**: package.json analysis
+- **Tags**: testing, framework, test-runner
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Tests use `node --test` with Node.js assert module. No Jest, Mocha, or Vitest. Test files are JS (compiled from TS via build step). Each test file is listed explicitly in the test script.
+
+### [2026-03-24] Three-tier test structure: unit (6), integration (3), scenarios (4)
+- **Type**: PATTERN [bootstrapped]
+- **Source**: project structure analysis
+- **Tags**: testing, structure
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: tests/unit/ covers individual modules (files, hooks, scan, skill-recommendations, create-agent, cli). tests/integration/ covers full install flows (fresh-project, idempotency, update). tests/scenarios/ covers end-to-end project types and orchestration.
+
+### [2026-03-24] 308 passing tests, 0 failures — test script lists files explicitly
+- **Type**: PATTERN [bootstrapped]
+- **Source**: npm test output
+- **Tags**: testing, count, ci
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Tests run in ~9 seconds. New test files must be added to the explicit list in package.json scripts.test. CI runs tests on 3 OS (ubuntu, macos, windows) with Node 22.
+
+### [2026-03-24] TDD enforced via hook — dev-team-tdd-enforce.js
+- **Type**: PATTERN [bootstrapped]
+- **Source**: templates/hooks/ analysis
+- **Tags**: testing, tdd, hooks
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: TDD enforcement hook ensures tests exist for implementation changes. Part of the 6-hook enforcement suite. See ADR-004 for TDD enforcement rationale.
 
 ## Framework and Runner Notes
 
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
-

--- a/.dev-team/agent-memory/dev-team-borges/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-borges/MEMORY.md
@@ -3,10 +3,32 @@
 
 ## Memory Health Status
 
+### [2026-03-24] Cold start seed generation completed for all 12 agents
+- **Type**: DECISION [bootstrapped]
+- **Source**: Issue #212 — cold start seed generation
+- **Tags**: memory, cold-start, seeding
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: All 12 agent MEMORY.md files populated with 3-5 bootstrapped seed entries derived from package.json, tsconfig.json, CI config, ADRs, and project structure. Seeds marked [bootstrapped] with outcome pending-verification.
+
+### [2026-03-24] Memory architecture: Tier 1 shared learnings + Tier 2 agent calibration
+- **Type**: PATTERN [bootstrapped]
+- **Source**: CLAUDE.md + .dev-team/learnings.md analysis
+- **Tags**: memory, architecture, tiers
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Tier 1 is .dev-team/learnings.md (shared facts, benchmarks, conventions). Tier 2 is .dev-team/agent-memory/*/MEMORY.md (agent-specific calibration). First 200 lines loaded into context. Formal decisions go to docs/adr/.
+
+### [2026-03-24] Quality benchmarks in learnings.md: 308 tests, 12 agents, 7 skills, 6 hooks
+- **Type**: PATTERN [bootstrapped]
+- **Source**: .dev-team/learnings.md analysis
+- **Tags**: benchmarks, accuracy
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: These benchmarks drift frequently. Borges should verify and update them at end of each task cycle. Current count confirmed: 308 tests passing as of 2026-03-24.
 
 ## System Improvement Log
 
 
 ## Calibration Log
 <!-- Recommendations accepted/deferred — tunes what to flag over time -->
-

--- a/.dev-team/agent-memory/dev-team-brooks/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-brooks/MEMORY.md
@@ -3,10 +3,40 @@
 
 ## Project Conventions
 
+### [2026-03-24] 22 ADRs governing architecture — TypeScript/CommonJS, zero runtime deps, 12 agents
+- **Type**: PATTERN [bootstrapped]
+- **Source**: docs/adr/ + package.json analysis
+- **Tags**: architecture, adr, structure
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Key ADRs: 001 (hooks over CLAUDE.md), 002 (zero deps), 005 (adversarial agents), 007 (oxc tooling), 019 (parallel review waves), 022 (agent proliferation governance with 15-agent soft cap). TypeScript 6 with NodeNext module resolution (ADR-021).
+
+### [2026-03-24] Module structure: src/ (8 modules) to dist/ with templates/ shipped separately
+- **Type**: PATTERN [bootstrapped]
+- **Source**: project structure analysis
+- **Tags**: architecture, modules, build
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: src/ contains init.ts (entry), files.ts, scan.ts, create-agent.ts, update.ts, doctor.ts, status.ts, skill-recommendations.ts, prompts.ts. bin/dev-team.js is the CLI shim. templates/ contains agents, hooks, skills shipped to target projects. .dev-team/ is self-use only.
+
+### [2026-03-24] Strict separation: templates/ (shipped) vs .dev-team/ (self-use)
+- **Type**: PATTERN [bootstrapped]
+- **Source**: CLAUDE.md + package.json files array
+- **Tags**: architecture, boundaries
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: templates/ contains what gets installed in target projects. .dev-team/ contains dev-team's own agents/hooks/skills for dogfooding. Improvements must target templates/ to ship in releases — never modify .dev-team/ for improvements (overwritten by update).
+
+### [2026-03-24] Agent proliferation governed by ADR-022 — soft cap of 15
+- **Type**: DECISION [bootstrapped]
+- **Source**: docs/adr/022-agent-proliferation-governance.md
+- **Tags**: architecture, agents, governance
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Currently 12 agents. New agents require justification against 4 criteria. Brooks flags additions during architectural review. Drucker evaluates extending existing agents first.
 
 ## Patterns to Watch For
 
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
-

--- a/.dev-team/agent-memory/dev-team-conway/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-conway/MEMORY.md
@@ -3,10 +3,40 @@
 
 ## Project Conventions
 
+### [2026-03-24] Semver versioning — currently v0.11.0, pre-1.0
+- **Type**: PATTERN [bootstrapped]
+- **Source**: package.json + CHANGELOG.md analysis
+- **Tags**: versioning, semver, release
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Pre-1.0 semver. Version in package.json must match git tag (validated in release workflow). CHANGELOG.md tracks all versions with [Unreleased] section at top.
+
+### [2026-03-24] Tag-triggered release: v* tag to npm publish + GitHub Release
+- **Type**: PATTERN [bootstrapped]
+- **Source**: .github/workflows/release.yml analysis
+- **Tags**: release, workflow, npm
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Release process: bump version in package.json, update CHANGELOG.md, commit, push tag v*. Release workflow validates semver match, runs full test suite + lint + validation, publishes to npm with provenance, then creates GitHub Release with extracted changelog notes.
+
+### [2026-03-24] npm package scope: @fredericboyer/dev-team, public access
+- **Type**: PATTERN [bootstrapped]
+- **Source**: package.json + release.yml analysis
+- **Tags**: npm, publishing, scope
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Published as scoped package with --access public --provenance. Uses NPM_TOKEN secret. Package includes bin/, dist/, templates/ (defined in files array).
+
+### [2026-03-24] Release checklist includes full validation suite before publish
+- **Type**: PATTERN [bootstrapped]
+- **Source**: .github/workflows/release.yml analysis
+- **Tags**: release, validation, quality-gate
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Release job runs: build, test, lint, format check, validate-agents, validate-hooks — all must pass before npm publish. This is more comprehensive than CI (which splits into separate jobs).
 
 ## Patterns to Watch For
 
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
-

--- a/.dev-team/agent-memory/dev-team-deming/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-deming/MEMORY.md
@@ -3,10 +3,40 @@
 
 ## Tooling Decisions
 
+### [2026-03-24] oxlint for linting, oxfmt for formatting — not ESLint/Prettier (ADR-007)
+- **Type**: PATTERN [bootstrapped]
+- **Source**: package.json + ADR-007 analysis
+- **Tags**: linting, formatting, tooling, oxc
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: TypeScript/OXC toolchain chosen for speed. npm run lint uses oxlint on src/, scripts/, templates/hooks/. npm run format uses oxfmt. CI enforces both via lint-and-format job. Format check runs oxfmt --check.
+
+### [2026-03-24] 6 hooks enforce quality gates — TDD, safety, review, lint, gate, watch list
+- **Type**: PATTERN [bootstrapped]
+- **Source**: templates/hooks/ analysis
+- **Tags**: hooks, enforcement, dx
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: dev-team-tdd-enforce.js (TDD), dev-team-safety-guard.js (safety), dev-team-post-change-review.js (review spawning), dev-team-pre-commit-lint.js (lint), dev-team-pre-commit-gate.js (blocking gate), dev-team-watch-list.js (file watch triggers). ADR-001: hooks over CLAUDE.md for enforcement.
+
+### [2026-03-24] Agent and hook validation scripts run in CI
+- **Type**: PATTERN [bootstrapped]
+- **Source**: .github/workflows/ci.yml analysis
+- **Tags**: ci, validation, agents, hooks
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: scripts/validate-agents.js checks agent frontmatter. scripts/validate-hooks.js verifies hook scripts load without errors. Both are separate CI jobs. Hook validation runs cross-platform (3 OS).
+
+### [2026-03-24] TypeScript 6 with NodeNext resolution — pretest builds before test
+- **Type**: PATTERN [bootstrapped]
+- **Source**: tsconfig.json + package.json analysis
+- **Tags**: typescript, build, tooling
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: TS 6.0.2 with ES2022 target, NodeNext modules (ADR-021). pretest script runs npm run build automatically. Source in src/, output in dist/. Tests run against compiled JS.
 
 ## Hook Effectiveness
 
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
-

--- a/.dev-team/agent-memory/dev-team-drucker/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-drucker/MEMORY.md
@@ -3,10 +3,40 @@
 
 ## Delegation Patterns
 
+### [2026-03-24] 12 agents with domain-specific triggers — 3 always-on reviewers
+- **Type**: PATTERN [bootstrapped]
+- **Source**: CLAUDE.md + templates/agents/ analysis
+- **Tags**: agents, delegation, routing
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Szabo (security), Knuth (correctness), Brooks (architecture + quality) review all code changes. Other agents triggered by file-type watch lists. Drucker routes implementation to domain specialist and spawns appropriate reviewers.
+
+### [2026-03-24] Parallel execution model — ADR-019 governs concurrent review waves
+- **Type**: PATTERN [bootstrapped]
+- **Source**: docs/adr/019-parallel-review-waves.md
+- **Tags**: orchestration, parallelism, review
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Brooks assesses file independence, implementations run concurrently in worktrees, reviews batched into coordinated wave, defects route back per-branch, Borges runs once across all branches at end.
+
+### [2026-03-24] Agent proliferation check before recommending new agents (ADR-022)
+- **Type**: DECISION [bootstrapped]
+- **Source**: docs/adr/022-agent-proliferation-governance.md
+- **Tags**: agents, governance, delegation
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Drucker must evaluate extending existing agents before recommending new ones. 4 justification criteria required. Soft cap of 15 agents. Currently at 12.
+
+### [2026-03-24] Spawn reviewers as general-purpose subagents with full agent definitions
+- **Type**: PATTERN [bootstrapped]
+- **Source**: .dev-team/learnings.md
+- **Tags**: orchestration, subagents, spawning
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Must load actual agent definition from .dev-team/agents/dev-team-*.md when spawning. Do NOT use pr-review-toolkit proxies — different behavior. Use subagent_type: "general-purpose".
 
 ## Conflict Resolution Log
 
 
 ## Calibration Log
 <!-- Delegation decisions that worked well or poorly — tunes routing over time -->
-

--- a/.dev-team/agent-memory/dev-team-hamilton/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-hamilton/MEMORY.md
@@ -1,8 +1,39 @@
-# Agent Memory: Hamilton (Operations Reviewer)
+# Agent Memory: Hamilton (Infrastructure Engineer)
 <!-- First 200 lines are loaded into agent context. Keep concise. -->
 
 ## Operational Patterns Mapped
 
+### [2026-03-24] CI: GitHub Actions with 4 jobs — build-and-test (3 OS), lint-and-format, validate-agents, validate-hooks
+- **Type**: PATTERN [bootstrapped]
+- **Source**: .github/workflows/ci.yml analysis
+- **Tags**: ci, github-actions, testing
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: build-and-test runs on ubuntu/macos/windows with Node 22. Lint and format check run on ubuntu only. Agent frontmatter validation and hook script validation are separate jobs. All triggered on push to main and PRs.
+
+### [2026-03-24] Release: tag-triggered npm publish with provenance + GitHub Release
+- **Type**: PATTERN [bootstrapped]
+- **Source**: .github/workflows/release.yml analysis
+- **Tags**: release, npm, ci, deployment
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Push of v* tag triggers: semver validation (tag vs package.json), full test suite, lint, format check, agent/hook validation, then npm publish --access public --provenance. Second job creates GitHub Release with changelog extraction. Uses NPM_TOKEN secret.
+
+### [2026-03-24] No Docker, no Kubernetes, no infrastructure-as-code
+- **Type**: PATTERN [bootstrapped]
+- **Source**: project structure analysis
+- **Tags**: infrastructure, deployment
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: dev-team is distributed as an npm package only. No Dockerfile, no Helm charts, no Terraform. Hamilton's role focuses on CI/CD pipeline health, cross-platform testing matrix, and release workflow integrity.
+
+### [2026-03-24] Cross-platform validation: hooks tested on 3 OS via validate-hooks job
+- **Type**: PATTERN [bootstrapped]
+- **Source**: .github/workflows/ci.yml analysis
+- **Tags**: cross-platform, hooks, ci
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Hook validation runs on ubuntu, macos, and windows matrices. Hooks are plain JS and must work cross-platform. See ADR-003 for cross-platform hook design rationale.
 
 ## Known Availability Risks
 

--- a/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
@@ -3,10 +3,40 @@
 
 ## Coverage Gaps Identified
 
+### [2026-03-24] 308 tests using Node.js built-in test runner across 3 tiers
+- **Type**: PATTERN [bootstrapped]
+- **Source**: package.json analysis
+- **Tags**: testing, coverage, test-runner
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: 6 unit tests, 3 integration tests, 4 scenario tests. Node.js `node --test` runner, no third-party test framework. Tests are pre-compiled JS (not TS).
+
+### [2026-03-24] Test directory structure: tests/unit + tests/integration + tests/scenarios
+- **Type**: PATTERN [bootstrapped]
+- **Source**: project structure analysis
+- **Tags**: testing, structure
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Unit tests cover files, hooks, scan, skill-recommendations, create-agent, cli. Integration tests cover fresh-project, idempotency, update. Scenario tests cover node-project, python-project, upgrade-path, orchestration.
+
+### [2026-03-24] No coverage tool configured — coverage is not measured
+- **Type**: PATTERN [bootstrapped]
+- **Source**: package.json analysis
+- **Tags**: testing, coverage
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: No c8, istanbul, or similar coverage tool in devDependencies or scripts. Coverage gaps must be identified by code review, not metrics.
+
+### [2026-03-24] mergeClaudeMd append-on-missing-END-marker duplicate BEGIN edge case
+- **Type**: RISK [bootstrapped]
+- **Source**: .dev-team/learnings.md (known tech debt)
+- **Tags**: boundary-condition, merge-logic
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Known edge case where subsequent runs can produce duplicate BEGIN markers if END marker is missing. Tracked in shared learnings.
 
 ## Recurring Boundary Conditions
 
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
-

--- a/.dev-team/agent-memory/dev-team-mori/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-mori/MEMORY.md
@@ -3,10 +3,32 @@
 
 ## Project Conventions
 
+### [2026-03-24] No frontend UI — CLI-only tool, Mori role is API contract review
+- **Type**: PATTERN [bootstrapped]
+- **Source**: package.json + src/ analysis
+- **Tags**: architecture, frontend, api-contracts
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: dev-team has no browser UI, no React/Vue/Svelte, no CSS, no components. Mori's role is scoped to API contract review — triggered when API-related files change (/api/, /routes/, schema, etc.). For this project, that means watching template schemas, agent frontmatter contracts, and hook interfaces.
+
+### [2026-03-24] Agent frontmatter is the primary schema contract
+- **Type**: PATTERN [bootstrapped]
+- **Source**: templates/agents/ + scripts/validate-agents.js analysis
+- **Tags**: schema, contracts, agents
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Agent definitions use YAML frontmatter (name, description, tools, model, memory). scripts/validate-agents.js validates this schema in CI. Changes to frontmatter structure are API-level changes affecting all consuming agents.
+
+### [2026-03-24] Hook interface contract: type + command fields in .claude/settings.json
+- **Type**: PATTERN [bootstrapped]
+- **Source**: src/files.ts HookEntry interface
+- **Tags**: schema, contracts, hooks
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Hooks are registered via HookEntry { type, command } and HookMatcher { matcher?, hooks[] } in HookSettings. This is the integration contract between dev-team and Claude Code's hook system.
 
 ## Patterns to Watch For
 
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
-

--- a/.dev-team/agent-memory/dev-team-szabo/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-szabo/MEMORY.md
@@ -3,10 +3,40 @@
 
 ## Trust Boundaries Mapped
 
+### [2026-03-24] CLI tool with no auth, no user data, no network services
+- **Type**: PATTERN [bootstrapped]
+- **Source**: package.json + src/ analysis
+- **Tags**: trust-boundary, attack-surface
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: dev-team is a CLI installer that copies template files into target projects. No authentication system, no user data handling, no database, no HTTP server. Primary security concern is file system operations and template injection.
+
+### [2026-03-24] readFile() broad catch treats permission errors same as missing file
+- **Type**: RISK [bootstrapped]
+- **Source**: .dev-team/learnings.md (known tech debt)
+- **Tags**: error-handling, file-system, tech-debt
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: src/files.ts readFile has a catch-all that conflates permission denied with file-not-found. Could mask security-relevant errors in target project file operations.
+
+### [2026-03-24] Hook scripts execute in target project context
+- **Type**: PATTERN [bootstrapped]
+- **Source**: templates/hooks/ analysis
+- **Tags**: code-execution, hooks, trust-boundary
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: 6 hooks shipped as plain JS run in the target project's environment. They spawn subprocesses and read/write files. Any command injection in hook logic would execute with the user's permissions.
+
+### [2026-03-24] Zero runtime dependencies — small supply chain surface
+- **Type**: PATTERN [bootstrapped]
+- **Source**: package.json analysis
+- **Tags**: supply-chain, dependencies
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Only devDependencies (typescript, oxlint, oxfmt, @types/node). No runtime deps means minimal supply chain attack surface. ADR-002 codifies this as a design principle.
 
 ## Known Attack Surfaces
 
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
-

--- a/.dev-team/agent-memory/dev-team-tufte/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-tufte/MEMORY.md
@@ -3,10 +3,40 @@
 
 ## Project Conventions
 
+### [2026-03-24] Documentation structure: README, CHANGELOG, 22 ADRs, CLAUDE.md, learnings.md
+- **Type**: PATTERN [bootstrapped]
+- **Source**: project structure analysis
+- **Tags**: documentation, structure
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: README.md at root. CHANGELOG.md follows Keep a Changelog format. docs/adr/ has 22 ADRs with README index. CLAUDE.md serves as project instructions for Claude Code. .dev-team/learnings.md holds shared team knowledge.
+
+### [2026-03-24] CHANGELOG follows Keep a Changelog with semver — used in release workflow
+- **Type**: PATTERN [bootstrapped]
+- **Source**: CHANGELOG.md + release.yml analysis
+- **Tags**: changelog, release, documentation
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Release workflow extracts changelog section matching the tag version to generate GitHub Release notes. Missing changelog entries produce a warning but don't block release. Format: ## [version] - YYYY-MM-DD with Added/Changed/Fixed/Internal sections.
+
+### [2026-03-24] Tufte is triggered on implementation file changes to detect doc-code drift
+- **Type**: PATTERN [bootstrapped]
+- **Source**: CLAUDE.md hook trigger rules
+- **Tags**: doc-code-drift, hooks, triggers
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Tufte is auto-flagged when .md/docs/README files change AND when significant implementation files change (src/, templates/agents/, templates/skills/, templates/hooks/, bin/, package.json). Dual trigger catches both direct doc edits and implementation changes that may require doc updates.
+
+### [2026-03-24] Quality benchmarks in learnings.md must stay synchronized with actual counts
+- **Type**: PATTERN [bootstrapped]
+- **Source**: .dev-team/learnings.md analysis
+- **Tags**: benchmarks, accuracy, learnings
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: learnings.md tracks test count (308), agent count (12), skill count (7), hook count (6). These drift as the project evolves. Tufte should flag when implementation changes affect these counts.
 
 ## Patterns to Watch For
 
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
-

--- a/.dev-team/agent-memory/dev-team-voss/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-voss/MEMORY.md
@@ -3,10 +3,32 @@
 
 ## Project Conventions
 
+### [2026-03-24] CLI tool — no database, no API server, no ORM
+- **Type**: PATTERN [bootstrapped]
+- **Source**: package.json + src/ analysis
+- **Tags**: architecture, data-layer, backend
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: dev-team is a CLI installer (npx dev-team init). No database, no HTTP server, no REST/GraphQL API. Data model is file-based: reads package.json/tsconfig for project scanning, writes template files to target projects. Voss role here focuses on file I/O patterns, config parsing, and data modeling for scan/init logic.
+
+### [2026-03-24] Config via JSON files — .dev-team/config.json in target projects
+- **Type**: PATTERN [bootstrapped]
+- **Source**: src/scan.ts + src/init.ts analysis
+- **Tags**: configuration, data-model
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Project detection via scan.ts reads package.json, tsconfig.json, pyproject.toml to auto-detect runtime. Config stored as JSON. No environment variables for configuration (CLI tool, not a service).
+
+### [2026-03-24] Zero runtime dependencies — all functionality is self-contained
+- **Type**: PATTERN [bootstrapped]
+- **Source**: package.json analysis
+- **Tags**: dependencies, architecture
+- **Outcome**: pending-verification
+- **Last-verified**: 2026-03-24
+- **Context**: Uses only Node.js built-in modules (fs, path, child_process). ADR-002 codifies zero-dep policy. Any new functionality must use built-ins or be implemented inline.
 
 ## Patterns to Watch For
 
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
-

--- a/.dev-team/learnings.md
+++ b/.dev-team/learnings.md
@@ -40,7 +40,7 @@
 - Always run `npm run format` before committing new `.ts` files — oxfmt formatting is checked in CI.
 
 ### Learning capture metrics
-- Non-empty agent memory files: 0 of 12 active agents (16 memory dirs exist, 4 are legacy pre-rename: architect, docs, lead, release)
+- Non-empty agent memory files: 12 of 12 active agents (16 memory dirs exist, 4 are legacy pre-rename: architect, docs, lead, release)
 - Last Borges run: not tracked yet (Borges spawning is now enforced via skill definitions)
 - Pre-commit gate: blocks commits without memory updates (override via `.dev-team/.memory-reviewed`)
 - All 7 implementing agents have mandatory Learnings Output section


### PR DESCRIPTION
## Summary
- Populates all 12 empty agent MEMORY.md files with 3-5 domain-specific bootstrapped seed entries
- Seeds derived from package.json, tsconfig.json, CI workflows, ADRs, and project structure analysis
- Each entry follows the structured memory format with `[bootstrapped]` type marker and `pending-verification` outcome
- Updates learnings.md memory count from 0/12 to 12/12

Closes #212

## Test plan
- [x] All 308 tests pass (`npm test`)
- [ ] Verify each agent's seeds are domain-appropriate (security for Szabo, testing for Knuth/Beck, etc.)
- [ ] Confirm seeds use correct structured format with all required fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)