### PR TITLE
chore: release v1.6.0

### DIFF
--- a/.dev-team/config.json
+++ b/.dev-team/config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.0",
+  "version": "1.6.0",
   "platform": "github",
   "agents": [
     "Voss",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-03-26
+
+### Added
+
+**Architecture:**
+- Move `process.md` and `learnings.md` to `.claude/rules/` for automatic agent context loading — ADR-033 (#406, #425).
+- Delegate language-specific knowledge to agents instead of hooks — ADR-034, language-agnostic hook patterns (#395, #419).
+- Audit agent templates for hardcoded workflow steps — Conway and Drucker now process-driven (#405, #426).
+- Add `disable-model-invocation: true` to orchestration skills (#409, #414).
+- Make scorecard skill autonomous — no longer requires manual invocation (#410, #413).
+
+**Platform neutrality:**
+- Generalize issue-closing syntax to be platform-aware (#386, #421).
+- Replace Copilot references with generic automated review monitoring (#387, #422).
+- Generalize milestone to milestone or iteration — platform-neutral language (#388, #415).
+- Configurable branch prefixes via `taskBranchPattern` in config.json (#385, #418).
+
+**Process improvements:**
+- Enforce merge-as-you-go with sequential chain hard gate (#393, #423).
+- Orchestrator agent liveness polling invariant for wait phases (#401, #420).
+- Post-PR automated review polling guidance (#391, #424).
+- Retro skill now audits `process.md` for staleness and gaps (#402, #416).
+- Generalize scorecard for review, audit, and task workflows (#352, #427).
+
+**Documentation:**
+- Document `.claude/rules/` as extension point in template CLAUDE.md (#411, #412).
+- Enforce `docs/` folder structure and file naming conventions (#392, #417).
+
+### New ADRs
+- ADR-033: Rules-based shared context distribution.
+- ADR-034: Delegate language-specific pattern matching to agents.
+
 ## [1.5.1] - 2026-03-27
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fredericboyer/dev-team",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "MIT",
       "bin": {
         "dev-team": "bin/dev-team.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Adversarial AI agent team for any project — installs Claude Code agents, hooks, and skills that enforce quality through productive friction",
   "main": "dist/init.js",
   "types": "dist/init.d.ts",


### PR DESCRIPTION
## Summary

Release v1.6.0 — architecture, platform neutrality, process improvements, and documentation.

**Architecture:**
- Move `process.md` and `learnings.md` to `.claude/rules/` for automatic agent context loading — ADR-033 (#406)
- Delegate language-specific knowledge to agents — ADR-034, language-agnostic hooks (#395)
- Audit agent templates for hardcoded workflow steps — Conway and Drucker now process-driven (#405)
- Add `disable-model-invocation: true` to orchestration skills (#409)
- Make scorecard skill autonomous (#410)

**Platform neutrality:**
- Generalize issue-closing syntax to be platform-aware (#386)
- Replace Copilot references with generic automated review monitoring (#387)
- Generalize milestone to milestone or iteration (#388)
- Configurable branch prefixes via config.json (#385)

**Process improvements:**
- Enforce merge-as-you-go and merge PRs as agents complete (#393)
- Orchestrator agent liveness polling invariant (#401)
- Post-PR automated review polling (#391)
- Retro skill audits process.md (#402)
- Generalize scorecard for review/audit workflows (#352)

**Documentation:**
- Document `.claude/rules/` as extension point (#411)
- Enforce docs/ folder structure and naming conventions (#392)

**New ADRs:**
- ADR-033: Rules-based shared context distribution
- ADR-034: Delegate language-specific pattern matching to agents

## Checklist
- [x] Version bumped in package.json (1.6.0)
- [x] Version bumped in config.json (1.6.0)
- [x] CHANGELOG.md updated
- [x] All 343 tests passing