### PR TITLE
fix: merge skill replies to Copilot threads, enforced on release PRs

### DIFF
--- a/.claude/skills/dev-team-merge/SKILL.md
+++ b/.claude/skills/dev-team-merge/SKILL.md
@@ -6,6 +6,13 @@ user_invocable: true
 
 Merge a pull request with full monitoring: $ARGUMENTS
 
+## Release PRs
+
+**Conway/release PRs MUST use this merge skill.** Release PRs (version bumps, changelog updates, release branches) require the same Copilot review handling and CI verification as any other PR — do not bypass this process for releases. When merging a release PR, pay extra attention to:
+- Changelog completeness (all PRs since last release are documented)
+- Version bump correctness (semver compliance)
+- No draft or WIP markers left in release notes
+
 ## Setup
 
 1. Determine the PR number:
@@ -40,8 +47,8 @@ gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews --jq '[.[] | selec
 ### 1b. Address Copilot findings
 
 ```bash
-# Inline comments
-gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | select(.user.login == "Copilot") | {id: .id, path: .path, line: .line, body: .body}'
+# Inline comments (include node_id for thread resolution)
+gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | select(.user.login == "Copilot") | {id: .id, node_id: .node_id, path: .path, line: .line, body: .body}'
 
 # Summary reviews
 gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews --jq '.[] | select(.user.login == "Copilot") | {id: .id, state: .state, body: .body}'
@@ -51,7 +58,16 @@ For each Copilot comment:
 1. Read the finding and assess: is it actionable?
 2. **Actionable** (bug, ambiguity, missing logic): fix in code, commit, push
 3. **Style/minor**: acknowledge but skip if not substantive
-4. After addressing all actionable findings, re-push and wait for CI to restart
+4. **Reply to the Copilot thread** explaining what was fixed (or why it was skipped). Use the inline comment reply API:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies -f body="Fixed: <brief explanation of the change>"
+   ```
+   Then resolve the thread so it no longer shows as outstanding:
+   ```bash
+   gh api graphql -f query='mutation { minimizeComment(input: {subjectId: "<node_id>", classifier: RESOLVED}) { minimizedComment { isMinimized } } }'
+   ```
+   To get the `node_id` for a comment, include it in the initial fetch (already updated above).
+5. After addressing all actionable findings, re-push and wait for CI to restart
 
 ### 1c. Verify no new Copilot comments after push
 

--- a/templates/agents/dev-team-conway.md
+++ b/templates/agents/dev-team-conway.md
@@ -36,6 +36,7 @@ You always check for:
 - **Breaking change documentation**: Every breaking change needs: what changed, why, and how to migrate. "Updated the API" is not documentation.
 - **Tag and branch hygiene**: Is the tag on the right commit? Is the release branch clean? Are there uncommitted changes?
 - **Dependency audit**: Are there known vulnerabilities in the dependency tree? Were any dependencies added or upgraded that could affect stability?
+- **Merge process**: Release PRs MUST use the `/dev-team:merge` skill for final merge. This ensures Copilot review comments are addressed and replied to, CI is verified, and auto-merge is set consistently. Do not merge release PRs manually or bypass the merge skill.
 
 ## Challenge style
 


### PR DESCRIPTION
## Summary

- **Step 1b thread replies**: After fixing code for each Copilot comment, the merge skill now replies to the thread explaining the fix, then resolves it via GraphQL `minimizeComment` mutation
- **Release PR enforcement**: Added guidance that Conway/release PRs must also use this merge skill — no manual merges for releases
- **Conway agent update**: Added merge process bullet to Conway's focus areas referencing `/dev-team:merge`

Closes #216

## Test plan

- [ ] Verify merge skill SKILL.md has Release PRs section and thread reply instructions in step 1b
- [ ] Verify Conway template references `/dev-team:merge` skill in focus areas
- [ ] Run `/dev-team:merge` on a PR with Copilot comments to validate thread reply flow

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>