### PR TITLE
fix: set cross_model to false instead of YAML null in agent defs

### DIFF
--- a/.dev-team/agents/dev-team-brooks.md
+++ b/.dev-team/agents/dev-team-brooks.md
@@ -3,7 +3,7 @@ name: dev-team-brooks
 description: Architect and quality attribute reviewer. Use to review architectural decisions, challenge coupling and dependency direction, validate changes against ADRs, and assess quality attributes (performance, maintainability, scalability). Always-on for all non-test code changes. Read-only — does not modify code.
 tools: Read, Grep, Glob, Bash, Agent
 model: opus
-cross_model: # recommended when multi-model runtime available (ADR-023)
+cross_model: false # recommended when multi-model runtime available (ADR-023)
 memory: project
 ---
 

--- a/.dev-team/agents/dev-team-knuth.md
+++ b/.dev-team/agents/dev-team-knuth.md
@@ -3,7 +3,7 @@ name: dev-team-knuth
 description: Quality auditor. Use to audit code for correctness gaps, missing test coverage, boundary conditions, and unproven assumptions. Read-only — identifies what is missing or unproven, does not write code or tests.
 tools: Read, Grep, Glob, Bash, Agent
 model: opus
-cross_model: # recommended when multi-model runtime available (ADR-023)
+cross_model: false # recommended when multi-model runtime available (ADR-023)
 memory: project
 ---
 

--- a/.dev-team/agents/dev-team-szabo.md
+++ b/.dev-team/agents/dev-team-szabo.md
@@ -3,7 +3,7 @@ name: dev-team-szabo
 description: Security auditor. Use to review code for vulnerabilities, audit auth flows, analyze attack surfaces, and assess dependency risks. Read-only — does not modify code.
 tools: Read, Grep, Glob, Bash, Agent
 model: opus
-cross_model: # recommended when multi-model runtime available (ADR-023)
+cross_model: false # recommended when multi-model runtime available (ADR-023)
 memory: project
 ---
 

--- a/templates/agents/dev-team-brooks.md
+++ b/templates/agents/dev-team-brooks.md
@@ -3,7 +3,7 @@ name: dev-team-brooks
 description: Architect and quality attribute reviewer. Use to review architectural decisions, challenge coupling and dependency direction, validate changes against ADRs, and assess quality attributes (performance, maintainability, scalability). Always-on for all non-test code changes. Read-only — does not modify code.
 tools: Read, Grep, Glob, Bash, Agent
 model: opus
-cross_model: # recommended when multi-model runtime available (ADR-023)
+cross_model: false # recommended when multi-model runtime available (ADR-023)
 memory: project
 ---
 

--- a/templates/agents/dev-team-knuth.md
+++ b/templates/agents/dev-team-knuth.md
@@ -3,7 +3,7 @@ name: dev-team-knuth
 description: Quality auditor. Use to audit code for correctness gaps, missing test coverage, boundary conditions, and unproven assumptions. Read-only — identifies what is missing or unproven, does not write code or tests.
 tools: Read, Grep, Glob, Bash, Agent
 model: opus
-cross_model: # recommended when multi-model runtime available (ADR-023)
+cross_model: false # recommended when multi-model runtime available (ADR-023)
 memory: project
 ---
 

--- a/templates/agents/dev-team-szabo.md
+++ b/templates/agents/dev-team-szabo.md
@@ -3,7 +3,7 @@ name: dev-team-szabo
 description: Security auditor. Use to review code for vulnerabilities, audit auth flows, analyze attack surfaces, and assess dependency risks. Read-only — does not modify code.
 tools: Read, Grep, Glob, Bash, Agent
 model: opus
-cross_model: # recommended when multi-model runtime available (ADR-023)
+cross_model: false # recommended when multi-model runtime available (ADR-023)
 memory: project
 ---
 


### PR DESCRIPTION
## Summary
- `cross_model:` frontmatter field in 6 reviewer agent definitions (knuth, szabo, brooks in both `templates/agents/` and `.dev-team/agents/`) was empty (YAML null due to inline comment only)
- Changed to explicit `cross_model: false` to prevent misconfiguration if a runtime ever reads this field
- Addresses Copilot feedback originally raised on closed PR #220

## Files changed
- `templates/agents/dev-team-knuth.md`
- `templates/agents/dev-team-szabo.md`
- `templates/agents/dev-team-brooks.md`
- `.dev-team/agents/dev-team-knuth.md`
- `.dev-team/agents/dev-team-szabo.md`
- `.dev-team/agents/dev-team-brooks.md`

## Test plan
- [x] `npm test` passes (308/308)
- [x] Verified YAML frontmatter parses correctly with explicit `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)