### PR TITLE
chore: Borges memory extraction for v1.6.0 release

### DIFF
--- a/.dev-team/agent-memory/dev-team-borges/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-borges/MEMORY.md
@@ -66,3 +66,11 @@
 - **Outcome**: resolved
 - **Last-verified**: 2026-03-26
 - **Context**: Deming had a RISK entry about review-gate pattern duplication. This was resolved in PR #344 (agent-patterns.json extraction). Updated entry from [acknowledged] to [resolved].
+
+### [2026-03-26] v1.6.0 extraction — 16 PRs, Copilot-only review, no formal wave
+- **Type**: MILESTONE [verified]
+- **Source**: v1.6.0 task loop (16 issues, 16 PRs)
+- **Tags**: metrics, calibration, extraction
+- **Outcome**: verified
+- **Last-verified**: 2026-03-26
+- **Context**: Major architectural release. Research-first approach (Turing #406, #407). No formal review wave — Copilot sole reviewer. All findings addressed inline. 2 new ADRs (033, 034), 7 design principles codified. Key coherence update: Conway's guarded files entry updated for rules migration. New entries written for Deming (2), Tufte (2), Turing (2), Voss (1), Brooks (2), Drucker (1). Process learnings added to shared learnings (research-first, verify against official docs).

--- a/.dev-team/agent-memory/dev-team-brooks/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-brooks/MEMORY.md
@@ -53,5 +53,21 @@
 - **Last-verified**: 2026-03-26
 - **Context**: Common agent protocol sections extracted to SHARED.md to reduce duplication. ~16% reduction in total agent definition lines. Brooks should watch for drift between SHARED.md and individual agent overrides.
 
+### [2026-03-26] Process-driven agents: capabilities in definitions, steps in process.md
+- **Type**: DECISION [verified]
+- **Source**: Issue #405, v1.6.0 design principles
+- **Tags**: architecture, agents, process, separation-of-concerns
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-26
+- **Context**: Agent definitions describe what the agent can do (capabilities), not how a specific project uses them (workflow steps). Steps live in `.claude/rules/dev-team-process.md` which each project customizes. This separates stable agent identity from variable project workflow. Brooks should flag agent definitions that embed workflow steps.
+
+### [2026-03-26] Two new ADRs in v1.6.0: 033 (rules-based context), 034 (language delegation)
+- **Type**: DECISION [verified]
+- **Source**: PRs #425, #419
+- **Tags**: architecture, adr
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-26
+- **Context**: ADR-033 uses `.claude/rules/` for automatic shared context loading (replaces explicit read instructions). ADR-034 delegates language-specific knowledge from hooks to agents (hooks detect, agents interpret). Both support the "discoverable-only" and "language-neutral" design principles.
+
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->

--- a/.dev-team/agent-memory/dev-team-conway/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-conway/MEMORY.md
@@ -93,11 +93,11 @@
 
 ### [2026-03-26] Guarded files: learnings.md, metrics.md, process.md — never overwritten
 - **Type**: PATTERN [verified]
-- **Source**: PR #398 (fix/397)
-- **Tags**: update, guarded-files, release
+- **Source**: PR #398 (fix/397), updated by v1.6.0 rules migration (ADR-033)
+- **Tags**: update, guarded-files, release, rules
 - **Outcome**: verified
 - **Last-verified**: 2026-03-26
-- **Context**: update.ts guards three user-editable files in .dev-team/: learnings.md, metrics.md, and process.md. These are only installed if missing (for upgrades from older versions). All other .dev-team/ files are overwritten on update. This matters for release testing — verify guarded files survive `dev-team update`.
+- **Context**: update.ts guards user-editable files. In v1.6.0, learnings.md and process.md migrated from `.dev-team/` to `.claude/rules/dev-team-learnings.md` and `.claude/rules/dev-team-process.md`. Migration is automatic (renameSync from old to new path, only if old exists and new doesn't). metrics.md stays in `.dev-team/`. All guarded files are only installed if missing. Release testing must verify: (1) fresh install creates files in `.claude/rules/`, (2) upgrade migrates from old paths, (3) existing `.claude/rules/` files are preserved.
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->

--- a/.dev-team/agent-memory/dev-team-deming/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-deming/MEMORY.md
@@ -75,5 +75,21 @@
 - **Last-verified**: 2026-03-26
 - **Context**: process.md joins learnings.md and metrics.md as files that are never overwritten by `dev-team update`. update.ts only installs process.md if missing (for pre-v1.5.0 projects). The contradiction between "Never modify .dev-team/" and process.md being user-editable was resolved by clarifying which files are preserved vs overwritten.
 
+### [2026-03-26] Skill invocation control: orchestration vs advisory skills
+- **Type**: DECISION [verified]
+- **Source**: Issue #409, PR #414
+- **Tags**: skills, invocation, dx, enforcement
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-26
+- **Context**: Orchestration skills (task, review, audit, retro) get `disable-model-invocation: true` to prevent accidental autonomous firing. Advisory/read-only skills (scorecard, challenge) can be autonomous. This is a design principle in CLAUDE.md.
+
+### [2026-03-26] Language delegation: hooks detect ecosystem, agents interpret
+- **Type**: DECISION [verified]
+- **Source**: Issue #385, PR #419, ADR-034
+- **Tags**: hooks, language-neutral, delegation
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-26
+- **Context**: Hooks replaced JS/TS-specific patterns with language-agnostic structural proxies (nesting depth, control flow density). Test file detection expanded to Go/Python/Java conventions. Complexity scoring no longer keyword-based. Key principle: hooks handle detection and gating, agents handle language-specific interpretation.
+
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->

--- a/.dev-team/agent-memory/dev-team-drucker/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-drucker/MEMORY.md
@@ -43,6 +43,14 @@
 - **Last-verified**: 2026-03-26
 - **Context**: When multiple issues form a dependency chain, each PR must be merged before the next agent starts. Batching merges at the end causes agents to branch from stale main, nullifying the sequencing. Drucker must integrate-as-you-go, not batch-at-end.
 
+### [2026-03-26] Research-first orchestration for architectural changes
+- **Type**: PATTERN [verified]
+- **Source**: v1.6.0 session (#406, #407 research, then 14 implementation issues)
+- **Tags**: orchestration, research, process
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-26
+- **Context**: For releases with architectural impact, spawn Turing research briefs before implementation. v1.6.0 used two briefs (#406 rules, #407 AGENTS.md verdict) that directly shaped ADR-033, ADR-034, and 7 design principles. Research findings reduced rework vs implementing-then-discovering issues.
+
 ## Conflict Resolution Log
 
 

--- a/.dev-team/agent-memory/dev-team-tufte/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-tufte/MEMORY.md
@@ -72,3 +72,19 @@
 - **Outcome**: accepted
 - **Last-verified**: 2026-03-26
 - **Context**: ADR-030 (shared agent protocol/SHARED.md), ADR-031 (process rules extraction), ADR-032 (memory write semantics — archive vs remove, seed vs real entries). All accepted status.
+
+### [2026-03-26] Two new ADRs in v1.6.0: 033 (rules-based context), 034 (language delegation)
+- **Type**: DECISION [verified]
+- **Source**: PRs #425, #419
+- **Tags**: adr, documentation, rules, language-neutral
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-26
+- **Context**: ADR-033 moves shared context to `.claude/rules/` for automatic agent loading. ADR-034 delegates language-specific knowledge from hooks to agents. Both accepted. ADR README index should be checked for these entries.
+
+### [2026-03-26] Design principles section added to CLAUDE.md template
+- **Type**: DECISION [verified]
+- **Source**: PRs #408, #428
+- **Tags**: documentation, design-principles, templates
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-26
+- **Context**: Seven design principles codified: workflow-agnostic, platform-neutral, language-neutral, discoverable-only, process-driven, rules for shared context, skill invocation control. These are the product's template design contract — all future template changes must comply.

--- a/.dev-team/agent-memory/dev-team-turing/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-turing/MEMORY.md
@@ -34,3 +34,19 @@
 - **Outcome**: benchmark written to `docs/benchmarks/benchmark-non-jsts.md`
 - **Last-verified**: 2026-03-26
 - **Calibration**: Language bias lives entirely in the pattern/hook layer — agent definitions and skills are agnostic. When researching cross-language support, always test regex patterns against actual conventions (e.g., `_test.go` vs `.test.ts`, hooks lowercase paths before matching). See `docs/benchmarks/benchmark-non-jsts.md` for full findings and prioritized recommendations.
+
+### [2026-03-26] Rules research (#406) — verify claims against official docs, not third-party
+- **Type**: CALIBRATION [verified]
+- **Source**: Issue #406, Turing research
+- **Tags**: research, verification, rules, official-docs
+- **Outcome**: corrected
+- **Last-verified**: 2026-03-26
+- **Context**: Initial research on `.claude/rules/` incorrectly stated subagents don't inherit rules. User corrected with official Claude Code documentation confirming rules ARE inherited by subagents and agent teams. Lesson: always verify behavioral claims against official platform documentation, not third-party blog posts or inferred behavior. This correction shaped ADR-033.
+
+### [2026-03-26] Research-first approach validated in v1.6.0
+- **Type**: PATTERN [verified]
+- **Source**: v1.6.0 session (#406, #407 research briefs)
+- **Tags**: research, orchestration, process
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-26
+- **Context**: Two research briefs (#406 rules-based context, #407 AGENTS.md verdict) preceded 14 implementation issues. Research findings directly shaped ADR-033, ADR-034, and the design principles. Process confirmation: research-first reduces rework for architectural changes.

--- a/.dev-team/agent-memory/dev-team-voss/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-voss/MEMORY.md
@@ -37,5 +37,13 @@
 - **Last-verified**: 2026-03-26
 - **Context**: Shared context files (learnings.md, process.md) moved from .dev-team/ to .claude/rules/ for automatic agent context loading. update.ts migration uses fs.renameSync for atomic move from old to new path. init.ts creates .claude/rules/ directory via copyFile (which mkdirSync's parent). Key pattern: migration checks old path exists AND new path missing before moving — prevents data loss if both exist.
 
+### [2026-03-26] "AGENTS.md Verdict" — discoverable knowledge doesn't belong in templates
+- **Type**: DECISION [verified]
+- **Source**: Issue #405, v1.6.0 design principles
+- **Tags**: architecture, templates, discoverability
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-26
+- **Context**: User insight that reshaped product direction: "if the agent can discover it from code, delete it." Templates should only contain what agents can't discover — tool preferences, legacy traps, process decisions. This filters what goes into agent definitions, hooks, and shared context.
+
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->

--- a/.dev-team/learnings.md
+++ b/.dev-team/learnings.md
@@ -12,6 +12,8 @@
 - Spawn review agents as `general-purpose` subagents with the actual agent definition loaded from `.dev-team/agents/dev-team-*.md`. Do NOT use `pr-review-toolkit:*` as proxies — they have different behavior.
 - Hooks over CLAUDE.md for enforcement (ADR-001). If agents keep flagging the same pattern, it should be a hook.
 - **Review gate enforces the adversarial loop at commit time** (ADR-029). Two stateless gates: review evidence + findings resolution. Sidecar files in `.dev-team/.reviews/` keyed by agent + content hash. LIGHT reviews are advisory only. `--skip-review` is the escape hatch.
+- **Research-first for architectural releases.** When a release involves architectural changes, run Turing research briefs before implementation. Findings shape ADRs and design decisions, reducing rework. Validated in v1.6.0 (2 briefs → 2 ADRs + 7 design principles).
+- **Verify platform behavior against official docs, not third-party sources.** Turing research #406 initially got rules inheritance wrong by relying on inferred behavior. Always check official Claude Code documentation for behavioral claims about rules, subagents, and agent teams.
 
 ## Design Principles
 

--- a/.dev-team/metrics.md
+++ b/.dev-team/metrics.md
@@ -64,3 +64,16 @@
 - **Duration**: single session, 1 PR
 - **Notes**: Small hotfix — process.md guarded from overwrite on reinstall. The 5 ignored findings were all about hook/config files referencing paths that only exist after local install (not committed to repo). One DEFECT fixed: contradiction in process.md between "never modify .dev-team/" and process.md being user-editable.
 
+### [2026-03-26] Task: v1.6.0 delivery (#409, #410, #411, #395, #385, #402, #388, #392, #401, #386, #393, #387, #391, #406, #405, #352)
+- **Agents**: implementing: Deming, Tufte, Voss (#406), Turing (research #406, #407); pre-assessment: Brooks; reviewers: Copilot
+- **Rounds**: 1
+- **Findings**:
+  - Copilot: inline findings across 16 PRs (all addressed per-PR)
+  - No formal review wave — Copilot was sole reviewer
+- **Acceptance rate**: 100% (all Copilot findings addressed inline)
+- **Overrule rate**: 0%
+- **Fix rate (DEFECTs)**: N/A (0 formal DEFECTs reported)
+- **Defer rate (advisory)**: 0%
+- **Duration**: single session, 16 PRs (#412-#428)
+- **Notes**: Major architectural release — research-first approach (Turing #406, #407). Key outcomes: rules-based shared context (ADR-033), language delegation (ADR-034), skill invocation control, process-driven agents, design principles codified. No formal review wave was run; Copilot was the sole code reviewer. All Copilot findings addressed inline during merge. Merge-as-you-go enforced successfully — no stale-branch issues (unlike v1.5.0 early delivery).
+


### PR DESCRIPTION
## Summary
- Metrics entry for v1.6.0: 16 issues, 16 PRs, Copilot-only review, 1 round
- 10 new memory entries across 7 agents (Deming, Tufte, Turing, Voss, Brooks, Drucker, Borges)
- Conway guarded-files entry updated for `.claude/rules/` migration (ADR-033)
- Shared learnings: research-first for architectural releases, verify against official docs

## Test plan
- [ ] Memory files are under 200-line cap
- [ ] No duplicate entries across agent memories
- [ ] Metrics entry follows established format

🤖 Generated with [Claude Code](https://claude.com/claude-code)