### PR TITLE
Add review-gate.test.js to test script

### DIFF
--- a/.dev-team/agent-memory/dev-team-deming/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-deming/MEMORY.md
@@ -107,13 +107,13 @@
 - **Last-verified**: 2026-03-26
 - **Context**: CI runs build/test/lint/validate but does not run npm audit. Adding an audit step would catch known vulnerabilities in dependencies before release.
 
-### [2026-03-26] review-gate.test.js excluded from test script
-- **Type**: SUGGESTION [open]
+### [2026-03-27] review-gate.test.js added to test script (Issue #435)
+- **Type**: SUGGESTION [resolved]
 - **Source**: Codebase audit, Issue #435
 - **Tags**: testing, hooks, dx
-- **Outcome**: accepted — issue created for v1.7.0
-- **Last-verified**: 2026-03-26
-- **Context**: review-gate.test.js exists but is not included in the npm test glob. Tests are not running in CI.
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-27
+- **Context**: review-gate.test.js was not in the npm test script. Added to package.json. Also fixed the runGate test helper: it used execFileSync which swallows stderr on exit 0 — switched to spawnSync to capture stderr in all cases. The --skip-review test was failing because the hook outputs via console.warn (stderr) but the helper only captured stderr on error paths.
 
 ### [2026-03-27] Symlink creation extracted to ensureSymlink() in files.ts
 - **Type**: DECISION [verified]

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc",
     "pretest": "npm run build",
-    "test": "node --test tests/unit/files.test.js tests/unit/hooks.test.js tests/unit/scan.test.js tests/unit/skill-recommendations.test.js tests/unit/create-agent.test.js tests/unit/cli.test.js tests/integration/fresh-project.test.js tests/integration/idempotency.test.js tests/integration/update.test.js tests/scenarios/node-project.test.js tests/scenarios/python-project.test.js tests/scenarios/upgrade-path.test.js tests/scenarios/orchestration.test.js",
+    "test": "node --test tests/unit/files.test.js tests/unit/hooks.test.js tests/unit/scan.test.js tests/unit/skill-recommendations.test.js tests/unit/create-agent.test.js tests/unit/cli.test.js tests/unit/review-gate.test.js tests/integration/fresh-project.test.js tests/integration/idempotency.test.js tests/integration/update.test.js tests/scenarios/node-project.test.js tests/scenarios/python-project.test.js tests/scenarios/upgrade-path.test.js tests/scenarios/orchestration.test.js",
     "test:unit": "node --test tests/unit/files.test.js tests/unit/hooks.test.js",
     "test:integration": "node --test tests/integration/fresh-project.test.js tests/integration/idempotency.test.js",
     "test:scenarios": "node --test tests/scenarios/node-project.test.js tests/scenarios/python-project.test.js tests/scenarios/upgrade-path.test.js tests/scenarios/orchestration.test.js",

--- a/tests/unit/review-gate.test.js
+++ b/tests/unit/review-gate.test.js
@@ -1,9 +1,9 @@
 "use strict";
 
-const { describe, it, beforeEach, afterEach } = require("node:test");
+const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 const { createHash } = require("crypto");
-const { execFileSync } = require("child_process");
+const { execFileSync, spawnSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
@@ -15,17 +15,13 @@ const HOOK_PATH = path.join(__dirname, "..", "..", "templates", "hooks", "dev-te
  */
 function runGate(toolInput, cwd) {
   const input = JSON.stringify({ tool_input: toolInput });
-  try {
-    const stdout = execFileSync(process.execPath, [HOOK_PATH, input], {
-      encoding: "utf-8",
-      timeout: 10000,
-      cwd: cwd || process.cwd(),
-      env: { ...process.env, PATH: process.env.PATH },
-    });
-    return { code: 0, stdout, stderr: "" };
-  } catch (err) {
-    return { code: err.status, stdout: err.stdout || "", stderr: err.stderr || "" };
-  }
+  const result = spawnSync(process.execPath, [HOOK_PATH, input], {
+    encoding: "utf-8",
+    timeout: 10000,
+    cwd: cwd || process.cwd(),
+    env: { ...process.env, PATH: process.env.PATH },
+  });
+  return { code: result.status, stdout: result.stdout || "", stderr: result.stderr || "" };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `tests/unit/review-gate.test.js` to the npm test script
- Fix `runGate` helper to use `spawnSync` instead of `execFileSync` so stderr is captured on exit 0

Closes #435

## Test plan
- [x] `npm test` — all tests pass including review-gate tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>