### PR TITLE
Align retro promotion criteria with AGENTS.md Verdict framework

### DIFF
--- a/.claude/rules/dev-team-learnings.md
+++ b/.claude/rules/dev-team-learnings.md
@@ -4,7 +4,7 @@
 
 ## Coding Conventions
 
-- Use oxlint for linting, oxfmt for formatting (not ESLint/Prettier). See ADR-007.
+- oxlint/oxfmt tool preference promoted to `CLAUDE.md` Development section (see ADR-007).
 
 ## Process
 

--- a/.dev-team/agent-memory/dev-team-tufte/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-tufte/MEMORY.md
@@ -43,6 +43,14 @@
 - **Last-verified**: 2026-03-26
 - **Context**: All ADRs use the Nygard lightweight format. No frontmatter, no YAML. Title line is `# ADR-NNN: Title`. Status line values: proposed, accepted, deprecated, superseded by ADR-NNN, amended by ADR-NNN.
 
+### [2026-03-27] AGENTS.md Verdict framework codified in retro skill for promotion/removal decisions
+- **Type**: DECISION [verified]
+- **Source**: Issue #445 implementation
+- **Tags**: retro, promotion, discoverable, verdict
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-27
+- **Context**: Retro skill Phase 1 and Phase 3 now use an explicit classification table to distinguish PROMOTE categories (tool preferences, test quirks, legacy traps, custom middleware warnings) from DO NOT PROMOTE categories (codebase structure, language/framework, directory tree, tech stack overview). Previously the retro would flag tool preferences as discoverable, which contradicted the AGENTS.md Verdict principle already documented in design principles. oxlint/oxfmt entry was the first concrete promotion under this framework.
+
 ## Patterns to Watch For
 
 

--- a/.dev-team/skills/dev-team-retro/SKILL.md
+++ b/.dev-team/skills/dev-team-retro/SKILL.md
@@ -45,9 +45,25 @@ Check for:
 - Learnings about process that are not reflected in `CLAUDE.md`
 
 ### Promotion opportunities
-- Learnings that are mature enough to become formal project instructions in `CLAUDE.md`
+
+Before flagging an entry as "discoverable" or recommending promotion, classify it using the **AGENTS.md Verdict** framework:
+
+| Category | Action | Examples |
+|----------|--------|----------|
+| **Tool preference** | PROMOTE to `CLAUDE.md` | "Use oxlint not ESLint", "uv not pip", "pnpm not npm" |
+| **Test quirk** | PROMOTE to `CLAUDE.md` | "Run with `--no-cache`", "Tests require Docker running" |
+| **Legacy trap** | PROMOTE to `CLAUDE.md` | "Don't touch `old_auth.py` — migrating in Q3", "v1 API routes are frozen" |
+| **Custom middleware warning** | PROMOTE to `CLAUDE.md` | "Our `withAuth` HOC requires server component", "Rate limiter reads from Redis" |
+| **Codebase structure** | DO NOT promote — discoverable | "src/ contains TypeScript source", "Tests are in `__tests__/`" |
+| **Language/framework** | DO NOT promote — discoverable | "Uses React 18", "Written in Go" |
+| **Directory tree** | DO NOT promote — discoverable | "Components are in `src/components/`" |
+| **Tech stack overview** | DO NOT promote — discoverable | "PostgreSQL database with Redis cache" |
+
+Apply this classification to:
+- Learnings that are mature enough to become formal project instructions in `CLAUDE.md` — only if they fall into the PROMOTE categories above
 - Learnings that should be elevated to an ADR in `docs/adr/`
 - Learnings that are really agent-specific calibration and should move to the appropriate agent's `MEMORY.md`
+- Learnings currently in `CLAUDE.md` that are purely discoverable — flag for removal
 
 ## Phase 2: Agent memory audit (`.dev-team/agent-memory/*/MEMORY.md`)
 
@@ -102,8 +118,10 @@ Check the project's `CLAUDE.md` for:
 
 ### Instruction surface health
 - Count lines in the CLAUDE.md managed section (between `<!-- dev-team:begin -->` and `<!-- dev-team:end -->` markers) — flag as `[RISK]` if over 100 lines
-- Scan `.dev-team/learnings.md` for entries that describe information discoverable from code or config files (e.g., tech stack, project structure, framework choices) — flag each for removal
-- Report a "discoverable content ratio": number of flagged entries / total entries
+- Scan `.dev-team/learnings.md` using the **AGENTS.md Verdict** classification (see Phase 1 table):
+  - Entries in PROMOTE categories (tool preferences, test quirks, legacy traps, custom middleware warnings) belong in learnings or `CLAUDE.md` — do NOT flag these for removal
+  - Entries in DO NOT PROMOTE categories (codebase structure, language/framework, directory tree, tech stack overview) are discoverable — flag each for removal
+- Report a "discoverable content ratio": number of discoverable-flagged entries / total entries (excluding tool preferences and quirks from the count)
 
 ## Phase 4: Calibration metrics audit (`.dev-team/metrics.md`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Adversarial AI agent team for any project. Installs Claude Code agents, hooks, a
 - `npm test` — run all tests
 - `node bin/dev-team.js init --all` — test the installer locally
 - TypeScript source, compiled to CommonJS. Node.js 22+, zero runtime dependencies.
+- Use oxlint for linting, oxfmt for formatting (not ESLint/Prettier). See ADR-007.
 - Version bumps: use `npm version <version> --no-git-tag-version` to update both `package.json` and `package-lock.json` atomically. Do not edit `package-lock.json` manually.
 
 ## Template design principles

--- a/templates/skills/dev-team-retro/SKILL.md
+++ b/templates/skills/dev-team-retro/SKILL.md
@@ -47,9 +47,25 @@ Check for:
 - Learnings about process that are not reflected in `CLAUDE.md`
 
 ### Promotion opportunities
-- Learnings that are mature enough to become formal project instructions in `CLAUDE.md`
+
+Before flagging an entry as "discoverable" or recommending promotion, classify it using the **AGENTS.md Verdict** framework:
+
+| Category | Action | Examples |
+|----------|--------|----------|
+| **Tool preference** | PROMOTE to `CLAUDE.md` | "Use oxlint not ESLint", "uv not pip", "pnpm not npm" |
+| **Test quirk** | PROMOTE to `CLAUDE.md` | "Run with `--no-cache`", "Tests require Docker running" |
+| **Legacy trap** | PROMOTE to `CLAUDE.md` | "Don't touch `old_auth.py` — migrating in Q3", "v1 API routes are frozen" |
+| **Custom middleware warning** | PROMOTE to `CLAUDE.md` | "Our `withAuth` HOC requires server component", "Rate limiter reads from Redis" |
+| **Codebase structure** | DO NOT promote — discoverable | "src/ contains TypeScript source", "Tests are in `__tests__/`" |
+| **Language/framework** | DO NOT promote — discoverable | "Uses React 18", "Written in Go" |
+| **Directory tree** | DO NOT promote — discoverable | "Components are in `src/components/`" |
+| **Tech stack overview** | DO NOT promote — discoverable | "PostgreSQL database with Redis cache" |
+
+Apply this classification to:
+- Learnings that are mature enough to become formal project instructions in `CLAUDE.md` — only if they fall into the PROMOTE categories above
 - Learnings that should be elevated to an ADR in `docs/adr/`
 - Learnings that are really agent-specific calibration and should move to the appropriate agent's `MEMORY.md`
+- Learnings currently in `CLAUDE.md` that are purely discoverable — flag for removal
 
 ## Phase 1b: Process file audit (`.claude/rules/dev-team-process.md`)
 
@@ -128,8 +144,10 @@ Check the project's `CLAUDE.md` for:
 
 ### Instruction surface health
 - Count lines in the CLAUDE.md managed section (between `<!-- dev-team:begin -->` and `<!-- dev-team:end -->` markers) — flag as `[RISK]` if over 100 lines
-- Scan `.claude/rules/dev-team-learnings.md` for entries that describe information discoverable from code or config files (e.g., tech stack, project structure, framework choices) — flag each for removal
-- Report a "discoverable content ratio": number of flagged entries / total entries
+- Scan `.claude/rules/dev-team-learnings.md` using the **AGENTS.md Verdict** classification (see Phase 1 table):
+  - Entries in PROMOTE categories (tool preferences, test quirks, legacy traps, custom middleware warnings) belong in learnings or `CLAUDE.md` — do NOT flag these for removal
+  - Entries in DO NOT PROMOTE categories (codebase structure, language/framework, directory tree, tech stack overview) are discoverable — flag each for removal
+- Report a "discoverable content ratio": number of discoverable-flagged entries / total entries (excluding tool preferences and quirks from the count)
 
 ## Phase 4: Calibration metrics audit (`.dev-team/metrics.md`)
 


### PR DESCRIPTION
## Summary
- Add AGENTS.md Verdict classification table to retro skill Phase 1 and Phase 3
- Distinguishes PROMOTE items (tool preferences, test quirks, legacy traps) from DO NOT PROMOTE items (discoverable facts)
- Promote oxlint/oxfmt preference from learnings to CLAUDE.md Development section
- Update both template and local skill copies

Closes #445

## Test plan
- [x] Both skill files updated consistently
- [x] oxlint/oxfmt entry promoted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>