### PR TITLE
feat: add memory content guidance and reduce volatile benchmarks

### DIFF
--- a/.dev-team/agents/dev-team-beck.md
+++ b/.dev-team/agents/dev-team-beck.md
@@ -71,6 +71,20 @@ After completing work, write key learnings to your MEMORY.md:
 - Over-mocking patterns identified and refactored
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
 
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+
 ## Learnings Output (mandatory)
 
 After completing work, you MUST:

--- a/.dev-team/agents/dev-team-borges.md
+++ b/.dev-team/agents/dev-team-borges.md
@@ -66,6 +66,11 @@ Write entries to the appropriate agent's MEMORY.md using the structured format:
 - **Context**: One-sentence explanation of what happened and why it matters
 ```
 
+**Extraction filter — skip these:**
+- Entries that record specific numeric metrics derivable from the codebase (test counts, file counts, line counts)
+- Entries that merely restate what is in `package.json`, `tsconfig.json`, or other config files
+- Entries that duplicate existing ADRs or `.dev-team/learnings.md` entries
+
 **Extraction rules:**
 - Every accepted DEFECT becomes a memory entry for the reviewer who found it (reinforcement)
 - Every overruled finding becomes an OVERRULED entry for the reviewer (calibration)
@@ -102,6 +107,12 @@ When agent memory files are empty (only contain the template boilerplate), gener
 - **Beck**: test framework, test directory structure, coverage tools
 - **Conway**: version scheme, release workflow, changelog format
 - **Mori**: UI framework, component directories, accessibility tools
+
+**Seed content rules:**
+- Describe **patterns and conventions**, not counts or specific numbers
+- Do NOT include specific numeric metrics (test counts, ADR counts, agent counts) — these are volatile and create memory churn when they change
+- Focus on stable structural knowledge: framework choices, architectural patterns, security boundaries, naming conventions
+- If a fact can be derived by running a command or reading a config file, it does not belong in memory
 
 **Seed entries are marked** with `[bootstrapped]` in their Type field so agents know to verify and refine them:
 ```markdown

--- a/.dev-team/agents/dev-team-brooks.md
+++ b/.dev-team/agents/dev-team-brooks.md
@@ -124,3 +124,17 @@ After completing a review, write key learnings to your MEMORY.md:
 - Layer boundaries and where they are weakest
 - Quality attribute patterns observed (hot paths, complexity hotspots, scalability assumptions)
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)

--- a/.dev-team/agents/dev-team-conway.md
+++ b/.dev-team/agents/dev-team-conway.md
@@ -98,6 +98,20 @@ After completing work, write key learnings to your MEMORY.md:
 - Changelog formatting preferences
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
 
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+
 ## Learnings Output (mandatory)
 
 After completing work, you MUST:

--- a/.dev-team/agents/dev-team-deming.md
+++ b/.dev-team/agents/dev-team-deming.md
@@ -91,6 +91,20 @@ After completing work, write key learnings to your MEMORY.md:
 - Onboarding friction points identified
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
 
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+
 ## Learnings Output (mandatory)
 
 After completing work, you MUST:

--- a/.dev-team/agents/dev-team-hamilton.md
+++ b/.dev-team/agents/dev-team-hamilton.md
@@ -72,6 +72,20 @@ After completing work, write key learnings to your MEMORY.md:
 - Conventions the team has established for deployment and operations
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
 
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+
 ## Learnings Output (mandatory)
 
 After completing work, you MUST:

--- a/.dev-team/agents/dev-team-knuth.md
+++ b/.dev-team/agents/dev-team-knuth.md
@@ -74,3 +74,17 @@ After completing an audit, write key learnings to your MEMORY.md:
 - Boundary conditions that keep recurring
 - Counter-examples that exposed real bugs
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)

--- a/.dev-team/agents/dev-team-mori.md
+++ b/.dev-team/agents/dev-team-mori.md
@@ -70,6 +70,20 @@ After completing work, write key learnings to your MEMORY.md:
 - Component patterns the team prefers
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
 
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+
 ## Learnings Output (mandatory)
 
 After completing work, you MUST:

--- a/.dev-team/agents/dev-team-szabo.md
+++ b/.dev-team/agents/dev-team-szabo.md
@@ -74,3 +74,17 @@ After completing a review, write key learnings to your MEMORY.md:
 - Vulnerabilities found and remediated (watch for regressions)
 - Trust boundaries mapped
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)

--- a/.dev-team/agents/dev-team-tufte.md
+++ b/.dev-team/agents/dev-team-tufte.md
@@ -85,6 +85,20 @@ After completing work, write key learnings to your MEMORY.md:
 - Conventions the team has adopted for doc style and structure
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
 
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+
 ## Learnings Output (mandatory)
 
 After completing work, you MUST:

--- a/.dev-team/agents/dev-team-voss.md
+++ b/.dev-team/agents/dev-team-voss.md
@@ -70,6 +70,20 @@ After completing work, write key learnings to your MEMORY.md:
 - Conventions the team has established
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
 
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+
 ## Learnings Output (mandatory)
 
 After completing work, you MUST:

--- a/.dev-team/learnings.md
+++ b/.dev-team/learnings.md
@@ -31,16 +31,15 @@
 
 ## Quality Benchmarks
 
-- 306 tests total (was 117 at v0.3.0, was 273 before TS6 migration consolidated some)
-- 12 agents: Voss, Mori, Szabo, Knuth, Beck, Deming, Tufte, Brooks, Conway, Drucker, Borges, Hamilton
-- 5 framework skills: challenge, task, review, audit, assess
-- 6 hooks: TDD enforce, safety guard, post-change review, pre-commit gate (blocking), pre-commit lint, watch list
-- 3 always-on reviewers: Szabo (security), Knuth (correctness), Brooks (architecture + quality attributes)
+- Tests: `npm test` for current count. Three-tier structure: unit, integration, scenarios.
+- Agents: see `src/init.ts` ALL_AGENTS array for current roster. ADR-022 governs proliferation (soft cap 15).
+- Skills: see `templates/skills/` for current list. Framework skills ship with every install.
+- Hooks: see `templates/hooks/` for current list. 3 always-on reviewers: Szabo, Knuth, Brooks.
 - CI: 3 OS (ubuntu, macos, windows) x Node 22 + lint + format + agent validation + hook validation.
 - Always run `npm run format` before committing new `.ts` files — oxfmt formatting is checked in CI.
 
 ### Learning capture metrics
-- Non-empty agent memory files: 12 of 12 active agents (12 memory dirs, legacy dirs removed)
+- Non-empty agent memory files: all active agents have memory dirs
 - Last Borges run: not tracked yet (Borges spawning is now enforced via skill definitions)
 - Pre-commit gate: blocks commits without memory updates (override via `.dev-team/.memory-reviewed`)
 - All 10 implementing agents (Voss, Mori, Szabo, Knuth, Beck, Deming, Tufte, Brooks, Conway, Hamilton) have mandatory Learnings Output section

--- a/templates/agents/dev-team-beck.md
+++ b/templates/agents/dev-team-beck.md
@@ -71,6 +71,20 @@ After completing work, write key learnings to your MEMORY.md:
 - Over-mocking patterns identified and refactored
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
 
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+
 ## Learnings Output (mandatory)
 
 After completing work, you MUST:

--- a/templates/agents/dev-team-borges.md
+++ b/templates/agents/dev-team-borges.md
@@ -66,6 +66,11 @@ Write entries to the appropriate agent's MEMORY.md using the structured format:
 - **Context**: One-sentence explanation of what happened and why it matters
 ```
 
+**Extraction filter — skip these:**
+- Entries that record specific numeric metrics derivable from the codebase (test counts, file counts, line counts)
+- Entries that merely restate what is in `package.json`, `tsconfig.json`, or other config files
+- Entries that duplicate existing ADRs or `.dev-team/learnings.md` entries
+
 **Extraction rules:**
 - Every accepted DEFECT becomes a memory entry for the reviewer who found it (reinforcement)
 - Every overruled finding becomes an OVERRULED entry for the reviewer (calibration)
@@ -102,6 +107,12 @@ When agent memory files are empty (only contain the template boilerplate), gener
 - **Beck**: test framework, test directory structure, coverage tools
 - **Conway**: version scheme, release workflow, changelog format
 - **Mori**: UI framework, component directories, accessibility tools
+
+**Seed content rules:**
+- Describe **patterns and conventions**, not counts or specific numbers
+- Do NOT include specific numeric metrics (test counts, ADR counts, agent counts) — these are volatile and create memory churn when they change
+- Focus on stable structural knowledge: framework choices, architectural patterns, security boundaries, naming conventions
+- If a fact can be derived by running a command or reading a config file, it does not belong in memory
 
 **Seed entries are marked** with `[bootstrapped]` in their Type field so agents know to verify and refine them:
 ```markdown

--- a/templates/agents/dev-team-brooks.md
+++ b/templates/agents/dev-team-brooks.md
@@ -124,3 +124,17 @@ After completing a review, write key learnings to your MEMORY.md:
 - Layer boundaries and where they are weakest
 - Quality attribute patterns observed (hot paths, complexity hotspots, scalability assumptions)
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)

--- a/templates/agents/dev-team-conway.md
+++ b/templates/agents/dev-team-conway.md
@@ -99,6 +99,20 @@ After completing work, write key learnings to your MEMORY.md:
 - Changelog formatting preferences
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
 
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+
 ## Learnings Output (mandatory)
 
 After completing work, you MUST:

--- a/templates/agents/dev-team-deming.md
+++ b/templates/agents/dev-team-deming.md
@@ -91,6 +91,20 @@ After completing work, write key learnings to your MEMORY.md:
 - Onboarding friction points identified
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
 
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+
 ## Learnings Output (mandatory)
 
 After completing work, you MUST:

--- a/templates/agents/dev-team-hamilton.md
+++ b/templates/agents/dev-team-hamilton.md
@@ -72,6 +72,20 @@ After completing work, write key learnings to your MEMORY.md:
 - Conventions the team has established for deployment and operations
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
 
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+
 ## Learnings Output (mandatory)
 
 After completing work, you MUST:

--- a/templates/agents/dev-team-knuth.md
+++ b/templates/agents/dev-team-knuth.md
@@ -74,3 +74,17 @@ After completing an audit, write key learnings to your MEMORY.md:
 - Boundary conditions that keep recurring
 - Counter-examples that exposed real bugs
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)

--- a/templates/agents/dev-team-mori.md
+++ b/templates/agents/dev-team-mori.md
@@ -70,6 +70,20 @@ After completing work, write key learnings to your MEMORY.md:
 - Component patterns the team prefers
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
 
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+
 ## Learnings Output (mandatory)
 
 After completing work, you MUST:

--- a/templates/agents/dev-team-szabo.md
+++ b/templates/agents/dev-team-szabo.md
@@ -74,3 +74,17 @@ After completing a review, write key learnings to your MEMORY.md:
 - Vulnerabilities found and remediated (watch for regressions)
 - Trust boundaries mapped
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
+
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)

--- a/templates/agents/dev-team-tufte.md
+++ b/templates/agents/dev-team-tufte.md
@@ -85,6 +85,20 @@ After completing work, write key learnings to your MEMORY.md:
 - Conventions the team has adopted for doc style and structure
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
 
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+
 ## Learnings Output (mandatory)
 
 After completing work, you MUST:

--- a/templates/agents/dev-team-voss.md
+++ b/templates/agents/dev-team-voss.md
@@ -70,6 +70,20 @@ After completing work, write key learnings to your MEMORY.md:
 - Conventions the team has established
 - Challenges you raised that were accepted (reinforce) or overruled (calibrate)
 
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.dev-team/learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+
 ## Learnings Output (mandatory)
 
 After completing work, you MUST:


### PR DESCRIPTION
## Summary
- All implementing agent templates now have "What belongs in memory" guidance in the Learning section
- Borges cold start seed generation and extraction rules filter out volatile numeric metrics
- learnings.md Quality Benchmarks section replaced counts with convention references and commands
- Agents should record patterns/calibration/conventions, not derivable counts that create churn

Closes #256

## Test plan
- [ ] All tests pass
- [ ] Agent definitions have "What belongs in memory" section
- [ ] Borges has extraction filter and seed content rules
- [ ] learnings.md no longer contains specific numeric counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)