### PR TITLE
chore: Borges memory extraction for v1.5.1 hotfix

### DIFF
--- a/.dev-team/agent-memory/dev-team-borges/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-borges/MEMORY.md
@@ -51,6 +51,14 @@
 - **Last-verified**: 2026-03-26
 - **Context**: Largest task batch to date. 8 DEFECTs + 10 advisory, all fixed in first pass. Copilot was the primary reviewer (no in-team agents reviewing). Brooks provided pre-assessment. Key process learnings: merge-as-you-go for sequential chains, Copilot comments must be monitored during delivery not just at merge time. 3 new ADRs, SHARED.md extraction, process.md extraction, platform detection, scorecard skill added. Cleaned up 2 bootstrapped entries (Turing "first install", Rams "first install").
 
+### [2026-03-26] v1.5.1 extraction — 6 findings, 1 fixed, 5 ignored (install artifacts)
+- **Type**: MILESTONE [verified]
+- **Source**: v1.5.1 hotfix (#397, PR #398)
+- **Tags**: metrics, calibration, extraction
+- **Outcome**: verified
+- **Last-verified**: 2026-03-26
+- **Context**: Small hotfix. High ignore rate (83%) is not a signal quality issue — 5 ignored findings were all about local install artifact paths (hook files not committed to repo). The 1 DEFECT (contradiction in process.md) was fixed. New memory entries written for Deming (guarded files) and Conway (guarded files + update testing). Design principle "Don't encode what agents already know" was already in learnings from a prior commit in this session.
+
 ### [2026-03-26] Deming pattern duplication entry superseded
 - **Type**: COHERENCE [resolved]
 - **Source**: cross-agent audit

--- a/.dev-team/agent-memory/dev-team-conway/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-conway/MEMORY.md
@@ -66,7 +66,7 @@
 - **Source**: update.ts migration system, v1.0.0 skillRemovals migration
 - **Tags**: update, migration, breaking-change
 - **Outcome**: verified
-- **Last-verified**: 2026-03-25
+- **Last-verified**: 2026-03-26
 - **Context**: The MIGRATIONS array in update.ts supports agentRenames (v0.4.0) and skillRemovals (v1.0.0). When `dev-team update` detects the user's installed version is older, it runs all applicable migrations. Added skillRemovals to clean up legacy workflow skill dirs.
 
 ### [2026-03-25] Close milestone after release PR creation
@@ -90,6 +90,14 @@
 - **Outcome**: fixed
 - **Last-verified**: 2026-03-26
 - **Context**: Changelog entries should be grouped within their Added/Changed/Fixed/Internal categories, not across them. Conway definition updated to clarify this convention.
+
+### [2026-03-26] Guarded files: learnings.md, metrics.md, process.md — never overwritten
+- **Type**: PATTERN [verified]
+- **Source**: PR #398 (fix/397)
+- **Tags**: update, guarded-files, release
+- **Outcome**: verified
+- **Last-verified**: 2026-03-26
+- **Context**: update.ts guards three user-editable files in .dev-team/: learnings.md, metrics.md, and process.md. These are only installed if missing (for upgrades from older versions). All other .dev-team/ files are overwritten on update. This matters for release testing — verify guarded files survive `dev-team update`.
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->

--- a/.dev-team/agent-memory/dev-team-deming/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-deming/MEMORY.md
@@ -62,10 +62,18 @@
 ### [2026-03-26] Process rules extracted from CLAUDE.md to dev-team-process.md
 - **Type**: DECISION [verified]
 - **Source**: PR #373, ADR-031
-- **Tags**: process, dx, claude-md, templates
+- **Tags**: process, dx, claude-md, templates, guarded-files
 - **Outcome**: accepted
 - **Last-verified**: 2026-03-26
 - **Context**: CLAUDE.md was growing unwieldy. Process rules now live in a dedicated file, keeping CLAUDE.md under 100 lines. ADR-031 governs the extraction.
+
+### [2026-03-26] process.md is a guarded file — never overwritten on update
+- **Type**: DECISION [verified]
+- **Source**: PR #398 (fix/397)
+- **Tags**: update, guarded-files, process
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-26
+- **Context**: process.md joins learnings.md and metrics.md as files that are never overwritten by `dev-team update`. update.ts only installs process.md if missing (for pre-v1.5.0 projects). The contradiction between "Never modify .dev-team/" and process.md being user-editable was resolved by clarifying which files are preserved vs overwritten.
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->

--- a/.dev-team/learnings.md
+++ b/.dev-team/learnings.md
@@ -48,7 +48,7 @@
 - Last Borges run: not tracked yet (Borges spawning is now enforced via skill definitions)
 - Pre-commit gate: blocks commits without memory updates (override via `.dev-team/.memory-reviewed`)
 - All implementing agents have mandatory Learnings Output section in their definitions
-- First calibration metrics entry recorded for v1.2.0. All future tasks should append to `.dev-team/metrics.md`. Second entry: v1.5.0 (18 findings, 100% acceptance, 1 round).
+- First calibration metrics entry recorded for v1.2.0. All future tasks should append to `.dev-team/metrics.md`. Second entry: v1.5.0 (18 findings, 100% acceptance, 1 round). Third entry: v1.5.1 (6 findings, 1 fixed, 5 ignored).
 - Finding Outcome Log vocabulary is standardized: outcomes are `fixed`, `accepted`, `deferred`, `overruled`, `ignored`. All skills and agents must use this vocabulary.
 - Agent definitions share common sections via SHARED.md (ADR-030). Process rules extracted to dev-team-process.md (ADR-031). Memory write semantics clarified in ADR-032.
 

--- a/.dev-team/metrics.md
+++ b/.dev-team/metrics.md
@@ -50,3 +50,16 @@
 - **Duration**: single session, 15 PRs across sequential and parallel branches
 - **Notes**: Largest batch to date. All findings addressed in first pass — zero deferred, zero overruled. Copilot was the primary code reviewer. Key themes: path correctness (findings #7, #12), null safety in merge logic (#1-3), documentation precision (#4-6, #9-11), and platform field backfill (#15-16). Process improvement: merge-as-you-go for sequential chains (#18).
 
+### [2026-03-26] Task: v1.5.1 hotfix (#397)
+- **Agents**: implementing: Deming (main loop), reviewers: Copilot
+- **Rounds**: 1
+- **Findings**:
+  - Copilot: 1 DEFECT (1 fixed / 0 overruled), 4 RISK (0 accepted / 0 overruled / 4 ignored), 1 SUGGESTION (0 accepted / 0 overruled / 1 ignored)
+- **Acceptance rate**: 17% (1 fixed / 6 total)
+- **Overrule rate**: 0% (0 / 6)
+- **Fix rate (DEFECTs)**: 100% (1/1)
+- **Defer rate (advisory)**: 0% (0/5)
+- **Ignore rate (advisory)**: 100% (5/5 — local install artifacts, not actionable)
+- **Duration**: single session, 1 PR
+- **Notes**: Small hotfix — process.md guarded from overwrite on reinstall. The 5 ignored findings were all about hook/config files referencing paths that only exist after local install (not committed to repo). One DEFECT fixed: contradiction in process.md between "never modify .dev-team/" and process.md being user-editable.
+


### PR DESCRIPTION
## Summary
- Records calibration metrics for v1.5.1 (#397/PR #398): 1 DEFECT fixed, 5 ignored (install artifacts)
- New memory entries: guarded-files pattern in Deming and Conway agent memories
- Updates shared learnings metrics line to include v1.5.1
- Borges self-memory updated with extraction milestone

## Files changed
- `.dev-team/metrics.md` — new v1.5.1 entry
- `.dev-team/learnings.md` — metrics line update
- `.dev-team/agent-memory/dev-team-deming/MEMORY.md` — guarded-files decision
- `.dev-team/agent-memory/dev-team-conway/MEMORY.md` — guarded-files pattern + Last-verified bump
- `.dev-team/agent-memory/dev-team-borges/MEMORY.md` — v1.5.1 extraction milestone

refs #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)