### PR TITLE
chore: release v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-03-27
+
+### Fixed
+- `doctor.ts` hookFileMap missing "Agent teams guide" — caused false failure on `dev-team doctor` (#431).
+- `status.ts` checking wrong learnings path after v1.6.0 migration — now checks `.claude/rules/` first, falls back to `.dev-team/` (#432).
+
 ## [1.6.0] - 2026-03-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fredericboyer/dev-team",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "bin": {
         "dev-team": "bin/dev-team.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Adversarial AI agent team for any project — installs Claude Code agents, hooks, and skills that enforce quality through productive friction",
   "main": "dist/init.js",
   "types": "dist/init.d.ts",


### PR DESCRIPTION
## Summary
- Hotfix: doctor.ts hookFileMap + status.ts learnings path drift
- Version bump to 1.6.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)