### PR TITLE
fix: rename /dev-team:assess to /dev-team:retro

### DIFF
--- a/.claude/skills/dev-team-retro
+++ b/.claude/skills/dev-team-retro
@@ -1,0 +1,1 @@
+../../.dev-team/skills/dev-team-retro

--- a/.dev-team/agent-memory/dev-team-borges/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-borges/MEMORY.md
@@ -27,7 +27,7 @@
 - **Tags**: metrics, calibration, baseline
 - **Outcome**: verified
 - **Last-verified**: 2026-03-25
-- **Context**: First real entry in `.dev-team/metrics.md`. Establishes baseline: 0% overrule rate, 100% DEFECT fix rate, 50% advisory defer rate. Future `/dev-team:assess` runs can now trend these numbers. Knuth was sole reviewer across all 4 branches; Deming sole implementer.
+- **Context**: First real entry in `.dev-team/metrics.md`. Establishes baseline: 0% overrule rate, 100% DEFECT fix rate, 50% advisory defer rate. Future `/dev-team:retro` runs can now trend these numbers. Knuth was sole reviewer across all 4 branches; Deming sole implementer.
 
 ### [2026-03-25] Vocabulary alignment is a cross-agent coherence risk
 - **Type**: PATTERN [verified]
@@ -41,4 +41,4 @@
 <!-- Recommendations accepted/deferred — tunes what to flag over time -->
 
 ### [2026-03-25] v1.2.0 extraction — high defer rate on advisory findings
-- Knuth's 50% advisory defer rate (7/14) is not a quality problem — deferred items were legitimate follow-ups outside the PR scope. But it signals that `/dev-team:assess` should track defer-to-issue conversion (are deferred findings actually becoming issues?).
+- Knuth's 50% advisory defer rate (7/14) is not a quality problem — deferred items were legitimate follow-ups outside the PR scope. But it signals that `/dev-team:retro` should track defer-to-issue conversion (are deferred findings actually becoming issues?).

--- a/.dev-team/learnings.md
+++ b/.dev-team/learnings.md
@@ -20,7 +20,7 @@
 - **Every deferred finding must become a tracked GitHub issue.** When deferring a review or Copilot finding, create the issue immediately with origin (PR, reviewer), the finding, and assessment context. "Worth considering in a follow-up" without a tracked issue is not acceptable.
 - **Close the GitHub milestone after creating the release PR.** Use `gh api repos/{owner}/{repo}/milestones/{number} -X PATCH -f state=closed`.
 - **Improvements must be project-agnostic and target `templates/`.** Never modify `.dev-team/` directly for improvements — those files get overwritten by `dev-team update`. All improvements go into `templates/` and ship in future versions. Project-specific conventions stay in local learnings only.
-- **Dogfooding is the product loop.** Using dev-team on dev-team surfaces friction → `/dev-team:assess` captures patterns → issues target `templates/` → next release improves the tool for everyone. Every session is a test run.
+- **Dogfooding is the product loop.** Using dev-team on dev-team surfaces friction → `/dev-team:retro` captures patterns → issues target `templates/` → next release improves the tool for everyone. Every session is a test run.
 
 ## Known Tech Debt
 

--- a/.dev-team/metrics.md
+++ b/.dev-team/metrics.md
@@ -1,7 +1,7 @@
 # Agent Calibration Metrics
 <!-- Appendable log of per-task agent performance metrics. -->
 <!-- Borges records an entry after each task cycle. -->
-<!-- Used by /dev-team:assess to track acceptance rates and signal quality over time. -->
+<!-- Used by /dev-team:retro to track acceptance rates and signal quality over time. -->
 
 ## Format
 <!-- Each entry follows this structure:

--- a/.dev-team/skills/dev-team-retro/SKILL.md
+++ b/.dev-team/skills/dev-team-retro/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dev-team:assess
+name: dev-team:retro
 description: Audit the health of your project's dev-team knowledge base — learnings, agent memory, and CLAUDE.md. Finds stale entries, contradictions, enforcement gaps, and promotion opportunities. Use periodically or after major changes.
 ---
 
@@ -184,4 +184,4 @@ After the health report is delivered:
 - **After major refactors** — code changes may invalidate learnings
 - **Before onboarding** — ensure the knowledge base is accurate for new team members
 - **After resolving many review findings** — learnings and memory may need cleanup
-- **On request** — `/dev-team:assess`
+- **On request** — `/dev-team:retro`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ For non-trivial work: explore the area first, then implement, then review.
 - **Rams** — auto-flagged when frontend/UI component files change (same trigger as Mori). Gracefully no-ops when no design system is detected.
 
 **End-of-workflow agents:**
-- **Borges** — mandatory at end of every `/dev-team:task`, `/dev-team:review`, `/dev-team:audit`, and `/dev-team:assess`. Extracts structured memory entries, reviews cross-agent coherence, and identifies system improvement opportunities.
+- **Borges** — mandatory at end of every `/dev-team:task`, `/dev-team:review`, `/dev-team:audit`, and `/dev-team:retro`. Extracts structured memory entries, reviews cross-agent coherence, and identifies system improvement opportunities.
 
 **Orchestration:**
 - **Drucker** — delegates tasks to the right implementing agent and spawns reviewers. Szabo, Knuth, and Brooks review all code changes.
@@ -111,7 +111,7 @@ Do NOT skip this. Do NOT treat hook output as optional. If you believe a review 
 - `/dev-team:task` — start an iterative task loop with adversarial review gates
 - `/dev-team:review` — orchestrated multi-agent parallel review of changes
 - `/dev-team:audit` — full codebase security + quality + tooling audit
-- `/dev-team:assess` — audit knowledge base health (learnings, agent memory, CLAUDE.md)
+- `/dev-team:retro` — audit knowledge base health (learnings, agent memory, CLAUDE.md)
 
 ### Project-specific customization
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ graph TB
         S2["/dev-team:review"]
         S3["/dev-team:audit"]
         S4["/dev-team:challenge"]
-        S5["/dev-team:assess"]
+        S5["/dev-team:retro"]
     end
 
     subgraph Lead["Orchestrator"]
@@ -146,7 +146,7 @@ All hooks are Node.js scripts — work on macOS, Linux, and Windows.
 | `/dev-team:review` | Parallel multi-agent review — spawns agents based on changed file patterns |
 | `/dev-team:audit` | Full codebase scan — Szabo (security) + Knuth (quality) + Deming (tooling) |
 | `/dev-team:challenge` | Critical examination of a proposal or design decision |
-| `/dev-team:assess` | Audit knowledge base health — learnings, agent memory, CLAUDE.md accuracy |
+| `/dev-team:retro` | Audit knowledge base health — learnings, agent memory, CLAUDE.md accuracy |
 
 ## Step-by-step usage guide
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -43,7 +43,7 @@ For non-trivial work: explore the area first, then implement, then review.
 - **Rams** — auto-flagged when frontend/UI component files change (same trigger as Mori). Gracefully no-ops when no design system is detected.
 
 **End-of-workflow agents:**
-- **Borges** — mandatory at end of every `/dev-team:task`, `/dev-team:review`, `/dev-team:audit`, and `/dev-team:assess`. Extracts structured memory entries, reviews cross-agent coherence, and identifies system improvement opportunities.
+- **Borges** — mandatory at end of every `/dev-team:task`, `/dev-team:review`, `/dev-team:audit`, and `/dev-team:retro`. Extracts structured memory entries, reviews cross-agent coherence, and identifies system improvement opportunities.
 
 **Orchestration:**
 - **Drucker** — delegates tasks to the right implementing agent and spawns reviewers. Szabo, Knuth, and Brooks review all code changes.
@@ -76,7 +76,7 @@ Do NOT skip this. Do NOT treat hook output as optional. If you believe a review 
 - `/dev-team:task` — start an iterative task loop with adversarial review gates
 - `/dev-team:review` — orchestrated multi-agent parallel review of changes
 - `/dev-team:audit` — full codebase security + quality + tooling audit
-- `/dev-team:assess` — audit knowledge base health (learnings, agent memory, CLAUDE.md)
+- `/dev-team:retro` — audit knowledge base health (learnings, agent memory, CLAUDE.md)
 
 ### Project-specific customization
 

--- a/templates/dev-team-metrics.md
+++ b/templates/dev-team-metrics.md
@@ -1,7 +1,7 @@
 # Agent Calibration Metrics
 <!-- Appendable log of per-task agent performance metrics. -->
 <!-- Borges records an entry after each task cycle. -->
-<!-- Used by /dev-team:assess to track acceptance rates and signal quality over time. -->
+<!-- Used by /dev-team:retro to track acceptance rates and signal quality over time. -->
 
 ## Format
 <!-- Each entry follows this structure:

--- a/templates/skills/dev-team-retro/SKILL.md
+++ b/templates/skills/dev-team-retro/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dev-team:assess
+name: dev-team:retro
 description: Audit the health of your project's dev-team knowledge base — learnings, agent memory, and CLAUDE.md. Finds stale entries, contradictions, enforcement gaps, and promotion opportunities. Use periodically or after major changes.
 ---
 
@@ -192,4 +192,4 @@ After the health report is delivered:
 - **After major refactors** — code changes may invalidate learnings
 - **Before onboarding** — ensure the knowledge base is accurate for new team members
 - **After resolving many review findings** — learnings and memory may need cleanup
-- **On request** — `/dev-team:assess`
+- **On request** — `/dev-team:retro`

--- a/tests/integration/fresh-project.test.js
+++ b/tests/integration/fresh-project.test.js
@@ -50,7 +50,7 @@ describe("fresh project installation", () => {
     );
     assert.ok(fs.existsSync(path.join(tmpDir, ".dev-team", "skills", "dev-team-task", "SKILL.md")));
     assert.ok(
-      fs.existsSync(path.join(tmpDir, ".dev-team", "skills", "dev-team-assess", "SKILL.md")),
+      fs.existsSync(path.join(tmpDir, ".dev-team", "skills", "dev-team-retro", "SKILL.md")),
     );
     // Memory
     assert.ok(


### PR DESCRIPTION
## Summary
- Renames the `assess` skill to `retro` across the entire codebase
- Directory renames: `templates/skills/dev-team-assess/` and `.dev-team/skills/dev-team-assess/` to `dev-team-retro`
- Updates all references in CLAUDE.md (root + template), README.md, SKILL.md frontmatter, metrics template, test files, learnings, and agent memory

Closes #285

## Test plan
- [x] All 317 tests pass (`npm test`)
- [x] Integration test updated to check for `dev-team-retro` directory
- [x] `git mv` preserves file history
- [x] Grep confirms no remaining `dev-team:assess` or `dev-team-assess` references (CHANGELOG entries are historical records, left as-is)