### PR TITLE
feat: enforce meaningful agent teammate naming convention

### DIFF
--- a/.dev-team/agents/dev-team-drucker.md
+++ b/.dev-team/agents/dev-team-drucker.md
@@ -95,6 +95,12 @@ Turing's output: a structured research brief passed to the implementing agent as
 
 ### 4. Delegate
 
+**Agent teammate naming convention:** When spawning teammates, use `{agent}-{role}[-{qualifier}]`:
+- Implementers: `{agent}-implement[-{qualifier}]` (e.g., `voss-implement`, `deming-implement-auth`)
+- Reviewers: `{agent}-review` (e.g., `szabo-review`, `knuth-review`)
+- Research: `turing-research[-{qualifier}]`
+- Memory extraction: `borges-extract`
+
 1. Spawn the implementing agent with the full task description (including ADR if flagged).
 2. After implementation completes, **validate the output** before spawning reviewers (see step 4b).
 3. Each reviewer uses their agent definition from `.dev-team/agents/`.

--- a/.dev-team/skills/dev-team-audit/SKILL.md
+++ b/.dev-team/skills/dev-team-audit/SKILL.md
@@ -19,7 +19,7 @@ Run a comprehensive audit of: $ARGUMENTS
 
 ## Execution
 
-1. Spawn all three agents as **parallel background subagents** using the Agent tool with `subagent_type: "general-purpose"`.
+1. Spawn all three agents as **parallel background subagents** using the Agent tool with `subagent_type: "general-purpose"`. Use the agent teammate naming convention: `szabo-audit`, `knuth-audit`, `deming-audit`.
 
 2. Each agent's prompt must include:
    - The agent's full definition (read from `.dev-team/agents/<agent>.md`)
@@ -91,6 +91,6 @@ Before starting the audit, check for open security alerts: run `/dev-team:securi
 ### Completion
 
 After the audit report is delivered:
-1. You MUST spawn **@dev-team-borges** (Librarian) as the final step to review memory freshness and capture learnings from the audit findings. Do NOT skip this.
+1. You MUST spawn **@dev-team-borges** as `borges-extract` (Librarian) as the final step to review memory freshness and capture learnings from the audit findings. Do NOT skip this.
 2. If Borges was not spawned, the audit is INCOMPLETE.
 3. Include Borges's recommendations in the final report.

--- a/.dev-team/skills/dev-team-review/SKILL.md
+++ b/.dev-team/skills/dev-team-review/SKILL.md
@@ -38,7 +38,7 @@ Before spawning reviewers, verify the changes are reviewable:
 
 ## Execution
 
-1. Spawn each selected agent as a **parallel background subagent** using the Agent tool with `subagent_type: "general-purpose"`.
+1. Spawn each selected agent as a **parallel background subagent** using the Agent tool with `subagent_type: "general-purpose"`. Use the agent teammate naming convention: `{agent}-review` (e.g., `szabo-review`, `knuth-review`, `brooks-review`).
 
 2. Each agent's prompt must include:
    - The agent's full definition (read from `.dev-team/agents/<agent>.md`)
@@ -103,7 +103,7 @@ Before starting the review, check for open security alerts using the project's s
 ### Completion
 
 After the review report is delivered:
-1. You MUST spawn **@dev-team-borges** (Librarian) as the final step. Pass Borges the **finding outcome log**: every finding with its classification, source agent, and outcome (accepted/overruled/ignored), including reasoning for overrules. Borges will:
+1. You MUST spawn **@dev-team-borges** as `borges-extract` (Librarian) as the final step. Pass Borges the **finding outcome log**: every finding with its classification, source agent, and outcome (accepted/overruled/ignored), including reasoning for overrules. Borges will:
    - **Extract structured memory entries** from the review findings (each classified finding becomes a memory entry for the reviewer who produced it)
    - **Reinforce accepted patterns** and **record overruled findings** for reviewer calibration
    - **Generate calibration rules** when 3+ findings on the same tag are overruled

--- a/.dev-team/skills/dev-team-task/SKILL.md
+++ b/.dev-team/skills/dev-team-task/SKILL.md
@@ -119,10 +119,10 @@ Spawn @dev-team-brooks once with all issues. Brooks identifies:
 Issues in the same conflict group execute sequentially. Independent issues proceed in parallel.
 
 ### Phase 1: Parallel implementation
-Drucker spawns one implementing agent per independent issue, each on its own branch (`feat/<issue>-<description>`). Agents work concurrently without awareness of each other. Drucker tracks which issues are assigned to which agents and branches in conversation context.
+Drucker spawns one implementing agent per independent issue, each on its own branch (`feat/<issue>-<description>`). Use the agent teammate naming convention: `{agent}-implement[-{qualifier}]` (e.g., `voss-implement`, `deming-implement-auth`, `tufte-implement-319`). Agents work concurrently without awareness of each other. Drucker tracks which issues are assigned to which agents and branches in conversation context.
 
 ### Phase 2: Review wave
-Reviews do **not** start until **all** implementation agents have completed (Agent tool provides completion notifications as the sync barrier). Once all are done, spawn review agents (Szabo + Knuth, plus conditional reviewers) in parallel across all branches simultaneously. Each reviewer receives the diff for one specific branch and produces classified findings scoped to that branch.
+Reviews do **not** start until **all** implementation agents have completed (Agent tool provides completion notifications as the sync barrier). Once all are done, spawn review agents using the naming convention `{agent}-review` (e.g., `szabo-review`, `knuth-review`, `brooks-review`) in parallel across all branches simultaneously. Each reviewer receives the diff for one specific branch and produces classified findings scoped to that branch.
 
 ### Phase 3: Finding routing
 Collect all findings across all branches. Route **all classified findings** — `[DEFECT]`, `[RISK]`, `[QUESTION]`, `[SUGGESTION]` — back to the original implementing agent for each branch. Each agent must acknowledge every finding (address/defer/dispute). Disputes follow the same protocol as single-issue mode: one-round escalation between implementer and reviewer, then human decides. A disputed finding blocks only the affected branch, not the entire batch. Only `[DEFECT]` findings block progress. Agents fix defects on their own branch. Before spawning the next review wave, **compact context**: produce a structured summary of all findings, their classification, and final outcome (fixed/accepted/deferred/overruled/ignored), plus files changed. New reviewers receive current diff + compact summary only — not full conversation history from prior waves. Continue until no `[DEFECT]` findings remain or the per-branch iteration limit is reached.
@@ -144,7 +144,7 @@ Before starting work, check for open security alerts using the project's securit
 When the loop exits:
 1. **Deliver the work**: If changes are on a feature branch, create the PR (body must include `Closes #<issue>`). Ensure the PR is ready to merge: CI green, reviews passed, branch up to date. If the project provides a merge workflow (e.g., a `/merge` skill or CLAUDE.md guidance), use it; if no such workflow exists, ensure the PR is mergeable and report readiness. If merge fails (CI failures, merge conflicts, branch protection), report the blocker to the human rather than leaving work unattended.
 2. **Clean up worktree**: If the work was done in a worktree, clean it up after the branch is pushed and the PR is created. Do not wait for merge to clean the worktree.
-3. You MUST spawn **@dev-team-borges** (Librarian) as the final step. Format and pass Borges the **finding outcome log** using this structured format:
+3. You MUST spawn **@dev-team-borges** as `borges-extract` (Librarian) as the final step. Format and pass Borges the **finding outcome log** using this structured format:
 
    **Single-branch format:**
    ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,19 @@ When working on multiple independent issues, combine agent teams with worktree i
 - **Implementing agents** must use both `team_name` and `isolation: "worktree"` to prevent branch conflicts between parallel teammates.
 - **Review/read-only agents** should assess whether they need access to an implementer's worktree (to run tests or read changed files in context), or should work in their own isolation for independent analysis.
 
+**Agent teammate naming convention:** Use `{agent}-{role}[-{qualifier}]` when spawning teammates:
+- `{agent}` — dev-team agent name (lowercase): `voss`, `deming`, `szabo`, etc.
+- `{role}` — action: `implement`, `review`, `research`, `audit`, `extract`
+- `{qualifier}` — optional, for disambiguation when multiple agents of the same type run in parallel (e.g., issue number, feature name)
+
+| Role suffix | When used | Examples |
+|-------------|-----------|---------|
+| `-implement` | Implementing agent on a task branch | `voss-implement`, `deming-implement-auth` |
+| `-review` | Reviewer in a review wave | `szabo-review`, `knuth-review` |
+| `-research` | Turing research brief | `turing-research`, `turing-research-caching` |
+| `-audit` | Full codebase audit pass | `szabo-audit`, `knuth-audit` |
+| `-extract` | Borges memory extraction | `borges-extract` |
+
 Drucker coordinates the review wave after all implementations complete.
 
 > **Note:** If your project's workflow section (above the `dev-team:begin` marker) already designates the main conversation loop as the team lead, do not spawn a separate Drucker subagent — the main loop IS Drucker. Otherwise, `@dev-team-drucker` can be used as a subagent for delegation.

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -62,6 +62,19 @@ When working on multiple independent issues, combine agent teams with worktree i
 - **Implementing agents** must use both `team_name` and `isolation: "worktree"` to prevent branch conflicts between parallel teammates.
 - **Review/read-only agents** should assess whether they need access to an implementer's worktree (to run tests or read changed files in context), or should work in their own isolation for independent analysis.
 
+**Agent teammate naming convention:** Use `{agent}-{role}[-{qualifier}]` when spawning teammates:
+- `{agent}` — dev-team agent name (lowercase): `voss`, `deming`, `szabo`, etc.
+- `{role}` — action: `implement`, `review`, `research`, `audit`, `extract`
+- `{qualifier}` — optional, for disambiguation when multiple agents of the same type run in parallel (e.g., issue number, feature name)
+
+| Role suffix | When used | Examples |
+|-------------|-----------|---------|
+| `-implement` | Implementing agent on a task branch | `voss-implement`, `deming-implement-auth` |
+| `-review` | Reviewer in a review wave | `szabo-review`, `knuth-review` |
+| `-research` | Turing research brief | `turing-research`, `turing-research-caching` |
+| `-audit` | Full codebase audit pass | `szabo-audit`, `knuth-audit` |
+| `-extract` | Borges memory extraction | `borges-extract` |
+
 Drucker coordinates the review wave after all implementations complete.
 
 > **Note:** If your project's workflow section (above the `dev-team:begin` marker) already designates the main conversation loop as the team lead, do not spawn a separate Drucker subagent — the main loop IS Drucker. Otherwise, `@dev-team-drucker` can be used as a subagent for delegation.

--- a/templates/agents/dev-team-drucker.md
+++ b/templates/agents/dev-team-drucker.md
@@ -95,6 +95,12 @@ Turing's output: a structured research brief passed to the implementing agent as
 
 ### 4. Delegate
 
+**Agent teammate naming convention:** When spawning teammates, use `{agent}-{role}[-{qualifier}]`:
+- Implementers: `{agent}-implement[-{qualifier}]` (e.g., `voss-implement`, `deming-implement-auth`)
+- Reviewers: `{agent}-review` (e.g., `szabo-review`, `knuth-review`)
+- Research: `turing-research[-{qualifier}]`
+- Memory extraction: `borges-extract`
+
 1. Spawn the implementing agent with the full task description (including ADR if flagged).
 2. After implementation completes, **validate the output** before spawning reviewers (see step 4b).
 3. Each reviewer uses their agent definition from `.dev-team/agents/`.

--- a/templates/skills/dev-team-audit/SKILL.md
+++ b/templates/skills/dev-team-audit/SKILL.md
@@ -19,7 +19,7 @@ Run a comprehensive audit of: $ARGUMENTS
 
 ## Execution
 
-1. Spawn all three agents as **parallel background subagents** using the Agent tool with `subagent_type: "general-purpose"`.
+1. Spawn all three agents as **parallel background subagents** using the Agent tool with `subagent_type: "general-purpose"`. Use the agent teammate naming convention: `szabo-audit`, `knuth-audit`, `deming-audit`.
 
 2. Each agent's prompt must include:
    - The agent's full definition (read from `.dev-team/agents/<agent>.md`)
@@ -91,6 +91,6 @@ Before starting the audit, check for open security alerts using the project's se
 ### Completion
 
 After the audit report is delivered:
-1. You MUST spawn **@dev-team-borges** (Librarian) as the final step to review memory freshness and capture learnings from the audit findings. Do NOT skip this.
+1. You MUST spawn **@dev-team-borges** as `borges-extract` (Librarian) as the final step to review memory freshness and capture learnings from the audit findings. Do NOT skip this.
 2. If Borges was not spawned, the audit is INCOMPLETE.
 3. Include Borges's recommendations in the final report.

--- a/templates/skills/dev-team-review/SKILL.md
+++ b/templates/skills/dev-team-review/SKILL.md
@@ -38,7 +38,7 @@ Before spawning reviewers, verify the changes are reviewable:
 
 ## Execution
 
-1. Spawn each selected agent as a **parallel background subagent** using the Agent tool with `subagent_type: "general-purpose"`.
+1. Spawn each selected agent as a **parallel background subagent** using the Agent tool with `subagent_type: "general-purpose"`. Use the agent teammate naming convention: `{agent}-review` (e.g., `szabo-review`, `knuth-review`, `brooks-review`).
 
 2. Each agent's prompt must include:
    - The agent's full definition (read from `.dev-team/agents/<agent>.md`)
@@ -103,7 +103,7 @@ Before starting the review, check for open security alerts using the project's s
 ### Completion
 
 After the review report is delivered:
-1. You MUST spawn **@dev-team-borges** (Librarian) as the final step. Pass Borges the **finding outcome log**: every finding with its classification, source agent, and outcome (accepted/overruled/ignored), including reasoning for overrules. Borges will:
+1. You MUST spawn **@dev-team-borges** as `borges-extract` (Librarian) as the final step. Pass Borges the **finding outcome log**: every finding with its classification, source agent, and outcome (accepted/overruled/ignored), including reasoning for overrules. Borges will:
    - **Extract structured memory entries** from the review findings (each classified finding becomes a memory entry for the reviewer who produced it)
    - **Reinforce accepted patterns** and **record overruled findings** for reviewer calibration
    - **Generate calibration rules** when 3+ findings on the same tag are overruled

--- a/templates/skills/dev-team-task/SKILL.md
+++ b/templates/skills/dev-team-task/SKILL.md
@@ -119,10 +119,10 @@ Spawn @dev-team-brooks once with all issues. Brooks identifies:
 Issues in the same conflict group execute sequentially. Independent issues proceed in parallel.
 
 ### Phase 1: Parallel implementation
-Drucker spawns one implementing agent per independent issue, each on its own branch (`feat/<issue>-<description>`). Agents work concurrently without awareness of each other. Drucker tracks which issues are assigned to which agents and branches in conversation context.
+Drucker spawns one implementing agent per independent issue, each on its own branch (`feat/<issue>-<description>`). Use the agent teammate naming convention: `{agent}-implement[-{qualifier}]` (e.g., `voss-implement`, `deming-implement-auth`, `tufte-implement-319`). Agents work concurrently without awareness of each other. Drucker tracks which issues are assigned to which agents and branches in conversation context.
 
 ### Phase 2: Review wave
-Reviews do **not** start until **all** implementation agents have completed (Agent tool provides completion notifications as the sync barrier). Once all are done, spawn review agents (Szabo + Knuth, plus conditional reviewers) in parallel across all branches simultaneously. Each reviewer receives the diff for one specific branch and produces classified findings scoped to that branch.
+Reviews do **not** start until **all** implementation agents have completed (Agent tool provides completion notifications as the sync barrier). Once all are done, spawn review agents using the naming convention `{agent}-review` (e.g., `szabo-review`, `knuth-review`, `brooks-review`) in parallel across all branches simultaneously. Each reviewer receives the diff for one specific branch and produces classified findings scoped to that branch.
 
 ### Phase 3: Finding routing
 Collect all findings across all branches. Route **all classified findings** — `[DEFECT]`, `[RISK]`, `[QUESTION]`, `[SUGGESTION]` — back to the original implementing agent for each branch. Each agent must acknowledge every finding (address/defer/dispute). Disputes follow the same protocol as single-issue mode: one-round escalation between implementer and reviewer, then human decides. A disputed finding blocks only the affected branch, not the entire batch. Only `[DEFECT]` findings block progress. Agents fix defects on their own branch. Before spawning the next review wave, **compact context**: produce a structured summary of all findings, their classification, and outcome (fixed/deferred/disputed/pending), plus files changed. New reviewers receive current diff + compact summary only — not full conversation history from prior waves. Continue until no `[DEFECT]` findings remain or the per-branch iteration limit is reached.
@@ -144,7 +144,7 @@ Before starting work, check for open security alerts using the project's securit
 When the loop exits:
 1. **Deliver the work**: If changes are on a feature branch, create the PR (body must include `Closes #<issue>`). Ensure the PR is ready to merge: CI green, reviews passed, branch up to date. If the project provides a merge workflow (e.g., a `/merge` skill or CLAUDE.md guidance), use it; if no such workflow exists, ensure the PR is mergeable and report readiness. If merge fails (CI failures, merge conflicts, branch protection), report the blocker to the human rather than leaving work unattended.
 2. **Clean up worktree**: If the work was done in a worktree, clean it up after the branch is pushed and the PR is created. Do not wait for merge to clean the worktree.
-3. You MUST spawn **@dev-team-borges** (Librarian) as the final step. Format and pass Borges the **finding outcome log** using this structured format:
+3. You MUST spawn **@dev-team-borges** as `borges-extract` (Librarian) as the final step. Format and pass Borges the **finding outcome log** using this structured format:
 
    **Single-branch format:**
    ```


### PR DESCRIPTION
## Summary

- Adds `{agent}-{role}[-{qualifier}]` naming convention for agent teammates (e.g., `szabo-review`, `voss-implement`, `borges-extract`)
- Updates `templates/CLAUDE.md` parallel execution section with convention table and examples
- Updates skill files (`dev-team-task`, `dev-team-review`, `dev-team-audit`) to use convention when spawning implementers, reviewers, and audit agents
- Updates `templates/agents/dev-team-drucker.md` to enforce naming when delegating
- Updates all `.dev-team/` self-use copies to match

## Test plan

- [x] `npm test` — 327 tests pass
- [x] `npm run validate:agents` — all 14 agents valid

Closes #319