### PR TITLE
fix: address Copilot review findings and Windows compatibility

### DIFF
--- a/tests/integration/update.test.js
+++ b/tests/integration/update.test.js
@@ -485,13 +485,19 @@ describe("dev-team update", () => {
     const testSkill = skillDirs[0];
     const symlinkPath = path.join(claudeSkillsDir, testSkill);
 
-    // Create a broken symlink: remove target, recreate symlink pointing to nonexistent path
+    // Create a broken symlink: point to a real directory first, then remove the target.
+    // On Windows, junctions require the target to exist at creation time, so we cannot
+    // create a junction directly to a nonexistent path.
     fs.unlinkSync(symlinkPath);
+    const tempTarget = path.join(tmpDir, "temp-symlink-target", testSkill);
+    fs.mkdirSync(tempTarget, { recursive: true });
     fs.symlinkSync(
-      "../nonexistent-target/" + testSkill,
+      path.relative(claudeSkillsDir, tempTarget),
       symlinkPath,
       process.platform === "win32" ? "junction" : "dir",
     );
+    // Now break the symlink by removing the target directory
+    fs.rmSync(path.join(tmpDir, "temp-symlink-target"), { recursive: true, force: true });
 
     // Verify it's broken (lstat succeeds but existsSync follows symlink and fails)
     assert.ok(fs.lstatSync(symlinkPath).isSymbolicLink(), "should be a symlink");


### PR DESCRIPTION
## Summary

Addresses all 5 Copilot review findings from PR #267 and fixes the Windows CI test failure.

Closes #269

## Changes

- `src/init.ts` — Guard preserves any non-symlink path (not just dirs with SKILL.md). Windows junction fallback on EPERM/EACCES.
- `src/update.ts` — Same guard fix. `Object.hasOwn()` instead of `in` operator. Windows junction fallback.
- `tests/integration/update.test.js` — Explicit symlink type (`junction` on Windows, `dir` elsewhere) in broken symlink test.
- `tests/unit/hooks.test.js` — Fixed flaky `blocks commit when format:check fails independently` test: increased timeout, check combined stdout+stderr.

## Test plan

- [x] 312 tests pass locally (`npm test`)
- [ ] Windows CI passes (the main fix target)
- [ ] Symlink guard preserves real directories without SKILL.md
- [ ] Junction fallback works on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)