### PR TITLE
fix: disambiguate 'Promotion opportunities' section names in retro skill

### DIFF
--- a/.dev-team/skills/dev-team-retro/SKILL.md
+++ b/.dev-team/skills/dev-team-retro/SKILL.md
@@ -71,6 +71,14 @@ Check each agent's memory file for:
 - Installed agents (from `config.json`) with no meaningful memory — suggests the agent has not been calibrated
 - Agents referenced in learnings but missing a memory file
 
+### Memory promotion opportunities
+- Scan each agent's `MEMORY.md` for entries that describe project-wide patterns, conventions, or rules rather than agent-specific calibration
+- Examples of promotable entries: "all API endpoints require rate limiting" (Szabo), "we always use transactions for multi-table writes" (Voss), "components must support keyboard navigation" (Mori)
+- Examples of non-promotable entries: "I tend to over-flag SQL injection in parameterized queries" (agent-specific calibration), "coverage is weak in the parser module" (agent-specific observation)
+- Flag entries that would benefit other agents if promoted to `.dev-team/learnings.md`
+- Classify each as `[SUGGESTION]` with the specific entry text and recommended shared learning wording
+- After an entry is promoted to shared learnings, the original agent memory entry should be removed or replaced with a cross-reference to avoid the duplication that the Staleness check flags
+
 ## Phase 3: CLAUDE.md audit
 
 Check the project's `CLAUDE.md` for:

--- a/templates/skills/dev-team-retro/SKILL.md
+++ b/templates/skills/dev-team-retro/SKILL.md
@@ -71,7 +71,7 @@ Check each agent's memory file for:
 - Installed agents (from `config.json`) with no meaningful memory — suggests the agent has not been calibrated
 - Agents referenced in learnings but missing a memory file
 
-### Promotion opportunities
+### Memory promotion opportunities
 - Scan each agent's `MEMORY.md` for entries that describe project-wide patterns, conventions, or rules rather than agent-specific calibration
 - Examples of promotable entries: "all API endpoints require rate limiting" (Szabo), "we always use transactions for multi-table writes" (Voss), "components must support keyboard navigation" (Mori)
 - Examples of non-promotable entries: "I tend to over-flag SQL injection in parameterized queries" (agent-specific calibration), "coverage is weak in the parser module" (agent-specific observation)


### PR DESCRIPTION
## Summary
- Rename Phase 2's `### Promotion opportunities` to `### Memory promotion opportunities` in the retro skill template to distinguish it from Phase 1's identically-named section
- Add the missing Phase 2 promotion section to the local `.dev-team/` copy

Closes #283