### PR TITLE
Extract symlink creation logic into files.ts helper

### DIFF
--- a/.dev-team/agent-memory/dev-team-deming/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-deming/MEMORY.md
@@ -115,6 +115,14 @@
 - **Last-verified**: 2026-03-26
 - **Context**: review-gate.test.js exists but is not included in the npm test glob. Tests are not running in CI.
 
+### [2026-03-27] Symlink creation extracted to ensureSymlink() in files.ts
+- **Type**: DECISION [verified]
+- **Source**: Issue #441
+- **Tags**: duplication, files, dx
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-27
+- **Context**: ~30 lines of identical symlink creation with Windows junction fallback existed in both init.ts and update.ts. Extracted to ensureSymlink() in files.ts. Also removed unused fs import from init.ts. Part of the hook/utility dedup series (#436, #437).
+
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
 

--- a/src/files.ts
+++ b/src/files.ts
@@ -243,6 +243,57 @@ export function getPackageVersion(): string {
 }
 
 /**
+ * Creates a symlink at symlinkPath pointing to symlinkTarget.
+ * Skips if a non-symlink (real file/dir) already exists at the path.
+ * Removes stale symlinks before creating. Falls back to junction on Windows
+ * when symlink creation fails due to permissions.
+ */
+export function ensureSymlink(symlinkPath: string, symlinkTarget: string): void {
+  // Skip if path exists and is NOT a symlink (user's real directory — preserve it)
+  let isNonSymlink = false;
+  try {
+    isNonSymlink = fs.existsSync(symlinkPath) && !fs.lstatSync(symlinkPath).isSymbolicLink();
+  } catch {
+    // ENOENT — path doesn't exist, proceed to create symlink
+  }
+  if (isNonSymlink) return;
+
+  try {
+    fs.mkdirSync(path.dirname(symlinkPath), { recursive: true });
+    // Remove existing symlink (broken or stale) — only unlink symlinks, not real files/dirs
+    try {
+      if (fs.lstatSync(symlinkPath).isSymbolicLink()) {
+        fs.unlinkSync(symlinkPath);
+      }
+    } catch {
+      // ENOENT is expected when no prior symlink exists
+    }
+    fs.symlinkSync(symlinkTarget, symlinkPath);
+  } catch (err) {
+    // On Windows, non-admin users get EPERM/EACCES for symlinks — fall back to junction
+    if (
+      process.platform === "win32" &&
+      ((err as NodeJS.ErrnoException).code === "EPERM" ||
+        (err as NodeJS.ErrnoException).code === "EACCES")
+    ) {
+      try {
+        fs.symlinkSync(symlinkTarget, symlinkPath, "junction");
+      } catch (junctionErr) {
+        const skillDir = path.basename(symlinkPath);
+        console.warn(
+          `  Warning: could not create skill symlink for ${skillDir}: ${(junctionErr as Error).message}`,
+        );
+      }
+    } else {
+      const skillDir = path.basename(symlinkPath);
+      console.warn(
+        `  Warning: could not create skill symlink for ${skillDir}: ${(err as Error).message}`,
+      );
+    }
+  }
+}
+
+/**
  * Lists all files in a directory recursively.
  */
 export function listFilesRecursive(dir: string): string[] {

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,5 +1,4 @@
 import path from "path";
-import fs from "fs";
 import {
   templateDir,
   copyFile,
@@ -11,6 +10,7 @@ import {
   mergeClaudeMd,
   listSubdirectories,
   getPackageVersion,
+  ensureSymlink,
 } from "./files.js";
 import type { HookSettings, HookMatcher } from "./files.js";
 import * as prompts from "./prompts.js";
@@ -415,46 +415,7 @@ export async function run(targetDir: string, flags: string[] = []): Promise<void
   for (const skillDir of skillDirs) {
     const symlinkPath = path.join(claudeSkillsDir, skillDir);
     const symlinkTarget = path.relative(claudeSkillsDir, path.join(skillsDir, skillDir));
-    // Skip if path exists and is NOT a symlink (user's real directory — preserve it)
-    let isNonSymlink = false;
-    try {
-      isNonSymlink = fs.existsSync(symlinkPath) && !fs.lstatSync(symlinkPath).isSymbolicLink();
-    } catch {
-      // ENOENT — path doesn't exist, proceed to create symlink
-    }
-    if (!isNonSymlink) {
-      try {
-        fs.mkdirSync(path.dirname(symlinkPath), { recursive: true });
-        // Remove existing symlink (broken or stale) — only unlink symlinks, not real files/dirs
-        try {
-          if (fs.lstatSync(symlinkPath).isSymbolicLink()) {
-            fs.unlinkSync(symlinkPath);
-          }
-        } catch {
-          // ENOENT is expected when no prior symlink exists
-        }
-        fs.symlinkSync(symlinkTarget, symlinkPath);
-      } catch (err) {
-        // On Windows, non-admin users get EPERM/EACCES for symlinks — fall back to junction
-        if (
-          process.platform === "win32" &&
-          ((err as NodeJS.ErrnoException).code === "EPERM" ||
-            (err as NodeJS.ErrnoException).code === "EACCES")
-        ) {
-          try {
-            fs.symlinkSync(symlinkTarget, symlinkPath, "junction");
-          } catch (junctionErr) {
-            console.warn(
-              `  Warning: could not create skill symlink for ${skillDir}: ${(junctionErr as Error).message}`,
-            );
-          }
-        } else {
-          console.warn(
-            `  Warning: could not create skill symlink for ${skillDir}: ${(err as Error).message}`,
-          );
-        }
-      }
-    }
+    ensureSymlink(symlinkPath, symlinkTarget);
   }
 
   // Step 10: Merge CLAUDE.md

--- a/src/update.ts
+++ b/src/update.ts
@@ -11,6 +11,7 @@ import {
   listSubdirectories,
   listFilesRecursive,
   getPackageVersion,
+  ensureSymlink,
 } from "./files.js";
 import type { HookSettings, HookMatcher } from "./files.js";
 import fs from "fs";
@@ -592,47 +593,7 @@ export async function update(targetDir: string): Promise<void> {
   for (const skillDir of discoveredSkills) {
     const symlinkPath = path.join(claudeSkillsDir, skillDir);
     const symlinkTarget = path.relative(claudeSkillsDir, path.join(skillsDir, skillDir));
-    // Skip if path exists and is NOT a symlink (user's real directory — preserve it)
-    let isNonSymlink = false;
-    try {
-      isNonSymlink = fs.existsSync(symlinkPath) && !fs.lstatSync(symlinkPath).isSymbolicLink();
-    } catch {
-      // ENOENT — path doesn't exist, proceed to create symlink
-    }
-    if (!isNonSymlink) {
-      // Create symlink if target doesn't exist, or repair existing symlink
-      try {
-        fs.mkdirSync(path.dirname(symlinkPath), { recursive: true });
-        // Remove existing symlink (broken or stale) — only unlink symlinks, not real files/dirs
-        try {
-          if (fs.lstatSync(symlinkPath).isSymbolicLink()) {
-            fs.unlinkSync(symlinkPath);
-          }
-        } catch {
-          // ENOENT is expected when no prior symlink exists
-        }
-        fs.symlinkSync(symlinkTarget, symlinkPath);
-      } catch (err) {
-        // On Windows, non-admin users get EPERM/EACCES for symlinks — fall back to junction
-        if (
-          process.platform === "win32" &&
-          ((err as NodeJS.ErrnoException).code === "EPERM" ||
-            (err as NodeJS.ErrnoException).code === "EACCES")
-        ) {
-          try {
-            fs.symlinkSync(symlinkTarget, symlinkPath, "junction");
-          } catch (junctionErr) {
-            console.warn(
-              `  Warning: could not create skill symlink for ${skillDir}: ${(junctionErr as Error).message}`,
-            );
-          }
-        } else {
-          console.warn(
-            `  Warning: could not create skill symlink for ${skillDir}: ${(err as Error).message}`,
-          );
-        }
-      }
-    }
+    ensureSymlink(symlinkPath, symlinkTarget);
   }
 
   // Step 6: Update CLAUDE.md (preserves user content outside markers)


### PR DESCRIPTION
## Summary
- Extract ~30 lines of duplicated symlink creation logic from `init.ts` and `update.ts` into `ensureSymlink()` in `files.ts`
- Handles symlink creation, stale symlink cleanup, non-symlink preservation, and Windows junction fallback
- Net -19 lines (63 added, 82 removed)

Closes #441

## Test plan
- [x] `npm run build` — compiles clean
- [x] `npm test` — all tests pass
- [x] No behavioral changes — extracted code is identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>