### PR TITLE
feat: apply agents.md research to all instruction surfaces

### DIFF
--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -53,14 +53,14 @@ For each agent memory file:
 #### 4a. Template CLAUDE.md (`templates/CLAUDE.md`)
 
 The primary instruction surface shipped to all projects. Check:
-- Are workflow instructions accurate? (agent table, hook triggers, skill list)
+- Are workflow instructions accurate? (agent list, hook triggers, skill list)
 - Are there learnings that should be baked into CLAUDE.md as permanent instructions?
 - Are there stale instructions that no longer match current behavior?
 - Are there missing sections? (e.g., new skills added but not listed, new agents without hook descriptions)
 - Does the "Hook directives are MANDATORY" section reflect current enforcement mechanisms?
-- Is the "Learnings — where to write what" table still accurate?
+- Is the memory architecture table still accurate?
 - Does the skills list match what's actually in `templates/skills/`?
-- Are agent descriptions consistent with their actual definitions in `templates/agents/`?
+- **Template bloat audit:** Does `templates/CLAUDE.md` contain information discoverable from a fresh project install? Count lines in the managed section — flag if over 100. Check for content that duplicates what agents can find by reading `.dev-team/agents/`, `.dev-team/hooks/`, or config files.
 
 #### 4b. Project CLAUDE.md — section OUTSIDE dev-team markers
 

--- a/.dev-team/agents/dev-team-borges.md
+++ b/.dev-team/agents/dev-team-borges.md
@@ -70,6 +70,7 @@ Write entries to the appropriate agent's MEMORY.md using the structured format:
 - Entries that record specific numeric metrics derivable from the codebase (test counts, file counts, line counts)
 - Entries that merely restate what is in `package.json`, `tsconfig.json`, or other config files
 - Entries that duplicate existing ADRs or `.dev-team/learnings.md` entries
+- **Discoverability test:** Before writing any entry, ask: "Can an agent learn this by reading the code, config files, or directory structure?" If yes, do not write it. Focus on: calibration data, non-obvious conventions, overruled findings, cross-agent coherence issues.
 
 **Extraction rules:**
 - Every accepted DEFECT becomes a memory entry for the reviewer who found it (reinforcement)

--- a/.dev-team/skills/dev-team-retro/SKILL.md
+++ b/.dev-team/skills/dev-team-retro/SKILL.md
@@ -100,6 +100,11 @@ Check the project's `CLAUDE.md` for:
 ### Learnings promotion
 - Mature learnings that have been stable for multiple sessions and should be promoted to `CLAUDE.md` instructions
 
+### Instruction surface health
+- Count lines in the CLAUDE.md managed section (between `<!-- dev-team:begin -->` and `<!-- dev-team:end -->` markers) — flag as `[RISK]` if over 100 lines
+- Scan `.dev-team/learnings.md` for entries that describe information discoverable from code or config files (e.g., tech stack, project structure, framework choices) — flag each for removal
+- Report a "discoverable content ratio": number of flagged entries / total entries
+
 ## Phase 4: Calibration metrics audit (`.dev-team/metrics.md`)
 
 If `.dev-team/metrics.md` exists and contains entries, analyze:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,22 +41,7 @@ This project uses [dev-team](https://github.com/dev-team) — adversarial AI age
 
 ### Agents
 
-| Agent | Role | When to use |
-|-------|------|-------------|
-| `@dev-team-voss` | Backend Engineer | API design, data modeling, system architecture, error handling |
-| `@dev-team-hamilton` | Infrastructure Engineer | Dockerfiles, IaC, CI/CD, k8s, deployment, health checks, monitoring |
-| `@dev-team-mori` | Frontend/UI Engineer | Components, accessibility, UX patterns, state management |
-| `@dev-team-szabo` | Security Auditor | Vulnerability review, auth flows, attack surface analysis |
-| `@dev-team-knuth` | Quality Auditor | Coverage gaps, boundary conditions, correctness verification |
-| `@dev-team-beck` | Test Implementer | Writing tests, TDD cycles, translating audit findings into test cases |
-| `@dev-team-deming` | Tooling Optimizer | Linters, formatters, CI/CD, hooks, onboarding, automation |
-| `@dev-team-tufte` | Documentation Engineer | Doc accuracy, stale docs, README/API docs, doc-code sync |
-| `@dev-team-brooks` | Architect & Quality Reviewer | Architectural review, coupling, ADR compliance, quality attributes (performance, maintainability, scalability) |
-| `@dev-team-conway` | Release Manager | Versioning, changelog, release readiness, semver validation |
-| `@dev-team-drucker` | Team Lead / Orchestrator | Auto-delegates to specialists, manages review loops, resolves conflicts |
-| `@dev-team-turing` | Pre-implementation Researcher | Library evaluation, migration paths, trade-off analysis, security pattern research |
-| `@dev-team-rams` | Design System Reviewer | Token compliance, spacing consistency, component API usage, design-code alignment |
-| `@dev-team-borges` | Librarian | End-of-task memory extraction, cross-agent coherence, system improvement |
+Available agents: `@dev-team-voss`, `@dev-team-hamilton`, `@dev-team-mori`, `@dev-team-szabo`, `@dev-team-knuth`, `@dev-team-beck`, `@dev-team-deming`, `@dev-team-tufte`, `@dev-team-brooks`, `@dev-team-conway`, `@dev-team-drucker`, `@dev-team-turing`, `@dev-team-rams`, `@dev-team-borges`. See `.dev-team/agents/` for full definitions, roles, and when to use each agent.
 
 ### Capabilities
 
@@ -64,25 +49,11 @@ For automatic delegation, use `@dev-team-drucker` — it analyzes the task and r
 
 For non-trivial work: explore the area first, then implement, then review.
 
-**Automatic invocation (hooks):**
-- **Szabo** — auto-flagged when security-sensitive files change (auth, token, session, crypto, etc.)
-- **Knuth** — auto-flagged when any non-test implementation code changes
-- **Mori** — auto-flagged when API contract files change (/api/, /routes/, schema, etc.)
-- **Hamilton** — auto-flagged when infrastructure/operations files change (Dockerfile, docker-compose, CI workflows, Terraform, Helm, k8s, health checks, monitoring config, .env templates, etc.)
-- **Voss** — auto-flagged when app config/data files change (.env, config, migrations, database, etc.)
-- **Deming** — auto-flagged when tooling files change (linter/formatter config, CI workflows, package.json, etc.)
-- **Tufte** — auto-flagged when documentation files change (.md, /docs/, README, etc.) AND when significant implementation files change to detect doc-code drift
-- **Brooks** — auto-flagged when any non-test implementation code changes (quality attributes) and when architectural boundaries are touched (/adr/, /core/, /domain/, /lib/, build config, etc.)
-- **Conway** — auto-flagged when release artifacts change (package.json, changelog, version files, release/publish/deploy workflows, etc.)
-- **Turing** — on-demand only. Spawned by Drucker when task involves library selection, migration, or unfamiliar domain. Not auto-triggered by hooks.
-- **Beck** — auto-flagged when test code files change (`*.test.*`, `*.spec.*`, `__tests__/`, `/test(s)/`)
-- **Rams** — auto-flagged when frontend/UI component files change (same trigger as Mori). Gracefully no-ops when no design system is detected.
+**Automatic invocation (hooks):** Agents are auto-spawned based on changed file patterns. See `.dev-team/hooks/` for the watch-list patterns that determine which agents are triggered. Turing is on-demand only (spawned by Drucker for research tasks).
 
-**End-of-workflow agents:**
-- **Borges** — mandatory at end of every `/dev-team:task`, `/dev-team:review`, `/dev-team:audit`, and `/dev-team:retro`. Extracts structured memory entries, reviews cross-agent coherence, and identifies system improvement opportunities.
+**End-of-workflow agents:** Borges is mandatory at end of every `/dev-team:task`, `/dev-team:review`, `/dev-team:audit`, and `/dev-team:retro`.
 
-**Orchestration:**
-- **Drucker** — delegates tasks to the right implementing agent and spawns reviewers. Szabo, Knuth, and Brooks review all code changes.
+**Orchestration:** Drucker delegates tasks to the right implementing agent and spawns reviewers. Szabo, Knuth, and Brooks review all code changes.
 
 **CRITICAL: Always run agents in the background.** When spawning Drucker or any agent for tasks that take more than a few seconds, use `run_in_background: true`. The main conversation loop must remain interactive.
 
@@ -156,12 +127,12 @@ Project facts, overruled challenges, cross-agent decisions, process rules. All a
 **Tier 2 — Agent calibration memory** (`.dev-team/agent-memory/<agent>/MEMORY.md`):
 Domain-specific findings, known patterns, active watch lists. Each agent owns its own file. Entries include `Last-verified` dates for temporal decay.
 
-| What | Where | Examples |
-|------|-------|---------|
-| Project patterns, process rules, tech debt, overruled challenges | `.dev-team/learnings.md` (Tier 1) | "We use PostgreSQL", "Hooks over guidelines", "Knuth's finding X was overruled because Y" |
-| Agent-specific calibration | `.dev-team/agent-memory/<agent>/MEMORY.md` (Tier 2) | Szabo: "Auth uses JWT not sessions", Knuth: "Coverage weak in parsers" |
-| Formal architecture decisions | `docs/adr/` | ADR format, not learnings |
-| User-specific preferences only | Machine-local memory | Personal style, name, role — things that vary per person, not per project |
+| What | Where |
+|------|-------|
+| Project patterns, process rules, tech debt, overruled challenges | `.dev-team/learnings.md` (Tier 1) |
+| Agent-specific calibration | `.dev-team/agent-memory/<agent>/MEMORY.md` (Tier 2) |
+| Formal architecture decisions | `docs/adr/` |
+| User-specific preferences only | Machine-local memory |
 
 **Memory evolution:** New entries trigger re-evaluation of related existing entries. Duplicates are merged, contradictions are superseded, and 3+ overrules on the same tag generate calibration rules.
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -6,22 +6,7 @@ This project uses [dev-team](https://github.com/dev-team) — adversarial AI age
 
 ### Agents
 
-| Agent | Role | When to use |
-|-------|------|-------------|
-| `@dev-team-voss` | Backend Engineer | API design, data modeling, system architecture, error handling |
-| `@dev-team-hamilton` | Infrastructure Engineer | Dockerfiles, IaC, CI/CD, k8s, deployment, health checks, monitoring |
-| `@dev-team-mori` | Frontend/UI Engineer | Components, accessibility, UX patterns, state management |
-| `@dev-team-szabo` | Security Auditor | Vulnerability review, auth flows, attack surface analysis |
-| `@dev-team-knuth` | Quality Auditor | Coverage gaps, boundary conditions, correctness verification |
-| `@dev-team-beck` | Test Implementer | Writing tests, TDD cycles, translating audit findings into test cases |
-| `@dev-team-deming` | Tooling Optimizer | Linters, formatters, CI/CD, hooks, onboarding, automation |
-| `@dev-team-tufte` | Documentation Engineer | Doc accuracy, stale docs, README/API docs, doc-code sync |
-| `@dev-team-brooks` | Architect & Quality Reviewer | Architectural review, coupling, ADR compliance, quality attributes (performance, maintainability, scalability) |
-| `@dev-team-conway` | Release Manager | Versioning, changelog, release readiness, semver validation |
-| `@dev-team-drucker` | Team Lead / Orchestrator | Auto-delegates to specialists, manages review loops, resolves conflicts |
-| `@dev-team-turing` | Pre-implementation Researcher | Library evaluation, migration paths, trade-off analysis, security pattern research |
-| `@dev-team-rams` | Design System Reviewer | Token compliance, spacing consistency, component API usage, design-code alignment |
-| `@dev-team-borges` | Librarian | End-of-task memory extraction, cross-agent coherence, system improvement |
+Available agents: `@dev-team-voss`, `@dev-team-hamilton`, `@dev-team-mori`, `@dev-team-szabo`, `@dev-team-knuth`, `@dev-team-beck`, `@dev-team-deming`, `@dev-team-tufte`, `@dev-team-brooks`, `@dev-team-conway`, `@dev-team-drucker`, `@dev-team-turing`, `@dev-team-rams`, `@dev-team-borges`. See `.dev-team/agents/` for full definitions, roles, and when to use each agent.
 
 ### Capabilities
 
@@ -29,25 +14,11 @@ For automatic delegation, use `@dev-team-drucker` — it analyzes the task and r
 
 For non-trivial work: explore the area first, then implement, then review.
 
-**Automatic invocation (hooks):**
-- **Szabo** — auto-flagged when security-sensitive files change (auth, token, session, crypto, etc.)
-- **Knuth** — auto-flagged when any non-test implementation code changes
-- **Mori** — auto-flagged when API contract files change (/api/, /routes/, schema, etc.)
-- **Hamilton** — auto-flagged when infrastructure/operations files change (Dockerfile, docker-compose, CI workflows, Terraform, Helm, k8s, health checks, monitoring config, .env templates, etc.)
-- **Voss** — auto-flagged when app config/data files change (.env, config, migrations, database, etc.)
-- **Deming** — auto-flagged when tooling files change (linter/formatter config, CI workflows, package.json, etc.)
-- **Tufte** — auto-flagged when documentation files change (.md, /docs/, README, etc.) AND when significant implementation files change to detect doc-code drift
-- **Brooks** — auto-flagged when any non-test implementation code changes (quality attributes) and when architectural boundaries are touched (/adr/, /core/, /domain/, /lib/, build config, etc.)
-- **Conway** — auto-flagged when release artifacts change (package.json, changelog, version files, release/publish/deploy workflows, etc.)
-- **Turing** — on-demand only. Spawned by Drucker when task involves library selection, migration, or unfamiliar domain. Not auto-triggered by hooks.
-- **Beck** — auto-flagged when test code files change (`*.test.*`, `*.spec.*`, `__tests__/`, `/test(s)/`)
-- **Rams** — auto-flagged when frontend/UI component files change (same trigger as Mori). Gracefully no-ops when no design system is detected.
+**Automatic invocation (hooks):** Agents are auto-spawned based on changed file patterns. See `.dev-team/hooks/` for the watch-list patterns that determine which agents are triggered. Turing is on-demand only (spawned by Drucker for research tasks).
 
-**End-of-workflow agents:**
-- **Borges** — mandatory at end of every `/dev-team:task`, `/dev-team:review`, `/dev-team:audit`, and `/dev-team:retro`. Extracts structured memory entries, reviews cross-agent coherence, and identifies system improvement opportunities.
+**End-of-workflow agents:** Borges is mandatory at end of every `/dev-team:task`, `/dev-team:review`, `/dev-team:audit`, and `/dev-team:retro`.
 
-**Orchestration:**
-- **Drucker** — delegates tasks to the right implementing agent and spawns reviewers. Szabo, Knuth, and Brooks review all code changes.
+**Orchestration:** Drucker delegates tasks to the right implementing agent and spawns reviewers. Szabo, Knuth, and Brooks review all code changes.
 
 **CRITICAL: Always run agents in the background.** When spawning Drucker or any agent for tasks that take more than a few seconds, use `run_in_background: true`. The main conversation loop must remain interactive.
 
@@ -128,12 +99,12 @@ Project facts, overruled challenges, cross-agent decisions, process rules. All a
 **Tier 2 — Agent calibration memory** (`.dev-team/agent-memory/<agent>/MEMORY.md`):
 Domain-specific findings, known patterns, active watch lists. Each agent owns its own file. Entries include `Last-verified` dates for temporal decay.
 
-| What | Where | Examples |
-|------|-------|---------|
-| Project patterns, process rules, tech debt, overruled challenges | `.dev-team/learnings.md` (Tier 1) | "We use PostgreSQL", "Hooks over guidelines", "Knuth's finding X was overruled because Y" |
-| Agent-specific calibration | `.dev-team/agent-memory/<agent>/MEMORY.md` (Tier 2) | Szabo: "Auth uses JWT not sessions", Knuth: "Coverage weak in parsers" |
-| Formal architecture decisions | `docs/adr/` | ADR format, not learnings |
-| User-specific preferences only | Machine-local memory | Personal style, name, role — things that vary per person, not per project |
+| What | Where |
+|------|-------|
+| Project patterns, process rules, tech debt, overruled challenges | `.dev-team/learnings.md` (Tier 1) |
+| Agent-specific calibration | `.dev-team/agent-memory/<agent>/MEMORY.md` (Tier 2) |
+| Formal architecture decisions | `docs/adr/` |
+| User-specific preferences only | Machine-local memory |
 
 **Memory evolution:** New entries trigger re-evaluation of related existing entries. Duplicates are merged, contradictions are superseded, and 3+ overrules on the same tag generate calibration rules.
 

--- a/templates/agent-memory/dev-team-beck/MEMORY.md
+++ b/templates/agent-memory/dev-team-beck/MEMORY.md
@@ -2,6 +2,8 @@
 <!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
 <!-- First 200 lines are loaded into agent context. Keep concise. -->
 <!-- Borges extracts structured entries automatically after each task. -->
+<!-- Discoverability filter: before writing an entry, verify it cannot be discovered -->
+<!-- by reading code or config files. Memory is for calibration and non-obvious knowledge. -->
 
 ## Structured Entries
 <!-- Format:

--- a/templates/agent-memory/dev-team-borges/MEMORY.md
+++ b/templates/agent-memory/dev-team-borges/MEMORY.md
@@ -2,6 +2,8 @@
 <!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
 <!-- First 200 lines are loaded into agent context. Keep concise. -->
 <!-- Borges extracts structured entries automatically after each task. -->
+<!-- Discoverability filter: before writing an entry, verify it cannot be discovered -->
+<!-- by reading code or config files. Memory is for calibration and non-obvious knowledge. -->
 
 ## Structured Entries
 <!-- Format:

--- a/templates/agent-memory/dev-team-brooks/MEMORY.md
+++ b/templates/agent-memory/dev-team-brooks/MEMORY.md
@@ -2,6 +2,8 @@
 <!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
 <!-- First 200 lines are loaded into agent context. Keep concise. -->
 <!-- Borges extracts structured entries automatically after each task. -->
+<!-- Discoverability filter: before writing an entry, verify it cannot be discovered -->
+<!-- by reading code or config files. Memory is for calibration and non-obvious knowledge. -->
 
 ## Structured Entries
 <!-- Format:

--- a/templates/agent-memory/dev-team-conway/MEMORY.md
+++ b/templates/agent-memory/dev-team-conway/MEMORY.md
@@ -2,6 +2,8 @@
 <!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
 <!-- First 200 lines are loaded into agent context. Keep concise. -->
 <!-- Borges extracts structured entries automatically after each task. -->
+<!-- Discoverability filter: before writing an entry, verify it cannot be discovered -->
+<!-- by reading code or config files. Memory is for calibration and non-obvious knowledge. -->
 
 ## Structured Entries
 <!-- Format:

--- a/templates/agent-memory/dev-team-deming/MEMORY.md
+++ b/templates/agent-memory/dev-team-deming/MEMORY.md
@@ -2,6 +2,8 @@
 <!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
 <!-- First 200 lines are loaded into agent context. Keep concise. -->
 <!-- Borges extracts structured entries automatically after each task. -->
+<!-- Discoverability filter: before writing an entry, verify it cannot be discovered -->
+<!-- by reading code or config files. Memory is for calibration and non-obvious knowledge. -->
 
 ## Structured Entries
 <!-- Format:

--- a/templates/agent-memory/dev-team-drucker/MEMORY.md
+++ b/templates/agent-memory/dev-team-drucker/MEMORY.md
@@ -2,6 +2,8 @@
 <!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
 <!-- First 200 lines are loaded into agent context. Keep concise. -->
 <!-- Borges extracts structured entries automatically after each task. -->
+<!-- Discoverability filter: before writing an entry, verify it cannot be discovered -->
+<!-- by reading code or config files. Memory is for calibration and non-obvious knowledge. -->
 
 ## Structured Entries
 <!-- Format:

--- a/templates/agent-memory/dev-team-hamilton/MEMORY.md
+++ b/templates/agent-memory/dev-team-hamilton/MEMORY.md
@@ -2,6 +2,8 @@
 <!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
 <!-- First 200 lines are loaded into agent context. Keep concise. -->
 <!-- Borges extracts structured entries automatically after each task. -->
+<!-- Discoverability filter: before writing an entry, verify it cannot be discovered -->
+<!-- by reading code or config files. Memory is for calibration and non-obvious knowledge. -->
 
 ## Structured Entries
 <!-- Format:

--- a/templates/agent-memory/dev-team-knuth/MEMORY.md
+++ b/templates/agent-memory/dev-team-knuth/MEMORY.md
@@ -2,6 +2,8 @@
 <!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
 <!-- First 200 lines are loaded into agent context. Keep concise. -->
 <!-- Borges extracts structured entries automatically after each task. -->
+<!-- Discoverability filter: before writing an entry, verify it cannot be discovered -->
+<!-- by reading code or config files. Memory is for calibration and non-obvious knowledge. -->
 
 ## Structured Entries
 <!-- Format:

--- a/templates/agent-memory/dev-team-mori/MEMORY.md
+++ b/templates/agent-memory/dev-team-mori/MEMORY.md
@@ -2,6 +2,8 @@
 <!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
 <!-- First 200 lines are loaded into agent context. Keep concise. -->
 <!-- Borges extracts structured entries automatically after each task. -->
+<!-- Discoverability filter: before writing an entry, verify it cannot be discovered -->
+<!-- by reading code or config files. Memory is for calibration and non-obvious knowledge. -->
 
 ## Structured Entries
 <!-- Format:

--- a/templates/agent-memory/dev-team-rams/MEMORY.md
+++ b/templates/agent-memory/dev-team-rams/MEMORY.md
@@ -2,6 +2,8 @@
 <!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
 <!-- First 200 lines are loaded into agent context. Keep concise. -->
 <!-- Borges extracts structured entries automatically after each task. -->
+<!-- Discoverability filter: before writing an entry, verify it cannot be discovered -->
+<!-- by reading code or config files. Memory is for calibration and non-obvious knowledge. -->
 
 ## Structured Entries
 <!-- Format:

--- a/templates/agent-memory/dev-team-szabo/MEMORY.md
+++ b/templates/agent-memory/dev-team-szabo/MEMORY.md
@@ -2,6 +2,8 @@
 <!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
 <!-- First 200 lines are loaded into agent context. Keep concise. -->
 <!-- Borges extracts structured entries automatically after each task. -->
+<!-- Discoverability filter: before writing an entry, verify it cannot be discovered -->
+<!-- by reading code or config files. Memory is for calibration and non-obvious knowledge. -->
 
 ## Structured Entries
 <!-- Format:

--- a/templates/agent-memory/dev-team-tufte/MEMORY.md
+++ b/templates/agent-memory/dev-team-tufte/MEMORY.md
@@ -2,6 +2,8 @@
 <!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
 <!-- First 200 lines are loaded into agent context. Keep concise. -->
 <!-- Borges extracts structured entries automatically after each task. -->
+<!-- Discoverability filter: before writing an entry, verify it cannot be discovered -->
+<!-- by reading code or config files. Memory is for calibration and non-obvious knowledge. -->
 
 ## Structured Entries
 <!-- Format:

--- a/templates/agent-memory/dev-team-turing/MEMORY.md
+++ b/templates/agent-memory/dev-team-turing/MEMORY.md
@@ -2,6 +2,8 @@
 <!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
 <!-- First 200 lines are loaded into agent context. Keep concise. -->
 <!-- Borges extracts structured entries automatically after each task. -->
+<!-- Discoverability filter: before writing an entry, verify it cannot be discovered -->
+<!-- by reading code or config files. Memory is for calibration and non-obvious knowledge. -->
 
 ## Structured Entries
 <!-- Format:

--- a/templates/agent-memory/dev-team-voss/MEMORY.md
+++ b/templates/agent-memory/dev-team-voss/MEMORY.md
@@ -2,6 +2,8 @@
 <!-- Tier 2: Agent calibration memory. Domain-specific findings, patterns, and watch lists. -->
 <!-- First 200 lines are loaded into agent context. Keep concise. -->
 <!-- Borges extracts structured entries automatically after each task. -->
+<!-- Discoverability filter: before writing an entry, verify it cannot be discovered -->
+<!-- by reading code or config files. Memory is for calibration and non-obvious knowledge. -->
 
 ## Structured Entries
 <!-- Format:

--- a/templates/agents/dev-team-borges.md
+++ b/templates/agents/dev-team-borges.md
@@ -70,6 +70,7 @@ Write entries to the appropriate agent's MEMORY.md using the structured format:
 - Entries that record specific numeric metrics derivable from the codebase (test counts, file counts, line counts)
 - Entries that merely restate what is in `package.json`, `tsconfig.json`, or other config files
 - Entries that duplicate existing ADRs or `.dev-team/learnings.md` entries
+- **Discoverability test:** Before writing any entry, ask: "Can an agent learn this by reading the code, config files, or directory structure?" If yes, do not write it. Focus on: calibration data, non-obvious conventions, overruled findings, cross-agent coherence issues.
 
 **Extraction rules:**
 - Every accepted DEFECT becomes a memory entry for the reviewer who found it (reinforcement)

--- a/templates/dev-team-learnings.md
+++ b/templates/dev-team-learnings.md
@@ -3,6 +3,10 @@
 <!-- Read by ALL agents at session start. Keep under 200 lines. -->
 <!-- For formal decisions, use ADRs instead. This file captures organic learnings. -->
 
+## What NOT to write here
+
+Before writing an entry, ask: "Can an agent discover this by reading the code or config files?" If yes, don't write it. Learnings are for process rules, overruled challenges, and non-obvious conventions — not documentation of project structure, tech stack, or framework choices.
+
 ## Coding Conventions
 
 

--- a/templates/skills/dev-team-retro/SKILL.md
+++ b/templates/skills/dev-team-retro/SKILL.md
@@ -100,6 +100,11 @@ Check the project's `CLAUDE.md` for:
 ### Learnings promotion
 - Mature learnings that have been stable for multiple sessions and should be promoted to `CLAUDE.md` instructions
 
+### Instruction surface health
+- Count lines in the CLAUDE.md managed section (between `<!-- dev-team:begin -->` and `<!-- dev-team:end -->` markers) — flag as `[RISK]` if over 100 lines
+- Scan `.dev-team/learnings.md` for entries that describe information discoverable from code or config files (e.g., tech stack, project structure, framework choices) — flag each for removal
+- Report a "discoverable content ratio": number of flagged entries / total entries
+
 ## Phase 4: Calibration metrics audit (`.dev-team/metrics.md`)
 
 If `.dev-team/metrics.md` exists and contains entries, analyze:


### PR DESCRIPTION
## Summary
- Slims `templates/CLAUDE.md` by ~30 lines: replaces 14-row agent table with compressed name list, replaces 12-line hook trigger descriptions with brief pointer to `.dev-team/hooks/`, removes examples column from memory architecture table
- Adds discoverability filtering rules to learnings template, all 14 agent memory templates, and Borges extraction filter
- Adds instruction surface bloat detection to retro skill (line count check, discoverable content ratio) and dogfood skill (template bloat audit)
- Updates self-use copies (CLAUDE.md managed section, Borges agent, retro skill)

## Test plan
- [x] `npm test` — all 327 tests pass
- [x] `npm run validate:agents` — all 14 agents valid
- [x] `node scripts/validate-readme.js` — README validation passed

Closes #318