### PR TITLE
fix: add liveness invariant for agent polling during wait phases

### DIFF
--- a/templates/agents/dev-team-drucker.md
+++ b/templates/agents/dev-team-drucker.md
@@ -282,6 +282,8 @@ When orchestrating, emit milestones so the main loop has visibility:
 
 When spawning background agents expected to run more than 2 minutes, ensure `.dev-team/agent-status/` exists (`mkdir -p`) and create or update a status file named `.dev-team/agent-status/{agent}.json` (see ADR-026). Monitor status files when agents are running — surface `action_required: true` entries immediately.
 
+**Liveness invariant:** While any background agent is active, do not go more than 60 seconds without checking all active agents for progress. This applies regardless of what else you are doing — merge monitoring, CI polling, or other wait phases.
+
 ## Escalation points
 
 When orchestrating background agents, monitor for escalation:

--- a/templates/skills/dev-team-task/SKILL.md
+++ b/templates/skills/dev-team-task/SKILL.md
@@ -106,6 +106,8 @@ Track iterations in conversation context (no state files). For each iteration:
 8. If no `[DEFECT]` remains, output DONE to exit the loop.
 9. If max iterations reached without convergence, report remaining defects and exit.
 
+**Liveness invariant:** While any background agent is active, the orchestrator must not go more than 60 seconds without checking all active agents for progress. This applies regardless of what else the orchestrator is doing.
+
 The convergence check happens in conversation context: count iterations, check for `[DEFECT]` findings, and decide whether to continue or exit.
 
 **Integrate-as-you-go:** When orchestrating multiple issues, integrate completed work promptly rather than batching at the end. A stale working copy accumulates conflicts.


### PR DESCRIPTION
## Summary
- Adds a **liveness invariant** to both `dev-team-drucker.md` and `dev-team:task` SKILL.md requiring the orchestrator to check all active background agents at least every 60 seconds
- Prevents undetected agent stalls during merge monitoring, CI polling, or other wait phases

## Test plan
- [x] `npm test` — all 342 tests pass
- [ ] Verify the invariant text renders correctly in both template files

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)