### PR TITLE
Extract hardcoded workflow steps from agent templates to process.md

### DIFF
--- a/templates/agents/dev-team-conway.md
+++ b/templates/agents/dev-team-conway.md
@@ -35,12 +35,12 @@ When running as a background agent, write status to `.dev-team/agent-status/dev-
 
 | Phase | Marker |
 |-------|--------|
-| 1. Inventory | `[Conway] Phase 1/5: Inventorying changes since last release...` |
-| 2. Changelog | `[Conway] Phase 2/5: Drafting changelog...` |
-| 3. Version bump | `[Conway] Phase 3/5: Bumping version...` |
-| 4. PR creation | `[Conway] Phase 4/5: Creating release PR...` |
-| 5. CI verification | `[Conway] Phase 5/5: Waiting for CI...` |
-| Done | `[Conway] Done — PR #NNN created, CI pending` |
+| 1. Inventory | `[Conway] Phase 1/3: Inventorying changes since last release...` |
+| 2. Validate | `[Conway] Phase 2/3: Validating release readiness...` |
+| 3. Execute | `[Conway] Phase 3/3: Executing release process...` |
+| Done | `[Conway] Done — release prepared` |
+
+Follow the release steps defined in `.claude/rules/dev-team-process.md` for changelog format, version bumping, and delivery.
 
 Clean up the status file on completion.
 
@@ -65,9 +65,9 @@ You always check for:
 - **Breaking change documentation**: Every breaking change needs: what changed, why, and how to migrate. "Updated the API" is not documentation.
 - **Tag and branch hygiene**: Is the tag on the right commit? Is the release branch clean? Are there uncommitted changes?
 - **Dependency audit**: Are there known vulnerabilities in the dependency tree? Were any dependencies added or upgraded that could affect stability?
-- **Merge process**: If the project provides merge automation (e.g., a `/merge` skill or CLAUDE.md guidance), use it for final merge; if no such automation exists, ensure the PR is in a mergeable state (CI green, reviews passed) and report readiness.
-- **Milestone closure**: After creating the release PR, close the associated milestone or iteration if one exists.
-- **Changelog grouping**: Within each Keep-A-Changelog category (Added, Changed, Fixed, etc.), order entries by theme rather than commit order. Thematic ordering within categories helps users understand what changed at a glance.
+- **Merge process**: Follow the project's merge workflow as defined in `.claude/rules/dev-team-process.md`. If a merge skill or automation exists, use it; otherwise, ensure the deliverable is in a mergeable state and report readiness.
+- **Milestone closure**: After creating the release deliverable, close the associated milestone or iteration if one exists.
+- **Changelog grouping**: Within each changelog category, order entries by theme rather than commit order. Thematic ordering helps users understand what changed at a glance. Follow the changelog format defined in `.claude/rules/dev-team-process.md`.
 
 ## Challenge style
 

--- a/templates/agents/dev-team-drucker.md
+++ b/templates/agents/dev-team-drucker.md
@@ -196,17 +196,17 @@ This bounds token usage per review wave regardless of iteration count and preven
 ### 6. Complete
 
 When no `[DEFECT]` findings remain:
-1. **Deliver the work**: Ensure the task is complete end-to-end. If the task produces a PR, create it. The PR body must include the platform's issue-closing keyword (e.g., `Closes #NNN` for GitHub, `Closes <PROJ>-NNN` for Jira/Linear — check `.dev-team/config.json` for `platform` and `issueTracker` settings). Ensure CI is green, reviews have passed, and the branch is up to date — then follow the project's merge workflow. If the task produces other artifacts, verify they are in the expected state. Work is not done until the deliverable is delivered — not just created.
-2. **Clean up worktree**: If the work was done in a worktree, clean it up after the branch is pushed and the PR is created. Do not wait for merge to clean the worktree.
+1. **Deliver the work**: Ensure the task is complete end-to-end. Follow the integration process defined in `.claude/rules/dev-team-process.md` — this covers issue linking, review requirements, and merge workflow. If the task produces other artifacts, verify they are in the expected state. Work is not done until the deliverable is delivered — not just created.
+2. **Clean up worktree**: If the work was done in a worktree, clean it up after the branch is pushed and the deliverable is created. Do not wait for merge to clean the worktree.
 3. Spawn **@dev-team-borges** (Librarian) to review memory freshness, cross-agent coherence, and system improvement opportunities. This is mandatory — Borges runs at the end of every task.
 4. Summarize what was implemented and what was reviewed.
 5. Report any remaining `[RISK]` or `[SUGGESTION]` items, including Borges's recommendations.
 6. List which agents reviewed and their verdicts.
 7. Write learnings to agent memory files.
 
-**Review bot monitoring:** After PR creation, check for automated review findings promptly. Do not wait for merge to discover review bot comments — route them to implementing agents as they appear.
+**Review bot monitoring:** After delivering work, check for automated review findings promptly. Do not wait for merge to discover review bot comments — route them to implementing agents as they appear.
 
-**Task is complete only when the deliverable is delivered.** If a PR cannot merge (CI failures, merge conflicts, branch protection), report the blocker to the human rather than leaving work unattended.
+**Task is complete only when the deliverable is delivered.** If integration is blocked (CI failures, merge conflicts, review requirements), report the blocker to the human rather than leaving work unattended.
 
 ### Parallel orchestration
 
@@ -214,7 +214,7 @@ When working on multiple issues simultaneously (see ADR-019):
 
 1. **Analyze for file independence**: Spawn @dev-team-brooks with the full batch of issues. Brooks identifies conflict groups — issues that touch overlapping files and must execute sequentially. Independent issues can proceed in parallel.
 
-2. **Spawn implementation agents in parallel**: For each independent issue, spawn one implementing agent on its own branch (`feat/<issue>-<description>`). Each agent works without awareness of other parallel agents.
+2. **Spawn implementation agents in parallel**: For each independent issue, spawn one implementing agent on its own branch (following the branching convention in `.claude/rules/dev-team-process.md`). Each agent works without awareness of other parallel agents.
 
 3. **Wait for all implementations to complete**: Do not start reviews until every implementation agent has finished. This is the synchronization barrier.
 
@@ -230,9 +230,7 @@ Conflict groups (issues with file overlaps) execute sequentially within the grou
 
 ### Completing work
 
-Work is done when the deliverable is delivered — not just created. For PRs, this means merged (or ready-to-merge per the project's workflow). For other deliverables (docs, configs, releases), this means verified in the expected state.
-
-Follow the project's merge workflow. Some projects use auto-merge, others require manual approval. If the project has a merge skill (e.g., `/merge`) or similar automation, use it. Otherwise, ensure the PR is in a mergeable state (CI green, reviews passed, branch updated) and report readiness.
+Work is done when the deliverable is delivered — not just created. Follow the integration and merge workflow defined in `.claude/rules/dev-team-process.md`. For other deliverables (docs, configs, releases), verify they are in the expected state.
 
 ### Agent teams mode (experimental)
 

--- a/templates/dev-team-process.md
+++ b/templates/dev-team-process.md
@@ -18,12 +18,27 @@ Use descriptive branch names that reference the issue being worked on.
 ## Integration
 <!-- How are changes integrated? PRs? Direct commits? Review requirements? -->
 
-All changes via pull request. Link PRs to issues for auto-close on merge.
+All changes via pull request. Link the deliverable to the originating issue so it auto-closes on merge. Include the issue-closing keyword appropriate for your platform (e.g., `Closes #NNN` for GitHub, `Closes <PROJ>-NNN` for Jira/Linear).
+
+Ensure CI is green and reviews have passed before merging. If the project provides merge automation (a `/merge` skill or similar), use it; otherwise, confirm the deliverable is in a mergeable state and report readiness.
 
 ## Release
 <!-- How are releases cut? Manual or automated? Who approves? -->
 
-The release engineer (Conway) handles version bumps, changelogs, and release PRs.
+The release engineer (Conway) handles release readiness validation, version bumps, changelogs, and release deliverables.
+
+### Changelog format
+
+Use a structured changelog grouped by: Added, Changed, Deprecated, Removed, Fixed, Security. Within each category, order entries by theme rather than commit order. Link entries to issues or PRs where available.
+
+### Release steps
+
+1. Inventory changes since the last release — commits merged, breaking changes, dependency updates.
+2. Draft the changelog with all user-facing changes documented.
+3. Bump the version in the project's manifest file(s) according to semver.
+4. Create the release deliverable (PR, tag, or equivalent) and link it to the milestone.
+5. Verify CI passes on the release branch.
+6. Close the associated milestone or iteration if one exists.
 
 ## Orchestration
 


### PR DESCRIPTION
## Summary

- Audited all 14 agent templates + SHARED.md for hardcoded workflow steps that violate template design principles (agents describe *capabilities*, not *steps*)
- Extracted workflow steps from **Conway** (release phases, changelog format, merge process) and **Drucker** (PR creation keywords, branch naming, merge workflow) into `templates/dev-team-process.md`
- Remaining 12 agents (Voss, Hamilton, Szabo, Knuth, Beck, Mori, Tufte, Turing, Brooks, Rams, Deming, Borges) are already capability-focused with no hardcoded workflow steps

### Changes
- **Conway**: Replaced 5-phase release step table with 3-phase capability phases; pointed changelog/version/merge steps to process.md
- **Drucker**: Replaced hardcoded PR creation keywords, branch naming, and merge workflow with pointers to process.md; removed platform-specific examples
- **process.md**: Added Integration details (issue linking, merge workflow), Release steps (6-step generic process), and Changelog format section as customizable project defaults

## Test plan

- [x] `npm test` — all 343 tests pass
- [ ] Verify Conway agent can still execute releases by reading process.md at runtime
- [ ] Verify Drucker agent follows process.md for integration workflow

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)