### PR TITLE
feat: add agent-teams-guide hook for TeamCreate + worktree enforcement

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -121,6 +121,11 @@ const QUALITY_HOOKS: HookDefinition[] = [
     description: "Run lint + format checks before git commit",
   },
   {
+    label: "Agent teams guide",
+    file: "dev-team-agent-teams-guide.js",
+    description: "Advisory guidance for agent team isolation patterns",
+  },
+  {
     label: "Watch list",
     file: "dev-team-watch-list.js",
     description: "Auto-spawn agents when file patterns match (configurable)",

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -56,7 +56,12 @@ Agents challenge each other using classified findings:
 
 ### Parallel execution
 
-When working on multiple independent issues, use agent teams or worktree subagents to run parallel agents on separate branches. Drucker coordinates the review wave after all implementations complete.
+When working on multiple independent issues, combine agent teams with worktree isolation:
+
+- **Implementing agents** must use both `team_name` and `isolation: "worktree"` to prevent branch conflicts between parallel teammates.
+- **Review/read-only agents** should assess whether they need access to an implementer's worktree (to run tests or read changed files in context), or should work in their own isolation for independent analysis.
+
+Drucker coordinates the review wave after all implementations complete.
 
 > **Note:** If your project's workflow section (above the `dev-team:begin` marker) already designates the main conversation loop as the team lead, do not spawn a separate Drucker subagent — the main loop IS Drucker. Otherwise, `@dev-team-drucker` can be used as a subagent for delegation.
 

--- a/templates/hooks/dev-team-agent-teams-guide.js
+++ b/templates/hooks/dev-team-agent-teams-guide.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+/**
+ * dev-team-agent-teams-guide.js
+ * PreToolUse hook on Agent.
+ *
+ * Advisory guidance for agent team isolation patterns.
+ * Always exits 0 (never blocks) — prints reminders to stderr.
+ *
+ * Conditions:
+ * 1. Implementing agent with team_name but no worktree isolation →
+ *    remind to add isolation: "worktree"
+ * 2. Agent with worktree isolation but no team_name (when agentTeams enabled) →
+ *    suggest using TeamCreate for coordination
+ * 3. Read-only agent spawned →
+ *    remind to consider whether it needs the implementer's worktree
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || "{}");
+} catch {
+  // Malformed input — advisory hook, just exit cleanly
+  process.exit(0);
+}
+
+const toolInput = input.tool_input || {};
+const prompt = (toolInput.prompt || "").toLowerCase();
+const teamName = toolInput.team_name || "";
+const agentName = toolInput.name || "";
+const isolation = toolInput.isolation || "";
+const subagentType = toolInput.subagent_type || "";
+
+// Detect read-only agents by name or prompt keywords
+const READ_ONLY_AGENTS = [
+  "szabo",
+  "knuth",
+  "brooks",
+  "borges",
+  "tufte",
+  "turing",
+  "rams",
+  "conway",
+  "deming",
+];
+
+const agentNameLower = agentName.toLowerCase();
+const isReadOnly =
+  READ_ONLY_AGENTS.some((a) => agentNameLower.includes(a) || prompt.includes(`@dev-team-${a}`)) ||
+  subagentType === "read-only" ||
+  prompt.includes("review") ||
+  prompt.includes("audit");
+
+// Implementing agents: have team_name but no worktree isolation
+if (teamName && !isolation && !isReadOnly) {
+  console.error(
+    `[dev-team agent-teams-guide] Advisory: implementing teammate "${agentName || "(unnamed)"}" has team_name but no isolation: "worktree". ` +
+      `Add isolation: "worktree" to prevent branch conflicts between parallel teammates.`,
+  );
+}
+
+// Worktree isolation without team coordination (when agent teams are available)
+if (isolation === "worktree" && !teamName) {
+  let agentTeamsEnabled = false;
+  try {
+    const configPath = path.join(process.cwd(), ".dev-team", "config.json");
+    const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    agentTeamsEnabled = !!config.agentTeams;
+  } catch {
+    // No config or parse error — skip this check
+  }
+
+  if (agentTeamsEnabled) {
+    console.error(
+      `[dev-team agent-teams-guide] Advisory: agent "${agentName || "(unnamed)"}" uses worktree isolation without a team_name. ` +
+        `Consider using TeamCreate for coordinated parallel work — it provides progress tracking and message passing between teammates.`,
+    );
+  }
+}
+
+// Read-only agent reminder
+if (isReadOnly && teamName) {
+  console.error(
+    `[dev-team agent-teams-guide] Advisory: read-only agent "${agentName || "(unnamed)"}" spawned as teammate. ` +
+      `Consider whether it needs access to an implementer's worktree (to run tests or read changed files in context), ` +
+      `or should work in its own isolation for independent analysis.`,
+  );
+}
+
+process.exit(0);

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -32,6 +32,15 @@
             "command": "node .dev-team/hooks/dev-team-pre-commit-lint.js"
           }
         ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .dev-team/hooks/dev-team-agent-teams-guide.js"
+          }
+        ]
       }
     ],
     "TaskCompleted": [

--- a/tests/scenarios/node-project.test.js
+++ b/tests/scenarios/node-project.test.js
@@ -56,7 +56,7 @@ describe("Node.js project scenario", () => {
 
     // Hooks installed in .dev-team/
     const hooks = fs.readdirSync(path.join(tmpDir, ".dev-team", "hooks"));
-    assert.equal(hooks.length, 6);
+    assert.equal(hooks.length, 7);
 
     // Existing CLAUDE.md preserved
     const claudeMd = fs.readFileSync(path.join(tmpDir, "CLAUDE.md"), "utf-8");

--- a/tests/unit/hooks.test.js
+++ b/tests/unit/hooks.test.js
@@ -1571,3 +1571,154 @@ describe("dev-team-watch-list", () => {
     );
   });
 });
+
+// ─── Agent Teams Guide ──────────────────────────────────────────────────────
+
+describe("dev-team-agent-teams-guide", () => {
+  const hook = "dev-team-agent-teams-guide.js";
+  let tmpDir;
+  let originalCwd;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dev-team-agent-guide-"));
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+    fs.mkdirSync(path.join(tmpDir, ".dev-team"), { recursive: true });
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function runGuideHook(toolInput, cwd) {
+    const { spawnSync } = require("child_process");
+    const input = JSON.stringify({ tool_input: toolInput });
+    const result = spawnSync(process.execPath, [path.join(HOOKS_DIR, hook), input], {
+      encoding: "utf-8",
+      timeout: 5000,
+      cwd: cwd || tmpDir,
+    });
+    return { code: result.status, stdout: result.stdout || "", stderr: result.stderr || "" };
+  }
+
+  it("always exits 0 (advisory only)", () => {
+    const result = runGuideHook({
+      team_name: "impl",
+      name: "builder",
+      prompt: "implement feature",
+    });
+    assert.equal(result.code, 0);
+  });
+
+  it("warns when implementing agent has team_name but no isolation", () => {
+    const result = runGuideHook({
+      team_name: "impl-team",
+      name: "builder",
+      prompt: "implement the login feature",
+    });
+    assert.equal(result.code, 0);
+    assert.ok(result.stderr.includes("isolation"), "should mention isolation in advisory");
+  });
+
+  it("does not warn when implementing agent has both team_name and worktree isolation", () => {
+    const result = runGuideHook({
+      team_name: "impl-team",
+      name: "builder",
+      isolation: "worktree",
+      prompt: "implement the login feature",
+    });
+    assert.equal(result.code, 0);
+    assert.ok(!result.stderr.includes('isolation: "worktree"'), "should not warn about isolation");
+  });
+
+  it("suggests TeamCreate when worktree used without team_name and agentTeams enabled", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".dev-team", "config.json"),
+      JSON.stringify({ agentTeams: true }),
+    );
+    const result = runGuideHook({
+      isolation: "worktree",
+      name: "builder",
+      prompt: "implement feature",
+    });
+    assert.equal(result.code, 0);
+    assert.ok(result.stderr.includes("TeamCreate"), "should suggest TeamCreate");
+  });
+
+  it("does not suggest TeamCreate when agentTeams is not enabled", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".dev-team", "config.json"),
+      JSON.stringify({ agentTeams: false }),
+    );
+    const result = runGuideHook({
+      isolation: "worktree",
+      name: "builder",
+      prompt: "implement feature",
+    });
+    assert.equal(result.code, 0);
+    assert.ok(!result.stderr.includes("TeamCreate"), "should not suggest TeamCreate");
+  });
+
+  it("reminds about read-only agent worktree access when spawned as teammate", () => {
+    const result = runGuideHook({
+      team_name: "review-team",
+      name: "knuth-reviewer",
+      prompt: "review the changes",
+    });
+    assert.equal(result.code, 0);
+    assert.ok(
+      result.stderr.includes("read-only") || result.stderr.includes("worktree"),
+      "should mention worktree consideration for read-only agent",
+    );
+  });
+
+  it("does not warn for read-only agent without team_name", () => {
+    const result = runGuideHook({
+      name: "szabo-security",
+      subagent_type: "read-only",
+      prompt: "audit security",
+    });
+    assert.equal(result.code, 0);
+    assert.ok(!result.stderr.includes("read-only agent"), "should not warn without team_name");
+  });
+
+  it("does not warn for implementing agent with team_name but detected as read-only", () => {
+    // Knuth is a known read-only agent — should not get the "missing isolation" warning
+    const result = runGuideHook({
+      team_name: "review-team",
+      name: "knuth",
+      prompt: "review quality",
+    });
+    assert.equal(result.code, 0);
+    assert.ok(
+      !result.stderr.includes("Add isolation"),
+      "should not tell read-only agent to add worktree isolation",
+    );
+  });
+
+  it("exits 0 on malformed input", () => {
+    try {
+      const stdout = execFileSync(process.execPath, [path.join(HOOKS_DIR, hook), "not-json"], {
+        encoding: "utf-8",
+        timeout: 5000,
+        cwd: tmpDir,
+      });
+      // If it doesn't throw, it exited 0
+      assert.ok(true);
+    } catch (err) {
+      assert.fail(`Should exit 0 on malformed input, got exit ${err.status}`);
+    }
+  });
+
+  it("exits 0 with no config file for worktree-without-team check", () => {
+    const result = runGuideHook({
+      isolation: "worktree",
+      name: "builder",
+      prompt: "implement feature",
+    });
+    assert.equal(result.code, 0);
+    // Without config, should not suggest TeamCreate
+    assert.ok(!result.stderr.includes("TeamCreate"));
+  });
+});


### PR DESCRIPTION
## Summary
- New advisory PreToolUse hook (`dev-team-agent-teams-guide.js`) on the Agent tool that guides proper isolation patterns for parallel work
- Three conditions checked: implementing agents missing worktree isolation, worktree without TeamCreate coordination, and read-only agent worktree access considerations
- Updated template CLAUDE.md parallel execution section to describe the combined TeamCreate + worktree pattern
- Hook registered in `init.ts` and `settings.json` template

Closes #294

## Test plan
- [x] 10 new unit tests covering all advisory conditions, edge cases, and malformed input
- [x] All 327 tests pass
- [x] Hook always exits 0 (advisory only, never blocks)
- [x] Read-only agent detection covers all known review/audit agents
- [x] Scenario test updated for new hook count (7 hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)