### PR TITLE
fix: document metrics install path constraint (#359)

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -320,6 +320,8 @@ export async function run(targetDir: string, flags: string[] = []): Promise<void
   }
 
   // Step 8b: Create metrics log
+  // Install destination must be .dev-team/metrics.md — skills (task, review, retro)
+  // and agents (Borges, Drucker) reference this exact path for calibration metrics.
   const metricsSrc = path.join(templates, "dev-team-metrics.md");
   const metricsDest = path.join(devTeamDir, "metrics.md");
   if (!fileExists(metricsDest)) {


### PR DESCRIPTION
## Summary
- Verified that the metrics file install path in `src/init.ts` (`.dev-team/metrics.md`) matches all skill and agent references
- Skills referencing this path: `dev-team-task`, `dev-team-review`, `dev-team-retro`
- Agents referencing this path: `dev-team-borges`, `dev-team-drucker`
- Added a comment documenting this load-bearing path constraint to prevent future drift

No functional changes — paths already aligned correctly.

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)