### PR TITLE
chore: release v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-03-27
+
+### Fixed
+- Guard `process.md` from overwrite on re-init — same `fileExists` protection as `learnings.md` and `metrics.md` (#397).
+- Install `process.md` during `dev-team update` for pre-v1.5.0 projects.
+- Clarify which `.dev-team/` files are preserved vs overwritten.
+
+### Changed
+- Process template now includes Versioning, Branching, Integration, and Release placeholder sections for project customization.
+- Deduplicated settings.json hook entries (from v1.5.0 update accumulation bug).
+
 ## [1.5.0] - 2026-03-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fredericboyer/dev-team",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "bin": {
         "dev-team": "bin/dev-team.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Adversarial AI agent team for any project — installs Claude Code agents, hooks, and skills that enforce quality through productive friction",
   "main": "dist/init.js",
   "types": "dist/init.d.ts",


### PR DESCRIPTION
## Summary
- Hotfix: guard process.md from overwrite, install on update, add template sections
- Version bump to 1.5.1

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)