### PR TITLE
fix: doctor.ts hookFileMap + status.ts learnings path (#431, #432)

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -54,6 +54,7 @@ export function doctor(targetDir: string): void {
       "Watch list": "dev-team-watch-list.js",
       "Pre-commit lint": "dev-team-pre-commit-lint.js",
       "Review gate": "dev-team-review-gate.js",
+      "Agent teams guide": "dev-team-agent-teams-guide.js",
     };
     for (const label of prefs.hooks) {
       const fileName = hookFileMap[label];

--- a/src/status.ts
+++ b/src/status.ts
@@ -68,8 +68,11 @@ export function status(targetDir: string): void {
     }
   }
 
-  // Shared learnings
-  const learningsPath = path.join(devTeamDir, "learnings.md");
+  // Shared learnings (check new path first, fall back to legacy)
+  const claudeDir = path.join(targetDir, ".claude");
+  const rulesLearningsPath = path.join(claudeDir, "rules", "dev-team-learnings.md");
+  const legacyLearningsPath = path.join(devTeamDir, "learnings.md");
+  const learningsPath = fileExists(rulesLearningsPath) ? rulesLearningsPath : legacyLearningsPath;
   if (fileExists(learningsPath)) {
     try {
       const content = readFile(learningsPath) || "";


### PR DESCRIPTION
## Summary
- doctor.ts: add missing "Agent teams guide" hook mapping
- status.ts: check new `.claude/rules/` path first, fall back to legacy `.dev-team/`

Closes #431, closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)