### PR TITLE
chore: release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-03-26
+
+### Added
+- Agent-teams-guide hook for TeamCreate and worktree enforcement (#306).
+- Deferred findings conversion tracking in retro skill (#305).
+
+### Changed
+- `/dev-team:assess` renamed to `/dev-team:retro` (#297).
+- Project-specific skills dropped `dev-team` prefix (#290).
+- Template references to merge/security-status skills made generic (#304).
+
+### Fixed
+- Review skill routing table aligned with hook patterns — Beck, Brooks, Hamilton gaps resolved (#303).
+- Copilot login detection now handles `[bot]` suffix via regex matching (#307).
+- Script detection aligned to use key-existence checks consistently (#308).
+- Disambiguated 'Promotion opportunities' section names in retro skill (#301).
+- Formatter detection package.json fallback added (#292).
+- Dual Learning / Learnings Output sections consolidated in agent definitions (#293).
+- Deferred findings tracking rule added to shared learnings (#296).
+- Conway milestone closure promoted to shared learnings (#291).
+
 ## [1.2.0] - 2026-03-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fredericboyer/dev-team",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "bin": {
         "dev-team": "bin/dev-team.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Adversarial AI agent team for any project — installs Claude Code agents, hooks, and skills that enforce quality through productive friction",
   "main": "dist/init.js",
   "types": "dist/init.d.ts",


### PR DESCRIPTION
## Summary

- Version bump to 1.3.0
- 12 issues resolved across 13 PRs
- [v1.3 milestone](https://github.com/fredericboyer/dev-team/milestone/5)

## Changelog

### Added
- Agent-teams-guide hook for TeamCreate and worktree enforcement (#306).
- Deferred findings conversion tracking in retro skill (#305).

### Changed
- `/dev-team:assess` renamed to `/dev-team:retro` (#297).
- Project-specific skills dropped `dev-team` prefix (#290).
- Template references to merge/security-status skills made generic (#304).

### Fixed
- Review skill routing table aligned with hook patterns — Beck, Brooks, Hamilton gaps resolved (#303).
- Copilot login detection now handles `[bot]` suffix via regex matching (#307).
- Script detection aligned to use key-existence checks consistently (#308).
- Disambiguated 'Promotion opportunities' section names in retro skill (#301).
- Formatter detection package.json fallback added (#292).
- Dual Learning / Learnings Output sections consolidated in agent definitions (#293).
- Deferred findings tracking rule added to shared learnings (#296).
- Conway milestone closure promoted to shared learnings (#291).

## Test plan
- [ ] `npm test` passes
- [ ] `node bin/dev-team.js init --all` works on a clean target
- [ ] Version reads 1.3.0 in package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)