### PR TITLE
chore: Borges memory extraction for v1.5.0

### DIFF
--- a/.dev-team/agent-memory/dev-team-borges/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-borges/MEMORY.md
@@ -42,3 +42,19 @@
 
 ### [2026-03-25] v1.2.0 extraction — high defer rate on advisory findings
 - Knuth's 50% advisory defer rate (7/14) is not a quality problem — deferred items were legitimate follow-ups outside the PR scope. But it signals that `/dev-team:retro` should track defer-to-issue conversion (are deferred findings actually becoming issues?).
+
+### [2026-03-26] v1.5.0 extraction — 18 findings, 100% acceptance, 1 round to convergence
+- **Type**: MILESTONE [verified]
+- **Source**: v1.5.0 task loop (14 issues, 15 PRs)
+- **Tags**: metrics, calibration, extraction
+- **Outcome**: verified
+- **Last-verified**: 2026-03-26
+- **Context**: Largest task batch to date. 8 DEFECTs + 10 advisory, all fixed in first pass. Copilot was the primary reviewer (no in-team agents reviewing). Brooks provided pre-assessment. Key process learnings: merge-as-you-go for sequential chains, Copilot comments must be monitored during delivery not just at merge time. 3 new ADRs, SHARED.md extraction, process.md extraction, platform detection, scorecard skill added. Cleaned up 2 bootstrapped entries (Turing "first install", Rams "first install").
+
+### [2026-03-26] Deming pattern duplication entry superseded
+- **Type**: COHERENCE [resolved]
+- **Source**: cross-agent audit
+- **Tags**: coherence, deming, patterns
+- **Outcome**: resolved
+- **Last-verified**: 2026-03-26
+- **Context**: Deming had a RISK entry about review-gate pattern duplication. This was resolved in PR #344 (agent-patterns.json extraction). Updated entry from [acknowledged] to [resolved].

--- a/.dev-team/agent-memory/dev-team-brooks/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-brooks/MEMORY.md
@@ -16,7 +16,7 @@
 - **Source**: project structure analysis
 - **Tags**: architecture, modules, build
 - **Outcome**: verified
-- **Last-verified**: 2026-03-25
+- **Last-verified**: 2026-03-26
 - **Context**: src/ contains core modules (init, files, scan, create-agent, update, doctor, status, skill-recommendations, prompts). bin/dev-team.js is the CLI shim. templates/ contains agents, hooks, skills shipped to target projects. .dev-team/ is self-use only.
 
 ### [2026-03-25] Strict separation: templates/ (shipped) vs .dev-team/ (self-use)
@@ -24,7 +24,7 @@
 - **Source**: CLAUDE.md + package.json files array
 - **Tags**: architecture, boundaries
 - **Outcome**: verified
-- **Last-verified**: 2026-03-25
+- **Last-verified**: 2026-03-26
 - **Context**: templates/ contains what gets installed in target projects. .dev-team/ contains dev-team's own agents/hooks/skills for dogfooding. Improvements must target templates/ to ship in releases — never modify .dev-team/ for improvements (overwritten by update).
 
 ### [2026-03-25] Agent proliferation governed by ADR-022 — soft cap of 15
@@ -37,6 +37,21 @@
 
 ## Patterns to Watch For
 
+### [2026-03-26] Sequential chain merges must integrate-as-you-go
+- **Type**: PATTERN [verified]
+- **Source**: PR #375 (fix/374), Brooks pre-assessment finding
+- **Tags**: orchestration, merging, sequential-chains
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-26
+- **Context**: When issues form a sequential chain (each depending on the previous), each PR must be merged before the next agent branches. Branching from stale main nullifies the sequencing. This was a process gap discovered during v1.5.0 delivery.
+
+### [2026-03-26] SHARED.md extraction pattern for agent definitions (ADR-030)
+- **Type**: DECISION [verified]
+- **Source**: PR #376 (feat/353), ADR-030
+- **Tags**: architecture, agents, shared-protocol
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-26
+- **Context**: Common agent protocol sections extracted to SHARED.md to reduce duplication. ~16% reduction in total agent definition lines. Brooks should watch for drift between SHARED.md and individual agent overrides.
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->

--- a/.dev-team/agent-memory/dev-team-conway/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-conway/MEMORY.md
@@ -83,5 +83,13 @@
 - **Last-verified**: 2026-03-25
 - **Context**: Patch releases: verify all PRs merged, create branch `chore/release-v{x.y.z}`, add CHANGELOG section under [Unreleased] with `### Fixed` only, `npm version {x.y.z} --no-git-tag-version`, commit, push, create PR, close milestone. Do NOT merge — wait for human. After merge: tag and release workflow handles npm publish.
 
+### [2026-03-26] Changelog grouping: within categories, not across them
+- **Type**: CALIBRATION [verified]
+- **Source**: PR #363 (fix/357), Copilot finding
+- **Tags**: changelog, formatting, release
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-26
+- **Context**: Changelog entries should be grouped within their Added/Changed/Fixed/Internal categories, not across them. Conway definition updated to clarify this convention.
+
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->

--- a/.dev-team/agent-memory/dev-team-deming/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-deming/MEMORY.md
@@ -8,7 +8,7 @@
 - **Source**: package.json + ADR-007 analysis
 - **Tags**: linting, formatting, tooling, oxc
 - **Outcome**: verified
-- **Last-verified**: 2026-03-25
+- **Last-verified**: 2026-03-26
 - **Context**: OXC toolchain chosen for speed. npm run lint uses oxlint on src/, scripts/, templates/hooks/. npm run format uses oxfmt. CI enforces both via lint-and-format job. Format check runs oxfmt --check.
 
 ### [2026-03-25] Hooks enforce quality gates — TDD, safety, review, lint, gate, watch list
@@ -16,7 +16,7 @@
 - **Source**: templates/hooks/ analysis
 - **Tags**: hooks, enforcement, dx
 - **Outcome**: verified
-- **Last-verified**: 2026-03-25
+- **Last-verified**: 2026-03-26
 - **Context**: dev-team-tdd-enforce.js (TDD), dev-team-safety-guard.js (safety), dev-team-post-change-review.js (review spawning), dev-team-pre-commit-lint.js (lint), dev-team-pre-commit-gate.js (blocking gate), dev-team-watch-list.js (file watch triggers). ADR-001: hooks over CLAUDE.md for enforcement.
 
 ### [2026-03-25] Agent and hook validation scripts run in CI
@@ -46,10 +46,26 @@
 ## Hook Effectiveness
 
 ### [2026-03-26] Review gate pattern duplication with post-change-review
-- **Type**: RISK [acknowledged]
+- **Type**: RISK [resolved]
 - **Tags**: hooks, maintenance
 - **Last-verified**: 2026-03-26
-- **Context**: review-gate.js duplicates the pattern arrays from post-change-review.js for deriveRequiredAgents(). This is intentional — the hooks must be independently deployable (no shared imports in template hooks). If patterns change in one, they must change in both. Consider extracting shared patterns to a JSON file in a future iteration.
+- **Context**: Pattern duplication was resolved by extracting shared patterns to `.dev-team/hooks/agent-patterns.json` (PR #344). Both hooks now import from a single source. Superseded by the shared pattern extraction approach.
+
+### [2026-03-26] SHARED.md protocol reduces agent definition duplication by ~16%
+- **Type**: DECISION [verified]
+- **Source**: PR #376 (feat/353), ADR-030
+- **Tags**: agents, templates, shared-protocol, dx
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-26
+- **Context**: Common agent sections (progress reporting, memory hygiene, challenge protocol) extracted to SHARED.md. Agent definitions include it via reference. Reduces 1873→1574 total lines. ADR-030 governs the shared protocol pattern.
+
+### [2026-03-26] Process rules extracted from CLAUDE.md to dev-team-process.md
+- **Type**: DECISION [verified]
+- **Source**: PR #373, ADR-031
+- **Tags**: process, dx, claude-md, templates
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-26
+- **Context**: CLAUDE.md was growing unwieldy. Process rules now live in a dedicated file, keeping CLAUDE.md under 100 lines. ADR-031 governs the extraction.
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->

--- a/.dev-team/agent-memory/dev-team-drucker/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-drucker/MEMORY.md
@@ -16,7 +16,7 @@
 - **Source**: docs/adr/019-parallel-review-waves.md
 - **Tags**: orchestration, parallelism, review
 - **Outcome**: verified
-- **Last-verified**: 2026-03-25
+- **Last-verified**: 2026-03-26
 - **Context**: Brooks assesses file independence, implementations run concurrently in worktrees, reviews batched into coordinated wave, defects route back per-branch, Borges runs once across all branches at end.
 
 ### [2026-03-25] Agent proliferation check before recommending new agents (ADR-022)
@@ -34,6 +34,14 @@
 - **Outcome**: verified
 - **Last-verified**: 2026-03-25
 - **Context**: Must load actual agent definition from .dev-team/agents/dev-team-*.md when spawning. Do NOT use pr-review-toolkit proxies — different behavior. Use subagent_type: "general-purpose".
+
+### [2026-03-26] Sequential chains require merge-as-you-go orchestration
+- **Type**: PATTERN [verified]
+- **Source**: PR #375 (fix/374), v1.5.0 process learning
+- **Tags**: orchestration, merging, sequential-chains
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-26
+- **Context**: When multiple issues form a dependency chain, each PR must be merged before the next agent starts. Batching merges at the end causes agents to branch from stale main, nullifying the sequencing. Drucker must integrate-as-you-go, not batch-at-end.
 
 ## Conflict Resolution Log
 

--- a/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
@@ -53,3 +53,11 @@
 - Advisory findings: 7 accepted, 7 deferred (follow-up issues), 0 overruled.
 - Deferred items are legitimate follow-ups, not rejections. Calibration signal: advisory finding quality is good but volume could be tuned — 7 deferred out of 14 advisory suggests some findings are premature for the current scope.
 - Watch: "section name collision" and "overlap" findings tend to get deferred. Consider raising threshold for naming/overlap suggestions unless they cause functional ambiguity.
+
+### [2026-03-26] Review skill had wrong path for agent-patterns.json
+- **Type**: DEFECT [fixed]
+- **Source**: PR #365 (fix/355), Copilot finding
+- **Tags**: routing, review-skill, path
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-26
+- **Context**: Review skill referenced agent-patterns.json at wrong path. Corrected to `.dev-team/hooks/agent-patterns.json`. Path correctness is a recurring theme — verify paths in skill definitions during review.

--- a/.dev-team/agent-memory/dev-team-rams/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-rams/MEMORY.md
@@ -3,10 +3,10 @@
 
 ## Design System Patterns
 
-### [2026-03-25] First install — no design system detected yet
+### [2026-03-26] CLI project — no design system, Rams scoped to accessibility observations
 - **Type**: PATTERN [verified]
-- **Source**: initial setup
-- **Tags**: design-system, tokens, setup
+- **Source**: v1.5.0 agent definition update (PR #363)
+- **Tags**: design-system, accessibility, scope
 - **Outcome**: verified
-- **Last-verified**: 2026-03-25
-- **Context**: Rams was added in v1.1. Gracefully no-ops when no design token system is detected. Reviews token compliance, spacing consistency, and component API usage.
+- **Last-verified**: 2026-03-26
+- **Context**: No browser UI, no design tokens, no CSS. Rams role scoped to passive accessibility observations in doc outputs and CLI formatting. Copilot finding in fix/357 clarified: accessibility scope should not conflict with broader UI concerns that don't exist here.

--- a/.dev-team/agent-memory/dev-team-szabo/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-szabo/MEMORY.md
@@ -40,3 +40,11 @@
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
+
+### [2026-03-26] Platform detection defaults to github — no fallback risk
+- **Type**: RISK [fixed]
+- **Source**: PR #371 (feat/358), Copilot finding
+- **Tags**: platform, config, security
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-26
+- **Context**: Skills now detect platform from config (default: github). When platform field is absent (pre-v1.5 installs), skills default to github rather than failing. update.ts backfills the platform field on upgrade.

--- a/.dev-team/agent-memory/dev-team-tufte/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-tufte/MEMORY.md
@@ -56,3 +56,19 @@
 - **Outcome**: fixed
 - **Last-verified**: 2026-03-26
 - **Context**: ADR-012 only specifies a freshness reminder, not append-only semantics. Append-only was an emergent practice. Be precise about what an ADR actually mandates vs what emerged organically.
+
+### [2026-03-26] ADR README index status vocabulary expanded
+- **Type**: SUGGESTION [fixed]
+- **Source**: PR #361 Copilot finding
+- **Tags**: adr, documentation, vocabulary
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-26
+- **Context**: ADR README.md status table was missing "superseded" and "amended" statuses. Added during ADR-032 work. Keep status vocabulary in sync when new lifecycle states are introduced.
+
+### [2026-03-26] Three new ADRs added in v1.5.0: 030, 031, 032
+- **Type**: DECISION [verified]
+- **Source**: PRs #376, #373, #361
+- **Tags**: adr, documentation
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-26
+- **Context**: ADR-030 (shared agent protocol/SHARED.md), ADR-031 (process rules extraction), ADR-032 (memory write semantics — archive vs remove, seed vs real entries). All accepted status.

--- a/.dev-team/agent-memory/dev-team-turing/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-turing/MEMORY.md
@@ -3,13 +3,21 @@
 
 ## Research Patterns
 
-### [2026-03-25] First install — no research history yet
-- **Type**: PATTERN [verified]
-- **Source**: initial setup
-- **Tags**: research, setup
-- **Outcome**: verified
-- **Last-verified**: 2026-03-25
-- **Context**: Turing was added in v1.1. Research briefs will be written to .dev-team/research/. Borges manages temporal decay (90-day archive).
+### [2026-03-26] Research brief template now includes Recommended Actions section
+- **Type**: DECISION [verified]
+- **Source**: PR #369
+- **Tags**: research, template, output-format
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-26
+- **Context**: Research briefs must end with a Recommended Actions section for triage-ready output. This was a process learning from v1.5.0 — briefs without actionable recommendations require extra triage work by the orchestrator.
+
+### [2026-03-26] Memory writes should capture decisions and calibration, not repeat findings
+- **Type**: CALIBRATION [verified]
+- **Source**: PR #363 Copilot finding (fix/357)
+- **Tags**: memory, research, calibration
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-26
+- **Context**: Turing memory entries should capture calibration data (what to test, which patterns to verify) rather than duplicating the research brief content. The brief is the authoritative source; memory captures what shapes future research behavior.
 
 ### [2026-03-26] Multi-user concurrency model (#257)
 - **Type**: RESEARCH [completed]

--- a/.dev-team/agent-memory/dev-team-voss/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-voss/MEMORY.md
@@ -29,6 +29,13 @@
 
 ## Patterns to Watch For
 
+### [2026-03-26] mergeSettings() must track Set state after push — dedup bug in src/files.ts
+- **Type**: DEFECT [fixed]
+- **Source**: PR #367 (fix/364), Copilot finding
+- **Tags**: merge-logic, settings, dedup
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-26
+- **Context**: mergeSettings() pushed new commands into the array but did not update the Set used for dedup tracking. Also required null-safe normalization for hooks (` ?? []`) and a consolidation pass for duplicate matcher blocks. Three related DEFECTs fixed together.
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->

--- a/.dev-team/learnings.md
+++ b/.dev-team/learnings.md
@@ -23,6 +23,7 @@
 - **Release publishing is automated via CI.** After merging the release PR, push the git tag — the `release.yml` workflow handles npm publish and GitHub release creation automatically. Do NOT manually run `npm publish` or `gh release create` — this causes CI job failures (duplicate release) and wasted effort (no local npm auth).
 - **Improvements must be project-agnostic and target `templates/`.** Never modify `.dev-team/` directly for improvements — those files get overwritten by `dev-team update`. All improvements go into `templates/` and ship in future versions. Project-specific conventions stay in local learnings only.
 - **Dogfooding is the product loop.** Using dev-team on dev-team surfaces friction → `/dev-team:retro` captures patterns → issues target `templates/` → next release improves the tool for everyone. Every session is a test run.
+- **Merge-as-you-go for sequential chains.** When issues depend on each other, merge each PR before spawning the next agent. Batching merges at the end causes stale-main branching. (Learned v1.5.0, now in process.md and Drucker definition.)
 
 ## Known Tech Debt
 
@@ -43,8 +44,9 @@
 - Last Borges run: not tracked yet (Borges spawning is now enforced via skill definitions)
 - Pre-commit gate: blocks commits without memory updates (override via `.dev-team/.memory-reviewed`)
 - All implementing agents have mandatory Learnings Output section in their definitions
-- First calibration metrics entry recorded for v1.2.0. All future tasks should append to `.dev-team/metrics.md`.
+- First calibration metrics entry recorded for v1.2.0. All future tasks should append to `.dev-team/metrics.md`. Second entry: v1.5.0 (18 findings, 100% acceptance, 1 round).
 - Finding Outcome Log vocabulary is standardized: outcomes are `fixed`, `accepted`, `deferred`, `overruled`, `ignored`. All skills and agents must use this vocabulary.
+- Agent definitions share common sections via SHARED.md (ADR-030). Process rules extracted to dev-team-process.md (ADR-031). Memory write semantics clarified in ADR-032.
 
 ## Overruled Challenges
 <!-- When the human overrules an agent, record why — prevents re-flagging -->

--- a/.dev-team/metrics.md
+++ b/.dev-team/metrics.md
@@ -36,3 +36,17 @@
   - [SUGGESTION] Pre-commit gate wording inaccuracy across agent templates (PR #277, 6 files) → #323
   - [SUGGESTION] Promotion opportunities section undefined in report format (PR #279) → #283 (closed)
 
+### [2026-03-26] Task: v1.5.0 delivery (#353, #354, #355, #356, #357, #358, #359, #364, #368, #374, #351, #348, #335, #325)
+- **Agents**: implementing: Voss, Deming, Tufte, Turing; pre-assessment: Brooks; reviewers: Copilot
+- **Rounds**: 1
+- **Findings**:
+  - Copilot: 8 DEFECT (8 fixed / 0 overruled), 7 RISK (7 fixed / 0 overruled), 1 SUGGESTION (1 fixed / 0 overruled)
+  - CI: 1 DEFECT (1 fixed / 0 overruled)
+  - Brooks: 1 SUGGESTION (1 fixed / 0 overruled)
+- **Acceptance rate**: 100% (18 fixed / 18 total)
+- **Overrule rate**: 0% (0 / 18)
+- **Fix rate (DEFECTs)**: 100% (9/9)
+- **Defer rate (advisory)**: 0% (0/9)
+- **Duration**: single session, 15 PRs across sequential and parallel branches
+- **Notes**: Largest batch to date. All findings addressed in first pass — zero deferred, zero overruled. Copilot was the primary code reviewer. Key themes: path correctness (findings #7, #12), null safety in merge logic (#1-3), documentation precision (#4-6, #9-11), and platform field backfill (#15-16). Process improvement: merge-as-you-go for sequential chains (#18).
+


### PR DESCRIPTION
## Summary
- Extract structured memory entries from 18 findings across 15 merged PRs in the v1.5.0 delivery
- Update 11 agent memories (Voss, Deming, Tufte, Turing, Brooks, Conway, Knuth, Szabo, Rams, Drucker, Borges)
- Update shared learnings with merge-as-you-go pattern and ADR references
- Record v1.5.0 calibration metrics (100% acceptance rate, 1 round to convergence)
- Clean up 2 bootstrapped entries (Turing "first install", Rams "first install")
- Resolve stale Deming pattern-duplication entry (now resolved via agent-patterns.json)
- Update Last-verified dates on 5 entries whose domains were touched

## Test plan
- [ ] Verify all MEMORY.md files are under 200-line cap
- [ ] Verify no duplicate entries across agent memories
- [ ] Verify metrics entry format matches template in metrics.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)