### PR TITLE
chore: retro cleanup — prune discoverable content, deduplicate memories

### DIFF
--- a/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
@@ -3,14 +3,6 @@
 
 ## Coverage Gaps Identified
 
-### [2026-03-25] Three-tier test structure using Node.js built-in test runner
-- **Type**: PATTERN [verified]
-- **Source**: package.json + project structure analysis
-- **Tags**: testing, coverage, test-runner
-- **Outcome**: verified
-- **Last-verified**: 2026-03-25
-- **Context**: Node.js `node --test` runner, no third-party test framework. Tests are pre-compiled JS (not TS). Three tiers: unit (individual modules), integration (install flows), scenarios (end-to-end project types).
-
 ### [2026-03-25] No coverage tool configured — coverage is not measured
 - **Type**: PATTERN [verified]
 - **Source**: package.json analysis
@@ -36,14 +28,6 @@
 - **Outcome**: verified
 - **Last-verified**: 2026-03-25
 - **Context**: Finding outcome vocabularies must stay aligned between skill definitions that produce outcomes (task, review) and agents that consume them (Borges). The task skill originally used "addressed/deferred/disputed" but Borges expects "accepted/overruled/fixed/ignored". Mismatches break automated memory extraction.
-
-### [2026-03-25] Routing table ownership patterns — .env to Voss, .env.example to Hamilton
-- **Type**: PATTERN [verified]
-- **Source**: v1.2.0 Branch C (#273) — review skill routing fix
-- **Tags**: routing, ownership, review-skill
-- **Outcome**: verified
-- **Last-verified**: 2026-03-25
-- **Context**: .env files route to Voss (app config/data). .env.example and .env.template route to Hamilton (infra scaffolding). CI workflows (.github/workflows) route to Hamilton. This distinction matters for correct reviewer assignment.
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->

--- a/.dev-team/agent-memory/dev-team-szabo/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-szabo/MEMORY.md
@@ -27,14 +27,6 @@
 - **Last-verified**: 2026-03-25
 - **Context**: Hooks shipped as plain JS run in the target project's environment. They spawn subprocesses and read/write files. Any command injection in hook logic would execute with the user's permissions.
 
-### [2026-03-25] Zero runtime dependencies — small supply chain surface
-- **Type**: PATTERN [verified]
-- **Source**: package.json analysis
-- **Tags**: supply-chain, dependencies
-- **Outcome**: verified
-- **Last-verified**: 2026-03-25
-- **Context**: Only devDependencies (typescript, oxlint, oxfmt, @types/node). No runtime deps means minimal supply chain attack surface. ADR-002 codifies this as a design principle.
-
 ## Known Attack Surfaces
 
 

--- a/.dev-team/agent-memory/dev-team-turing/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-turing/MEMORY.md
@@ -25,7 +25,7 @@
 - **Tags**: concurrency, memory, multi-user, agent-status
 - **Outcome**: brief written to `.dev-team/research/257-multi-user-model-2026-03-26.md`
 - **Last-verified**: 2026-03-26
-- **Calibration**: Language bias lives entirely in the pattern/hook layer — agent definitions and skills are agnostic. When researching cross-language support, always test regex patterns against actual conventions (e.g., `_test.go` vs `.test.ts`, hooks lowercase paths before matching). See `docs/benchmark-non-jsts.md` for full findings and prioritized recommendations.
+- **Calibration**: Concurrency risks center on shared mutable state — agent-status files, learnings.md, and agent memory can be written by multiple agents simultaneously. When researching multi-user scenarios, focus on file-level locking, status file contention, and memory merge conflicts rather than application-level concurrency primitives.
 
 ### [2026-03-26] Non-JS/TS ecosystem benchmark (#325)
 - **Type**: RESEARCH [completed]

--- a/.dev-team/agent-memory/dev-team-voss/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-voss/MEMORY.md
@@ -19,14 +19,6 @@
 - **Last-verified**: 2026-03-25
 - **Context**: Project detection via scan.ts reads package.json, tsconfig.json, pyproject.toml to auto-detect runtime. Config stored as JSON. No environment variables for configuration (CLI tool, not a service).
 
-### [2026-03-25] Zero runtime dependencies — all functionality is self-contained
-- **Type**: PATTERN [verified]
-- **Source**: package.json analysis
-- **Tags**: dependencies, architecture
-- **Outcome**: verified
-- **Last-verified**: 2026-03-25
-- **Context**: Uses only Node.js built-in modules (fs, path, child_process). ADR-002 codifies zero-dep policy. Any new functionality must use built-ins or be implemented inline.
-
 ## Patterns to Watch For
 
 ### [2026-03-26] mergeSettings() must track Set state after push — dedup bug in src/files.ts

--- a/.dev-team/learnings.md
+++ b/.dev-team/learnings.md
@@ -4,26 +4,14 @@
 
 ## Coding Conventions
 
-- TypeScript source in `src/`, compiled to `dist/` via `tsc`. Zero runtime dependencies.
 - Use oxlint for linting, oxfmt for formatting (not ESLint/Prettier). See ADR-007.
-- Hooks are shipped as plain JS (not TS) since they run in target projects.
 
 ## Process
 
-- **Security check at session start.** Run `/security-status` at the beginning of every session to check code scanning, Dependabot, and secret scanning alerts. Also run before releases.
 - Always use `/dev-team:task` for implementation work — dogfood the agents.
 - Spawn review agents as `general-purpose` subagents with the actual agent definition loaded from `.dev-team/agents/dev-team-*.md`. Do NOT use `pr-review-toolkit:*` as proxies — they have different behavior.
-- Don't ask for approval to continue between tasks. Just do the work. Only pause for critical decisions.
-- **Follow through to completion without prompting.** When auto-merge is set or CI is pending, monitor and complete the next step (tag, release, cleanup) without waiting for the user to ask "is it done yet?"
-- **When creating a PR for a tracked issue, link it in the PR body** (e.g., `Closes #NNN`). This lets the platform auto-close the issue on merge. Agents should include this when they know the issue number.
 - Hooks over CLAUDE.md for enforcement (ADR-001). If agents keep flagging the same pattern, it should be a hook.
 - **Review gate enforces the adversarial loop at commit time** (ADR-029). Two stateless gates: review evidence + findings resolution. Sidecar files in `.dev-team/.reviews/` keyed by agent + content hash. LIGHT reviews are advisory only. `--skip-review` is the escape hatch.
-- **Every deferred finding must become a tracked GitHub issue.** When deferring a review or Copilot finding, create the issue immediately with origin (PR, reviewer), the finding, and assessment context. "Worth considering in a follow-up" without a tracked issue is not acceptable.
-- **Close the GitHub milestone after creating the release PR.** Use `gh api repos/{owner}/{repo}/milestones/{number} -X PATCH -f state=closed`.
-- **Release publishing is automated via CI.** After merging the release PR, push the git tag — the `release.yml` workflow handles npm publish and GitHub release creation automatically. Do NOT manually run `npm publish` or `gh release create` — this causes CI job failures (duplicate release) and wasted effort (no local npm auth).
-- **Improvements must be project-agnostic and target `templates/`.** Never modify `.dev-team/` directly for improvements — those files get overwritten by `dev-team update`. All improvements go into `templates/` and ship in future versions. Project-specific conventions stay in local learnings only.
-- **Dogfooding is the product loop.** Using dev-team on dev-team surfaces friction → `/dev-team:retro` captures patterns → issues target `templates/` → next release improves the tool for everyone. Every session is a test run.
-- **Merge-as-you-go for sequential chains.** When issues depend on each other, merge each PR before spawning the next agent. Batching merges at the end causes stale-main branching. (Learned v1.5.0, now in process.md and Drucker definition.)
 
 ## Design Principles
 
@@ -36,21 +24,9 @@
 
 ## Quality Benchmarks
 
-- Tests: `npm test` for current count. Three-tier structure: unit, integration, scenarios.
-- Agents: see `src/init.ts` ALL_AGENTS array for current roster. ADR-022 governs proliferation (soft cap 15).
-- Skills: see `templates/skills/` for current list. Framework skills ship with every install.
-- Hooks: see `templates/hooks/` for current list. 3 always-on reviewers: Szabo, Knuth, Brooks.
-- CI: 3 OS (ubuntu, macos, windows) x Node 22 + lint + format + agent validation + hook validation.
 - Always run `npm run format` before committing new `.ts` files — oxfmt formatting is checked in CI.
-
-### Learning capture metrics
-- Non-empty agent memory files: all active agents have memory dirs
-- Last Borges run: not tracked yet (Borges spawning is now enforced via skill definitions)
-- Pre-commit gate: blocks commits without memory updates (override via `.dev-team/.memory-reviewed`)
-- All implementing agents have mandatory Learnings Output section in their definitions
-- First calibration metrics entry recorded for v1.2.0. All future tasks should append to `.dev-team/metrics.md`. Second entry: v1.5.0 (18 findings, 100% acceptance, 1 round). Third entry: v1.5.1 (6 findings, 1 fixed, 5 ignored).
 - Finding Outcome Log vocabulary is standardized: outcomes are `fixed`, `accepted`, `deferred`, `overruled`, `ignored`. All skills and agents must use this vocabulary.
-- Agent definitions share common sections via SHARED.md (ADR-030). Process rules extracted to dev-team-process.md (ADR-031). Memory write semantics clarified in ADR-032.
+- Pre-commit gate: blocks commits without memory updates (override via `.dev-team/.memory-reviewed`).
 
 ## Overruled Challenges
 <!-- When the human overrules an agent, record why — prevents re-flagging -->

--- a/.dev-team/metrics.md
+++ b/.dev-team/metrics.md
@@ -35,6 +35,7 @@
   - [SUGGESTION] `release-workflows` token inconsistency (PR #278) → already fixed in #303
   - [SUGGESTION] Pre-commit gate wording inaccuracy across agent templates (PR #277, 6 files) → #323
   - [SUGGESTION] Promotion opportunities section undefined in report format (PR #279) → #283 (closed)
+  - **Status (2026-03-26):** All 7 deferred findings resolved (issues closed). 100% conversion rate.
 
 ### [2026-03-26] Task: v1.5.0 delivery (#353, #354, #355, #356, #357, #358, #359, #364, #368, #374, #351, #348, #335, #325)
 - **Agents**: implementing: Voss, Deming, Tufte, Turing; pre-assessment: Brooks; reviewers: Copilot

--- a/.dev-team/process.md
+++ b/.dev-team/process.md
@@ -67,6 +67,8 @@ Background agents can get stuck without producing output. Apply this escalation 
 ## Dogfooding
 
 - Always use `/dev-team:task` for implementation work — dogfood the agents.
+- Don't ask for approval to continue between tasks. Just do the work. Only pause for critical decisions.
+- Follow through to completion without prompting. When auto-merge is set or CI is pending, monitor and complete the next step (tag, release, cleanup) without waiting for the user.
 - Improvements must be project-agnostic and target `templates/`. Most `.dev-team/` files get overwritten by `dev-team update` — exceptions are `process.md`, `learnings.md`, `metrics.md`, and agent memory files (these are preserved). Project-specific conventions stay in local learnings or this process file.
 - Dogfooding is the product loop: use dev-team on dev-team → surface friction → `/dev-team:retro` captures patterns → issues target `templates/` → next release improves the tool for everyone.
 


### PR DESCRIPTION
## Summary

- Pruned discoverable content from `learnings.md` (TypeScript source, hooks-as-JS, zero deps — all derivable from config files)
- Removed 10 entries from `learnings.md` that were duplicated in `process.md` (security-status, milestone closure, release publishing, deferred findings, dogfooding, merge-as-you-go, link PRs, approval/follow-through rules, project-agnostic improvements)
- Cleaned up stale learning capture metrics (historical milestones, operational status, "see X for count" pointers)
- Removed "zero runtime dependencies" entries from Szabo and Voss memories (discoverable from package.json)
- Removed duplicate test runner/structure entry from Knuth (kept in Beck, the test specialist)
- Removed routing table entry from Knuth (now in agent-patterns.json)
- Fixed Turing #257 calibration text — was copy-pasted from #325 (language bias), now has concurrency-specific calibration
- Added deferred tracking resolution note to metrics.md (all 7 v1.2.0 deferred findings resolved, 100% conversion)
- Added behavioral rules to process.md Dogfooding section (don't ask for approval, follow through to completion)
- `learnings.md` reduced from 57 to 34 lines (well under 200-line cap)

## Test plan

- [x] Verify `learnings.md` is under 200 lines (34 lines)
- [x] Verify no contradictions between learnings.md, process.md, and agent memories
- [x] Verify Turing #257 and #325 calibration texts are now distinct
- [x] Verify removed entries are covered by process.md or discoverable from code/config

Generated with Claude Code