### PR TITLE
fix: address unresolved Copilot feedback from PRs #225, #226

### DIFF
--- a/.dev-team/agent-memory/dev-team-beck/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-beck/MEMORY.md
@@ -19,13 +19,13 @@
 - **Last-verified**: 2026-03-24
 - **Context**: tests/unit/ covers individual modules (files, hooks, scan, skill-recommendations, create-agent, cli). tests/integration/ covers full install flows (fresh-project, idempotency, update). tests/scenarios/ covers end-to-end project types and orchestration.
 
-### [2026-03-24] 308 passing tests, 0 failures — test script lists files explicitly
+### [2026-03-24] 217 tests across 13 test files — test script lists files explicitly
 - **Type**: PATTERN [bootstrapped]
-- **Source**: npm test output
+- **Source**: npm test output + .dev-team/learnings.md
 - **Tags**: testing, count, ci
 - **Outcome**: pending-verification
 - **Last-verified**: 2026-03-24
-- **Context**: Tests run in ~9 seconds. New test files must be added to the explicit list in package.json scripts.test. CI runs tests on 3 OS (ubuntu, macos, windows) with Node 22.
+- **Context**: 217 test cases (per learnings.md benchmark). Tests run in ~9 seconds. New test files must be added to the explicit list in package.json scripts.test. CI runs tests on 3 OS (ubuntu, macos, windows) with Node 22.
 
 ### [2026-03-24] TDD enforced via hook — dev-team-tdd-enforce.js
 - **Type**: PATTERN [bootstrapped]

--- a/.dev-team/agent-memory/dev-team-borges/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-borges/MEMORY.md
@@ -19,13 +19,13 @@
 - **Last-verified**: 2026-03-24
 - **Context**: Tier 1 is .dev-team/learnings.md (shared facts, benchmarks, conventions). Tier 2 is .dev-team/agent-memory/*/MEMORY.md (agent-specific calibration). First 200 lines loaded into context. Formal decisions go to docs/adr/.
 
-### [2026-03-24] Quality benchmarks in learnings.md: 308 tests, 12 agents, 7 skills, 6 hooks
+### [2026-03-24] Quality benchmarks in learnings.md: 217 tests, 12 agents, 7 skills, 6 hooks
 - **Type**: PATTERN [bootstrapped]
 - **Source**: .dev-team/learnings.md analysis
 - **Tags**: benchmarks, accuracy
 - **Outcome**: pending-verification
 - **Last-verified**: 2026-03-24
-- **Context**: These benchmarks drift frequently. Borges should verify and update them at end of each task cycle. Current count confirmed: 308 tests passing as of 2026-03-24.
+- **Context**: These benchmarks drift frequently. Borges should verify and update them at end of each task cycle. Treat learnings.md as the source of truth for numeric benchmarks — avoid copying counts into agent memories without re-reading that file.
 
 ## System Improvement Log
 

--- a/.dev-team/agent-memory/dev-team-brooks/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-brooks/MEMORY.md
@@ -11,7 +11,7 @@
 - **Last-verified**: 2026-03-24
 - **Context**: Key ADRs: 001 (hooks over CLAUDE.md), 002 (zero deps), 005 (adversarial agents), 007 (oxc tooling), 019 (parallel review waves), 022 (agent proliferation governance with 15-agent soft cap). TypeScript 6 with NodeNext module resolution (ADR-021).
 
-### [2026-03-24] Module structure: src/ (8 modules) to dist/ with templates/ shipped separately
+### [2026-03-24] Module structure: src/ (9 modules) to dist/ with templates/ shipped separately
 - **Type**: PATTERN [bootstrapped]
 - **Source**: project structure analysis
 - **Tags**: architecture, modules, build

--- a/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
@@ -3,13 +3,13 @@
 
 ## Coverage Gaps Identified
 
-### [2026-03-24] 308 tests using Node.js built-in test runner across 3 tiers
+### [2026-03-24] 13 test files using Node.js built-in test runner across 3 tiers
 - **Type**: PATTERN [bootstrapped]
-- **Source**: package.json analysis
+- **Source**: package.json + project structure analysis
 - **Tags**: testing, coverage, test-runner
 - **Outcome**: pending-verification
 - **Last-verified**: 2026-03-24
-- **Context**: 6 unit tests, 3 integration tests, 4 scenario tests. Node.js `node --test` runner, no third-party test framework. Tests are pre-compiled JS (not TS).
+- **Context**: 6 unit test files, 3 integration test files, 4 scenario test files. Node.js `node --test` runner, no third-party test framework. Tests are pre-compiled JS (not TS). Actual test-case count is 217 (tracked in .dev-team/learnings.md).
 
 ### [2026-03-24] Test directory structure: tests/unit + tests/integration + tests/scenarios
 - **Type**: PATTERN [bootstrapped]

--- a/.dev-team/agent-memory/dev-team-szabo/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-szabo/MEMORY.md
@@ -11,13 +11,13 @@
 - **Last-verified**: 2026-03-24
 - **Context**: dev-team is a CLI installer that copies template files into target projects. No authentication system, no user data handling, no database, no HTTP server. Primary security concern is file system operations and template injection.
 
-### [2026-03-24] readFile() broad catch treats permission errors same as missing file
+### [2026-03-24] readFile() returns null for both missing and permission-denied files
 - **Type**: RISK [bootstrapped]
 - **Source**: .dev-team/learnings.md (known tech debt)
 - **Tags**: error-handling, file-system, tech-debt
 - **Outcome**: pending-verification
 - **Last-verified**: 2026-03-24
-- **Context**: src/files.ts readFile has a catch-all that conflates permission denied with file-not-found. Could mask security-relevant errors in target project file operations.
+- **Context**: src/files.ts readFile distinguishes ENOENT (missing file) from EACCES/EPERM (permission errors) and logs a warning on permission issues, but still returns null in both cases, which can mask security-relevant permission errors in target project file operations.
 
 ### [2026-03-24] Hook scripts execute in target project context
 - **Type**: PATTERN [bootstrapped]

--- a/.dev-team/agent-memory/dev-team-tufte/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-tufte/MEMORY.md
@@ -33,7 +33,7 @@
 - **Tags**: benchmarks, accuracy, learnings
 - **Outcome**: pending-verification
 - **Last-verified**: 2026-03-24
-- **Context**: learnings.md tracks test count (308), agent count (12), skill count (7), hook count (6). These drift as the project evolves. Tufte should flag when implementation changes affect these counts.
+- **Context**: learnings.md tracks test count (217), agent count (12), skill count (7), hook count (6). These drift as the project evolves. Tufte should flag when implementation changes affect these counts.
 
 ## Patterns to Watch For
 

--- a/.dev-team/learnings.md
+++ b/.dev-team/learnings.md
@@ -26,7 +26,7 @@
 
 ## Known Tech Debt
 
-- `readFile()` in `src/files.ts` has broad catch — treats permission errors same as missing file (Szabo finding, tracked).
+- `readFile()` in `src/files.ts` distinguishes ENOENT from EACCES/EPERM and logs a warning on permission errors, but still returns null in both cases — can mask security-relevant permission errors (Szabo finding, tracked).
 - `mergeClaudeMd` append-on-missing-END-marker can produce duplicate BEGIN markers on subsequent runs (Knuth finding, edge case).
 
 ## Quality Benchmarks
@@ -36,7 +36,7 @@
 - 7 skills: challenge, task, review, audit, security-status, merge, assess
 - 6 hooks: TDD enforce, safety guard, post-change review, pre-commit gate (blocking), pre-commit lint, watch list
 - 3 always-on reviewers: Szabo (security), Knuth (correctness), Brooks (architecture + quality attributes)
-- CI: 3 OS x 3 Node versions + lint + format + agent validation + hook validation.
+- CI: 3 OS (ubuntu, macos, windows) x Node 22 + lint + format + agent validation + hook validation.
 - Always run `npm run format` before committing new `.ts` files — oxfmt formatting is checked in CI.
 
 ### Learning capture metrics


### PR DESCRIPTION
## Summary

Audited all Copilot review comments across PRs #225 (7 comments), #226 (6 comments), #218 (1 comment), and #222 (3 comments). PRs #218 and #222 are still open (not merged), so their feedback is not applicable to main. Found **14 unaddressed findings** on current main from PRs #225 and #226:

- **Test count inconsistency**: Agent memories (Knuth, Beck, Borges, Tufte) referenced "308 tests" but learnings.md benchmark is 217. Reconciled all to 217 and clarified "test files" (13) vs "test cases" (217).
- **CI matrix description**: learnings.md said "3 OS x 3 Node versions" but CI uses Node 22 only. Fixed to "3 OS x Node 22".
- **readFile() tech debt description**: Described as "broad catch-all" in learnings.md and Szabo's memory, but the code actually distinguishes ENOENT from EACCES/EPERM with a warning log. Updated both descriptions.
- **Brooks module count**: Listed "src/ (8 modules)" but there are 9 .ts files. Fixed to 9.
- **cross_model: false in 6 agent files**: ADR-023 defines `cross_model` as a vendor-qualified string (e.g., `openai:o3`), not a boolean. Removed the field entirely from all 6 reviewer agent definitions (3 in `.dev-team/agents/`, 3 in `templates/agents/`).

### PR #218 and #222 (still open)
- PR #218: 1 Copilot comment about CI matrix — same issue fixed here on main.
- PR #222: 3 Copilot comments about parallelization terminology — PR is still open and not merged, so feedback applies to that branch, not main.

## Test plan
- [ ] Verify CI passes (no code changes, only docs/config)
- [ ] Verify agent frontmatter is still valid YAML after removing `cross_model` line
- [ ] Spot-check that learnings.md and agent memories are internally consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)