### PR TITLE
fix: align script detection key-existence checks

### DIFF
--- a/src/scan.ts
+++ b/src/scan.ts
@@ -45,7 +45,7 @@ export function scanProject(targetDir: string): ScanFinding[] {
     if (pkg) {
       try {
         const parsed = JSON.parse(pkg);
-        hasLintScript = !!(parsed.scripts && parsed.scripts.lint);
+        hasLintScript = !!(parsed.scripts && "lint" in parsed.scripts);
       } catch {
         // invalid JSON — treat as no script
       }
@@ -98,8 +98,8 @@ export function scanProject(targetDir: string): ScanFinding[] {
       try {
         const parsed = JSON.parse(fmtPkg);
         const scripts = parsed.scripts || {};
-        hasFormatScript = !!scripts.format;
-        hasFormatCheckScript = !!scripts["format:check"];
+        hasFormatScript = "format" in scripts;
+        hasFormatCheckScript = "format:check" in scripts;
       } catch {
         // invalid JSON — treat as no script
       }


### PR DESCRIPTION
## Summary
- Replaced truthiness checks (`!!parsed.scripts.lint`, `!!scripts.format`, `!!scripts["format:check"]`) with key-existence checks (`"lint" in parsed.scripts`, `"format" in scripts`, `"format:check" in scripts`) in `src/scan.ts`
- Now both the linter/formatter fallback paths and `parseCiScripts()` use the same `in` operator pattern for consistency

## Test plan
- [x] All 327 existing tests pass
- [ ] Verify empty-string scripts (`"lint": ""`) are now detected as present (behavior change aligned with `parseCiScripts`)

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>