### PR TITLE
fix: align pre-commit gate wording with actual hook behavior

### DIFF
--- a/templates/agents/dev-team-beck.md
+++ b/templates/agents/dev-team-beck.md
@@ -85,4 +85,4 @@ After completing work, you MUST:
 - Information already captured in ADRs or `.dev-team/learnings.md`
 - Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
 
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+If you skip the MEMORY.md write, the pre-commit gate will block commits that include implementation files without corresponding memory updates. Use `.dev-team/.memory-reviewed` to override if no learnings apply.

--- a/templates/agents/dev-team-borges.md
+++ b/templates/agents/dev-team-borges.md
@@ -232,4 +232,4 @@ After completing work, you MUST:
    - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
    - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
 
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+If you skip the MEMORY.md write, the pre-commit gate will block commits that include implementation files without corresponding memory updates. Use `.dev-team/.memory-reviewed` to override if no learnings apply. Your review will flag a [DEFECT] for missing memory writes.

--- a/templates/agents/dev-team-brooks.md
+++ b/templates/agents/dev-team-brooks.md
@@ -138,4 +138,4 @@ After completing work, you MUST:
 - Information already captured in ADRs or `.dev-team/learnings.md`
 - Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
 
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+If you skip the MEMORY.md write, the pre-commit gate will block commits that include implementation files without corresponding memory updates. Use `.dev-team/.memory-reviewed` to override if no learnings apply.

--- a/templates/agents/dev-team-conway.md
+++ b/templates/agents/dev-team-conway.md
@@ -113,4 +113,4 @@ After completing work, you MUST:
 - Information already captured in ADRs or `.dev-team/learnings.md`
 - Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
 
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+If you skip the MEMORY.md write, the pre-commit gate will block commits that include implementation files without corresponding memory updates. Use `.dev-team/.memory-reviewed` to override if no learnings apply.

--- a/templates/agents/dev-team-deming.md
+++ b/templates/agents/dev-team-deming.md
@@ -105,4 +105,4 @@ After completing work, you MUST:
 - Information already captured in ADRs or `.dev-team/learnings.md`
 - Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
 
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+If you skip the MEMORY.md write, the pre-commit gate will block commits that include implementation files without corresponding memory updates. Use `.dev-team/.memory-reviewed` to override if no learnings apply.

--- a/templates/agents/dev-team-drucker.md
+++ b/templates/agents/dev-team-drucker.md
@@ -313,4 +313,4 @@ After completing work, you MUST:
    - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
    - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
 
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+If you skip the MEMORY.md write, the pre-commit gate will block commits that include implementation files without corresponding memory updates. Use `.dev-team/.memory-reviewed` to override if no learnings apply.

--- a/templates/agents/dev-team-hamilton.md
+++ b/templates/agents/dev-team-hamilton.md
@@ -88,4 +88,4 @@ After completing work, you MUST:
 - Information already captured in ADRs or `.dev-team/learnings.md`
 - Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
 
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+If you skip the MEMORY.md write, the pre-commit gate will block commits that include implementation files without corresponding memory updates. Use `.dev-team/.memory-reviewed` to override if no learnings apply.

--- a/templates/agents/dev-team-knuth.md
+++ b/templates/agents/dev-team-knuth.md
@@ -89,4 +89,4 @@ After completing work, you MUST:
 - Information already captured in ADRs or `.dev-team/learnings.md`
 - Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
 
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+If you skip the MEMORY.md write, the pre-commit gate will block commits that include implementation files without corresponding memory updates. Use `.dev-team/.memory-reviewed` to override if no learnings apply.

--- a/templates/agents/dev-team-mori.md
+++ b/templates/agents/dev-team-mori.md
@@ -85,4 +85,4 @@ After completing work, you MUST:
 - Information already captured in ADRs or `.dev-team/learnings.md`
 - Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
 
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+If you skip the MEMORY.md write, the pre-commit gate will block commits that include implementation files without corresponding memory updates. Use `.dev-team/.memory-reviewed` to override if no learnings apply.

--- a/templates/agents/dev-team-rams.md
+++ b/templates/agents/dev-team-rams.md
@@ -92,4 +92,4 @@ After completing work, you MUST:
    - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
    - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
 
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+If you skip the MEMORY.md write, the pre-commit gate will block commits that include implementation files without corresponding memory updates. Use `.dev-team/.memory-reviewed` to override if no learnings apply.

--- a/templates/agents/dev-team-szabo.md
+++ b/templates/agents/dev-team-szabo.md
@@ -89,4 +89,4 @@ After completing work, you MUST:
 - Information already captured in ADRs or `.dev-team/learnings.md`
 - Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
 
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+If you skip the MEMORY.md write, the pre-commit gate will block commits that include implementation files without corresponding memory updates. Use `.dev-team/.memory-reviewed` to override if no learnings apply.

--- a/templates/agents/dev-team-tufte.md
+++ b/templates/agents/dev-team-tufte.md
@@ -100,4 +100,4 @@ After completing work, you MUST:
 - Information already captured in ADRs or `.dev-team/learnings.md`
 - Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
 
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+If you skip the MEMORY.md write, the pre-commit gate will block commits that include implementation files without corresponding memory updates. Use `.dev-team/.memory-reviewed` to override if no learnings apply.

--- a/templates/agents/dev-team-turing.md
+++ b/templates/agents/dev-team-turing.md
@@ -97,4 +97,4 @@ After completing work, you MUST:
    - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
    - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
 
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+If you skip the MEMORY.md write, the pre-commit gate will block commits that include implementation files without corresponding memory updates. Use `.dev-team/.memory-reviewed` to override if no learnings apply.

--- a/templates/agents/dev-team-voss.md
+++ b/templates/agents/dev-team-voss.md
@@ -86,4 +86,4 @@ After completing work, you MUST:
 - Information already captured in ADRs or `.dev-team/learnings.md`
 - Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
 
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+If you skip the MEMORY.md write, the pre-commit gate will block commits that include implementation files without corresponding memory updates. Use `.dev-team/.memory-reviewed` to override if no learnings apply.


### PR DESCRIPTION
## Summary
- Updated all 14 agent templates to accurately describe pre-commit gate behavior: the hook only blocks when implementation files are staged without corresponding memory updates, not all commits unconditionally
- Documented the `.dev-team/.memory-reviewed` override mechanism that was missing from the wording
- Fixed Borges template self-referential wording ("Borges will flag" -> "Your review will flag")

## Test plan
- [x] `npm test` — 327 tests pass
- [x] `npm run validate:agents` — all 14 agents valid
- [x] Verified wording matches actual behavior in `templates/hooks/dev-team-pre-commit-gate.js`

Closes #323