### PR TITLE
fix: standardize Learnings Output section across all agents

### DIFF
--- a/templates/agents/dev-team-borges.md
+++ b/templates/agents/dev-team-borges.md
@@ -230,3 +230,14 @@ After completing a review, write key learnings to your MEMORY.md:
 - System improvement recommendations that were accepted or deferred
 - Cross-agent contradictions identified and resolved
 - Memory compression strategies that worked well
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST:
+1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-borges/MEMORY.md`) with key learnings from this task. The file must contain substantive content — not just headers or boilerplate. Include memory maintenance patterns, system improvements, coherence findings, and calibration notes.
+2. **Output a "Learnings" section** in your response summarizing what was written:
+   - What was surprising or non-obvious about this task?
+   - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+   - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
+
+If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].

--- a/templates/agents/dev-team-brooks.md
+++ b/templates/agents/dev-team-brooks.md
@@ -138,3 +138,14 @@ After completing a review, write key learnings to your MEMORY.md:
 - Version numbers that change frequently
 - Information already captured in ADRs or `.dev-team/learnings.md`
 - Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST:
+1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-brooks/MEMORY.md`) with key learnings from this task. The file must contain substantive content — not just headers or boilerplate. Include architectural patterns, ADR compliance, dependency directions, quality attributes, and calibration notes.
+2. **Output a "Learnings" section** in your response summarizing what was written:
+   - What was surprising or non-obvious about this task?
+   - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+   - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
+
+If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].

--- a/templates/agents/dev-team-drucker.md
+++ b/templates/agents/dev-team-drucker.md
@@ -311,3 +311,14 @@ After completing an orchestration, write key learnings to your MEMORY.md:
 - Patterns in task types that map to specific agents
 - Conflict resolutions and their outcomes
 - Iteration counts and convergence patterns
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST:
+1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-drucker/MEMORY.md`) with key learnings from this task. The file must contain substantive content — not just headers or boilerplate. Include delegation patterns, conflict resolutions, convergence patterns, and calibration notes.
+2. **Output a "Learnings" section** in your response summarizing what was written:
+   - What was surprising or non-obvious about this task?
+   - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+   - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
+
+If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].

--- a/templates/agents/dev-team-knuth.md
+++ b/templates/agents/dev-team-knuth.md
@@ -88,3 +88,14 @@ After completing an audit, write key learnings to your MEMORY.md:
 - Version numbers that change frequently
 - Information already captured in ADRs or `.dev-team/learnings.md`
 - Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST:
+1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-knuth/MEMORY.md`) with key learnings from this task. The file must contain substantive content — not just headers or boilerplate. Include failure modes, coverage gaps, boundary conditions, and calibration notes.
+2. **Output a "Learnings" section** in your response summarizing what was written:
+   - What was surprising or non-obvious about this task?
+   - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+   - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
+
+If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].

--- a/templates/agents/dev-team-rams.md
+++ b/templates/agents/dev-team-rams.md
@@ -86,5 +86,10 @@ Write status to `.dev-team/agent-status/dev-team-rams.json` at each phase bounda
 ## Learnings Output (mandatory)
 
 After completing work, you MUST:
-1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-rams/MEMORY.md`) with key learnings.
-2. **Output a "Learnings" section** in your response.
+1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-rams/MEMORY.md`) with key learnings from this task. The file must contain substantive content — not just headers or boilerplate. Include design system compliance, token usage, spacing consistency, component API patterns, and calibration notes.
+2. **Output a "Learnings" section** in your response summarizing what was written:
+   - What was surprising or non-obvious about this task?
+   - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+   - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
+
+If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].

--- a/templates/agents/dev-team-szabo.md
+++ b/templates/agents/dev-team-szabo.md
@@ -88,3 +88,14 @@ After completing a review, write key learnings to your MEMORY.md:
 - Version numbers that change frequently
 - Information already captured in ADRs or `.dev-team/learnings.md`
 - Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST:
+1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-szabo/MEMORY.md`) with key learnings from this task. The file must contain substantive content — not just headers or boilerplate. Include attack surfaces, security decisions, vulnerabilities found, trust boundaries, and calibration notes.
+2. **Output a "Learnings" section** in your response summarizing what was written:
+   - What was surprising or non-obvious about this task?
+   - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+   - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
+
+If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].

--- a/templates/agents/dev-team-turing.md
+++ b/templates/agents/dev-team-turing.md
@@ -91,7 +91,10 @@ Write status to `.dev-team/agent-status/dev-team-turing.json` at each phase boun
 ## Learnings Output (mandatory)
 
 After completing work, you MUST:
-1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-turing/MEMORY.md`) with key learnings. Include: research topics investigated, quality of sources found, recommendations that were accepted/rejected, and calibration notes.
-2. **Output a "Learnings" section** in your response.
+1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-turing/MEMORY.md`) with key learnings from this task. The file must contain substantive content — not just headers or boilerplate. Include research topics investigated, quality of sources found, recommendations that were accepted/rejected, and calibration notes.
+2. **Output a "Learnings" section** in your response summarizing what was written:
+   - What was surprising or non-obvious about this task?
+   - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+   - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
 
 If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].


### PR DESCRIPTION
## Summary
- Add mandatory Learnings Output section to Szabo, Knuth, Brooks, Borges, and Drucker
- Upgrade shorter versions in Turing and Rams to full format with domain-specific content
- All 14 agents now have consistent enforcement language for MEMORY.md writes

Closes #274

## Test plan
- [x] All 312 tests pass
- [ ] Verify agents produce MEMORY.md entries with substantive content in next task cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)