### PR TITLE
Promote Conway milestone closure to shared learnings

### DIFF
--- a/.dev-team/agent-memory/dev-team-conway/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-conway/MEMORY.md
@@ -70,12 +70,10 @@
 - **Context**: The MIGRATIONS array in update.ts supports agentRenames (v0.4.0) and skillRemovals (v1.0.0). When `dev-team update` detects the user's installed version is older, it runs all applicable migrations. Added skillRemovals to clean up legacy workflow skill dirs.
 
 ### [2026-03-25] Close milestone after release PR creation
-- **Type**: PATTERN [verified]
-- **Source**: v1.1.1 release — team learnings require milestone closure as part of release process
+- **Type**: CROSS-REF
 - **Tags**: release, milestone, process
-- **Outcome**: verified
 - **Last-verified**: 2026-03-25
-- **Context**: After creating the release PR, close the corresponding GitHub milestone (e.g., v1.1.1). Use `gh api repos/{owner}/{repo}/milestones/{number} -X PATCH -f state=closed`. This is part of the standard release checklist.
+- **Context**: See shared learnings for milestone closure process.
 
 ### [2026-03-25] Patch release process — streamlined for bug-fix-only releases
 - **Type**: PATTERN [verified]

--- a/.dev-team/learnings.md
+++ b/.dev-team/learnings.md
@@ -17,6 +17,7 @@
 - **Follow through to completion without prompting.** When auto-merge is set or CI is pending, monitor and complete the next step (tag, release, cleanup) without waiting for the user to ask "is it done yet?"
 - **When creating a PR for a tracked issue, link it in the PR body** (e.g., `Closes #NNN`). This lets the platform auto-close the issue on merge. Agents should include this when they know the issue number.
 - Hooks over CLAUDE.md for enforcement (ADR-001). If agents keep flagging the same pattern, it should be a hook.
+- **Close the GitHub milestone after creating the release PR.** Use `gh api repos/{owner}/{repo}/milestones/{number} -X PATCH -f state=closed`.
 - **Improvements must be project-agnostic and target `templates/`.** Never modify `.dev-team/` directly for improvements — those files get overwritten by `dev-team update`. All improvements go into `templates/` and ship in future versions. Project-specific conventions stay in local learnings only.
 - **Dogfooding is the product loop.** Using dev-team on dev-team surfaces friction → `/dev-team:assess` captures patterns → issues target `templates/` → next release improves the tool for everyone. Every session is a test run.
 


### PR DESCRIPTION
## Summary
- Promoted Conway's "close milestone after release PR creation" entry from agent memory to shared team learnings (`Process` section)
- Replaced the original Conway MEMORY.md entry with a cross-reference to shared learnings to avoid duplication

Closes #287

## Test plan
- [ ] Verify `.dev-team/learnings.md` stays under 200 lines
- [ ] Verify Conway's MEMORY.md cross-reference is correctly formatted
- [ ] Confirm no other files were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)