### PR TITLE
Fix 200-line guideline attribution in research brief

### DIFF
--- a/.dev-team/research/257-multi-user-model-2026-03-26.md
+++ b/.dev-team/research/257-multi-user-model-2026-03-26.md
@@ -169,7 +169,7 @@ Add change hashing to post-change-review hooks. Before spawning a review agent, 
 
 ## Known Issues / Caveats
 
-1. **Append-only compaction is critical**: Without Borges compaction, learnings.md will grow unboundedly in high-activity projects. The 200-line guideline must be enforced by compaction, not just convention.
+1. **Append-only compaction is critical**: Without Borges compaction, learnings.md will grow unboundedly in high-activity projects. The 200-line guideline for agent MEMORY.md files (per agent definitions) must be enforced by compaction, not just convention.
 
 2. **Session ID availability**: Claude Code exposes session context through agent teams (team name, teammate ID), but a standalone session may not have a stable ID. Fallback: generate a short UUID at session start and persist it in `.dev-team/agent-status/session-id`.
 


### PR DESCRIPTION
## Summary
- Corrects the 200-line guideline attribution in the multi-user research brief (#257)
- The guideline applies to agent MEMORY.md files (per agent definitions), not learnings.md which has no documented line limit

## Test plan
- [x] Verified the corrected text accurately reflects agent definitions (e.g., Tufte agent line 15: "If approaching 200 lines, compress older entries")

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)