### PR TITLE
fix: make template references to merge/security-status generic

### DIFF
--- a/templates/agents/dev-team-conway.md
+++ b/templates/agents/dev-team-conway.md
@@ -64,7 +64,7 @@ You always check for:
 - **Breaking change documentation**: Every breaking change needs: what changed, why, and how to migrate. "Updated the API" is not documentation.
 - **Tag and branch hygiene**: Is the tag on the right commit? Is the release branch clean? Are there uncommitted changes?
 - **Dependency audit**: Are there known vulnerabilities in the dependency tree? Were any dependencies added or upgraded that could affect stability?
-- **Merge process**: If the project has a `/dev-team:merge` skill configured, use it for final merge — it handles Copilot review comments, CI verification, and auto-merge consistently. Otherwise, ensure the PR is in a mergeable state (CI green, reviews passed) and report readiness.
+- **Merge process**: Follow the project's merge process (skill or CLAUDE.md guidance), if configured. Otherwise, ensure the PR is in a mergeable state (CI green, reviews passed) and report readiness.
 
 ## Challenge style
 

--- a/templates/agents/dev-team-drucker.md
+++ b/templates/agents/dev-team-drucker.md
@@ -220,7 +220,7 @@ Conflict groups (issues with file overlaps) execute sequentially within the grou
 
 Work is done when the deliverable is delivered — not just created. For PRs, this means merged (or ready-to-merge per the project's workflow). For other deliverables (docs, configs, releases), this means verified in the expected state.
 
-Follow the project's merge workflow. Some projects use auto-merge, others require manual approval. If the project has a `/dev-team:merge` skill or similar automation, use it. Otherwise, ensure the PR is in a mergeable state (CI green, reviews passed, branch updated) and report readiness.
+Follow the project's merge process (skill or CLAUDE.md guidance), if configured. Some projects use auto-merge, others require manual approval. Otherwise, ensure the PR is in a mergeable state (CI green, reviews passed, branch updated) and report readiness.
 
 ### Agent teams mode (experimental)
 

--- a/templates/skills/dev-team-audit/SKILL.md
+++ b/templates/skills/dev-team-audit/SKILL.md
@@ -86,7 +86,7 @@ Numbered list of concrete actions, ordered by priority. Each action should refer
 
 ### Security preamble
 
-Before starting the audit, check for open security alerts: run `/dev-team:security-status` if available, or use the project's security monitoring tools. Include these in the audit scope.
+Before starting the audit, check for open security alerts using the project's security monitoring process (skill or CLAUDE.md guidance), if configured. Include these in the audit scope.
 
 ### Completion
 

--- a/templates/skills/dev-team-review/SKILL.md
+++ b/templates/skills/dev-team-review/SKILL.md
@@ -96,7 +96,7 @@ State the verdict clearly. List what must be fixed for approval if requesting ch
 
 ### Security preamble
 
-Before starting the review, check for open security alerts: run `/dev-team:security-status` if available, or use the project's security monitoring tools. Flag any critical findings in the review report.
+Before starting the review, check for open security alerts using the project's security monitoring process (skill or CLAUDE.md guidance), if configured. Flag any critical findings in the review report.
 
 ### Completion
 

--- a/templates/skills/dev-team-task/SKILL.md
+++ b/templates/skills/dev-team-task/SKILL.md
@@ -129,12 +129,12 @@ Parallel mode is complete when:
 
 ## Security preamble
 
-Before starting work, check for open security alerts: run `/dev-team:security-status` if available, or use the project's security monitoring tools. Flag any critical findings before proceeding.
+Before starting work, check for open security alerts using the project's security monitoring process (skill or CLAUDE.md guidance), if configured. Flag any critical findings before proceeding.
 
 ## Completion
 
 When the loop exits:
-1. **Deliver the work**: If changes are on a feature branch, create the PR (body must include `Closes #<issue>`). Ensure the PR is ready to merge: CI green, reviews passed, branch up to date. Then follow the project's merge workflow — use `/dev-team:merge` if the project has it configured, otherwise report readiness. If merge fails (CI failures, merge conflicts, branch protection), report the blocker to the human rather than leaving work unattended.
+1. **Deliver the work**: If changes are on a feature branch, create the PR (body must include `Closes #<issue>`). Ensure the PR is ready to merge: CI green, reviews passed, branch up to date. Then follow the project's merge process (skill or CLAUDE.md guidance), if configured, otherwise report readiness. If merge fails (CI failures, merge conflicts, branch protection), report the blocker to the human rather than leaving work unattended.
 2. **Clean up worktree**: If the work was done in a worktree, clean it up after the branch is pushed and the PR is created. Do not wait for merge to clean the worktree.
 3. You MUST spawn **@dev-team-borges** (Librarian) as the final step. Format and pass Borges the **finding outcome log** using this structured format:
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `/dev-team:merge` and `/dev-team:security-status` skill references in templates with generic wording that accommodates either a skill or CLAUDE.md-based workflow
- These are project-specific skills, not framework skills — not every project will have them

## Files changed
- `templates/skills/dev-team-task/SKILL.md` (2 references)
- `templates/skills/dev-team-review/SKILL.md` (1 reference)
- `templates/skills/dev-team-audit/SKILL.md` (1 reference)
- `templates/agents/dev-team-conway.md` (1 reference)
- `templates/agents/dev-team-drucker.md` (1 reference)

Closes #288