### PR TITLE
feat: track deferred findings conversion to issues

### DIFF
--- a/.dev-team/skills/dev-team-retro/SKILL.md
+++ b/.dev-team/skills/dev-team-retro/SKILL.md
@@ -117,8 +117,10 @@ If `.dev-team/metrics.md` exists and contains entries, analyze:
 ### Deferred findings follow-through
 - Scan all entries for findings with outcome `deferred` — these are findings accepted but deferred to a follow-up issue
 - For each deferred finding, extract the tracking reference from the Reason column (e.g., "Tracked in #999")
-- If the Reason column contains an issue number, verify the issue exists using `gh issue view <number>` (a 404/error means the issue was never created)
-- If the Reason column does NOT contain an issue number, search for a matching issue using `gh issue list --search "<finding summary>"` and check if any open issue corresponds to the deferred finding
+- **Issue tracker detection:** Check `.dev-team/config.json` or `CLAUDE.md` for the project's issue tracker type (GitHub Issues, Jira, Linear, or None). The verification steps below assume GitHub Issues — if the project uses a different tracker, perform the equivalent lookup in that system (e.g., Jira JQL search, Linear API query). If no external tracker is configured, flag all deferred findings for manual audit instead.
+- If the Reason column contains an issue reference (e.g., "Tracked in #999"), strip the `#` prefix before passing to the CLI — `"Tracked in #999"` means run `gh issue view 999`, not `gh issue view #999`
+- Verify the issue exists and is tracked: use `gh issue list --state all --search "<issue number or summary>"` so that both open and closed issues count as valid tracking (a deferred finding whose issue was already resolved should not be flagged as untracked)
+- If the Reason column does NOT contain an issue number, search for a matching issue using `gh issue list --state all --search "<finding summary>"` and check if any issue (open or closed) corresponds to the deferred finding
 - Flag each deferred finding with no corresponding issue as:
   ```
   **[RISK]** Metrics — Deferred finding has no tracking issue: "<finding summary>" (from <agent>, <date>)

--- a/templates/skills/dev-team-retro/SKILL.md
+++ b/templates/skills/dev-team-retro/SKILL.md
@@ -117,8 +117,10 @@ If `.dev-team/metrics.md` exists and contains entries, analyze:
 ### Deferred findings follow-through
 - Scan all entries for findings with outcome `deferred` — these are findings accepted but deferred to a follow-up issue
 - For each deferred finding, extract the tracking reference from the Reason column (e.g., "Tracked in #999")
-- If the Reason column contains an issue number, verify the issue exists using `gh issue view <number>` (a 404/error means the issue was never created)
-- If the Reason column does NOT contain an issue number, search for a matching issue using `gh issue list --search "<finding summary>"` and check if any open issue corresponds to the deferred finding
+- **Issue tracker detection:** Check `.dev-team/config.json` or `CLAUDE.md` for the project's issue tracker type (GitHub Issues, Jira, Linear, or None). The verification steps below assume GitHub Issues — if the project uses a different tracker, perform the equivalent lookup in that system (e.g., Jira JQL search, Linear API query). If no external tracker is configured, flag all deferred findings for manual audit instead.
+- If the Reason column contains an issue reference (e.g., "Tracked in #999"), strip the `#` prefix before passing to the CLI — `"Tracked in #999"` means run `gh issue view 999`, not `gh issue view #999`
+- Verify the issue exists and is tracked: use `gh issue list --state all --search "<issue number or summary>"` so that both open and closed issues count as valid tracking (a deferred finding whose issue was already resolved should not be flagged as untracked)
+- If the Reason column does NOT contain an issue number, search for a matching issue using `gh issue list --state all --search "<finding summary>"` and check if any issue (open or closed) corresponds to the deferred finding
 - Flag each deferred finding with no corresponding issue as:
   ```
   **[RISK]** Metrics — Deferred finding has no tracking issue: "<finding summary>" (from <agent>, <date>)


### PR DESCRIPTION
## Summary
- Adds a "Deferred findings follow-through" subsection to Phase 4 (Calibration metrics audit) of the retro skill
- Cross-references deferred findings from `.dev-team/metrics.md` against actual GitHub issues using `gh issue view` and `gh issue list --search`
- Flags untracked deferrals as `[RISK]` and reports conversion rate (e.g., "3/4 deferred findings have tracking issues")
- Updated both `templates/` and `.dev-team/` copies

Closes #284

## Test plan
- [ ] Run `/dev-team:retro` on a project with deferred findings in metrics to verify the check executes
- [ ] Verify deferred findings with valid issue references are not flagged
- [ ] Verify deferred findings without issue references are flagged as `[RISK]`
- [ ] Confirm conversion rate appears in executive summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)