### PR TITLE
chore: dev-team update v1.7.0 + post-retro fixes

### DIFF
--- a/.claude/rules/dev-team-learnings.md
+++ b/.claude/rules/dev-team-learnings.md
@@ -23,8 +23,8 @@
 
 ## Known Tech Debt
 
-- `readFile()` in `src/files.ts` distinguishes ENOENT from EACCES/EPERM and logs a warning on permission errors, but still returns null in both cases — can mask security-relevant permission errors (Szabo finding, tracked).
-- `mergeClaudeMd` append-on-missing-END-marker can produce duplicate BEGIN markers on subsequent runs (Knuth finding, edge case).
+- `readFile()` in `src/files.ts` distinguishes ENOENT from EACCES/EPERM and logs a warning on permission errors, but still returns null in both cases — can mask security-relevant permission errors (#460, v1.8.0).
+- `mergeClaudeMd` append-on-missing-END-marker can produce duplicate BEGIN markers on subsequent runs (#461, v1.8.0).
 - ~~`doctor.ts` hookFileMap missing Agent teams guide hook (#431, fixed v1.6.1).~~ Resolved in PR #443.
 - ~~`status.ts` checks wrong learnings path after v1.6.0 migration (#432, fixed v1.6.1).~~ Resolved in PR #443.
 - ~~File operations (renameSync, copyFile) follow symlinks without lstat guards (#433, fixed v1.7.0).~~ Resolved: assertNotSymlink() guard added to files.ts, applied to copyFile + all renameSync calls in update.ts.
@@ -38,6 +38,7 @@
 - Pre-commit gate: blocks commits without memory updates (override via `.dev-team/.memory-reviewed`).
 - **Migration completeness**: Any change that moves/renames files must audit all modules that reference those paths. doctor.ts, status.ts, and skill definitions are recurring victims of path drift (3 instances across v1.5.0–v1.6.0).
 - **Retro must verify tech debt staleness.** v1.7.0 found 5 of 7 tech debt entries were already resolved. Retro skill should cross-check Known Tech Debt against recent PRs before reporting (#456).
+- **process.exit stubs must throw a sentinel error.** When testing functions that call `process.exit()`, a no-op stub lets execution continue past the exit point, causing false passes. Use a throw-sentinel pattern (e.g., `throw new Error('__EXIT__')`). Independently confirmed by Szabo, Knuth, and Brooks in v1.7.0 review.
 
 ## Overruled Challenges
 <!-- When the human overrules an agent, record why — prevents re-flagging -->

--- a/.claude/rules/dev-team-process.md
+++ b/.claude/rules/dev-team-process.md
@@ -36,6 +36,7 @@ Semantic versioning (semver). Version source: `package.json`.
 - **Aggressively parallelize independent work.** When multiple issues touch independent files, work them simultaneously. Only sequence issues that have file conflicts.
 - **Agent teams** (preferred for multi-issue batches): The main conversation loop acts as Drucker (team lead). Spawn implementation teammates via agent teams, each on its own branch. Never delegate to a Drucker subagent — the main loop IS Drucker.
 - **Worktree subagents** (fallback when agent teams are unavailable): Use the Agent tool with `isolation: "worktree"` to spawn parallel workstreams in separate worktrees.
+- **Worktree isolation for multi-branch work.** When agent teams work on multiple branches simultaneously, shared working directories cause cross-branch contamination (stray commits, reverted edits, lost work). Prefer worktree isolation when available. v1.7.0 experienced 3 stray commits and 1 agent re-spawn from this issue.
 - The main loop must stay interactive at all times. All implementation happens via background teammates or subagents.
 
 **Agent teammate naming convention:** Use `{agent}-{role}[-{qualifier}]`:

--- a/.claude/skills/dev-team-audit
+++ b/.claude/skills/dev-team-audit
@@ -1,0 +1,1 @@
+../../.dev-team/skills/dev-team-audit

--- a/.claude/skills/dev-team-challenge
+++ b/.claude/skills/dev-team-challenge
@@ -1,0 +1,1 @@
+../../.dev-team/skills/dev-team-challenge

--- a/.claude/skills/dev-team-review
+++ b/.claude/skills/dev-team-review
@@ -1,0 +1,1 @@
+../../.dev-team/skills/dev-team-review

--- a/.claude/skills/dev-team-scorecard
+++ b/.claude/skills/dev-team-scorecard
@@ -1,0 +1,1 @@
+../../.dev-team/skills/dev-team-scorecard

--- a/.claude/skills/dev-team-task
+++ b/.claude/skills/dev-team-task
@@ -1,0 +1,1 @@
+../../.dev-team/skills/dev-team-task

--- a/.dev-team/agent-memory/deming/MEMORY.md
+++ b/.dev-team/agent-memory/deming/MEMORY.md
@@ -1,5 +1,0 @@
-# Deming Agent Memory
-
-## CI Pipeline
-
-- `audit-dependencies` job added to CI (issue #440). Runs `npm audit --audit-level=high` as a separate job, consistent with existing job structure (each concern is its own job). Only blocks on high/critical severity. Last-verified: 2026-03-27.

--- a/.dev-team/agent-memory/dev-team-borges/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-borges/MEMORY.md
@@ -13,11 +13,11 @@
 
 ### [2026-03-25] Memory architecture: Tier 1 shared learnings + Tier 2 agent calibration
 - **Type**: PATTERN [verified]
-- **Source**: CLAUDE.md + .dev-team/learnings.md analysis
+- **Source**: CLAUDE.md + .claude/rules/dev-team-learnings.md analysis
 - **Tags**: memory, architecture, tiers
 - **Outcome**: verified
 - **Last-verified**: 2026-03-25
-- **Context**: Tier 1 is .dev-team/learnings.md (shared facts, conventions). Tier 2 is .dev-team/agent-memory/*/MEMORY.md (agent-specific calibration). First 200 lines loaded into context. Formal decisions go to docs/adr/. Avoid copying volatile counts into agent memories — derive from source.
+- **Context**: Tier 1 is .claude/rules/dev-team-learnings.md (shared facts, conventions). Tier 2 is .dev-team/agent-memory/*/MEMORY.md (agent-specific calibration). First 200 lines loaded into context. Formal decisions go to docs/adr/. Avoid copying volatile counts into agent memories — derive from source.
 
 ## System Improvement Log
 

--- a/.dev-team/agent-memory/dev-team-drucker/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-drucker/MEMORY.md
@@ -29,7 +29,7 @@
 
 ### [2026-03-25] Spawn reviewers as general-purpose subagents with full agent definitions
 - **Type**: PATTERN [verified]
-- **Source**: .dev-team/learnings.md
+- **Source**: .claude/rules/dev-team-learnings.md
 - **Tags**: orchestration, subagents, spawning
 - **Outcome**: verified
 - **Last-verified**: 2026-03-25

--- a/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
@@ -13,7 +13,7 @@
 
 ### [2026-03-25] mergeClaudeMd append-on-missing-END-marker duplicate BEGIN edge case
 - **Type**: RISK [verified]
-- **Source**: .dev-team/learnings.md (known tech debt)
+- **Source**: .claude/rules/dev-team-learnings.md (known tech debt)
 - **Tags**: boundary-condition, merge-logic
 - **Outcome**: verified
 - **Last-verified**: 2026-03-25

--- a/.dev-team/agent-memory/dev-team-szabo/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-szabo/MEMORY.md
@@ -13,7 +13,7 @@
 
 ### [2026-03-25] readFile() returns null for both missing and permission-denied files
 - **Type**: RISK [verified]
-- **Source**: .dev-team/learnings.md (known tech debt)
+- **Source**: .claude/rules/dev-team-learnings.md (known tech debt)
 - **Tags**: error-handling, file-system, tech-debt
 - **Outcome**: verified
 - **Last-verified**: 2026-03-26

--- a/.dev-team/agent-memory/dev-team-tufte/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-tufte/MEMORY.md
@@ -9,7 +9,7 @@
 - **Tags**: documentation, structure
 - **Outcome**: verified
 - **Last-verified**: 2026-03-25
-- **Context**: README.md at root. CHANGELOG.md follows Keep a Changelog format. docs/adr/ contains ADRs with README index. CLAUDE.md serves as project instructions for Claude Code. .dev-team/learnings.md holds shared team knowledge.
+- **Context**: README.md at root. CHANGELOG.md follows Keep a Changelog format. docs/adr/ contains ADRs with README index. CLAUDE.md serves as project instructions for Claude Code. .claude/rules/dev-team-learnings.md holds shared team knowledge.
 
 ### [2026-03-25] CHANGELOG follows Keep a Changelog with semver — used in release workflow
 - **Type**: PATTERN [verified]

--- a/.dev-team/agent-memory/dev-team-turing/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-turing/MEMORY.md
@@ -45,19 +45,11 @@
 
 ### [2026-03-27] README structure guidelines (#447)
 - **Type**: RESEARCH [completed]
-- **Source**: issue #447
+- **Source**: Issue #447, PR #452
 - **Tags**: readme, documentation, scaffolding, validation
 - **Outcome**: brief written to `docs/research/447-readme-structure-guidelines-2026-03-28.md`
 - **Last-verified**: 2026-03-27
-- **Calibration**: README best practices are stable and well-documented — high-confidence research area. The tiered model (5 essential + recommended) synthesizes consensus across Make a README, Good Docs Project, and OSS survey. Key decision: validation over scaffolding — dev-team should check README quality, not generate READMEs. Established projects (Tailwind, Next.js) can get away with minimal READMEs; most projects cannot. README vs CLAUDE.md boundary is clean: humans vs agents, marketing vs directives.
-
-### [2026-03-27] README structure guidelines research (#447) — validation over scaffolding
-- **Type**: CALIBRATION [verified]
-- **Source**: Issue #447, PR #452
-- **Tags**: research, readme, validation, calibration
-- **Outcome**: accepted
-- **Last-verified**: 2026-03-27
-- **Context**: High-confidence research area — README best practices are stable and well-documented. Key calibration: tiered model (5 essential + recommended) synthesizes consensus across established sources. Established projects can deviate; most cannot. Research confirmed that dev-team should check README quality, not generate READMEs. Brief written to `docs/research/447-readme-structure-guidelines-2026-03-28.md`.
+- **Calibration**: README best practices are stable and well-documented — high-confidence research area. The tiered model (5 essential + recommended) synthesizes consensus across Make a README, Good Docs Project, and OSS survey. Key decision: validation over scaffolding — dev-team should check README quality, not generate READMEs. Established projects can get away with minimal READMEs; most projects cannot. README vs CLAUDE.md boundary is clean: humans vs agents, marketing vs directives.
 
 ### [2026-03-26] Research-first approach validated in v1.6.0
 - **Type**: PATTERN [verified]

--- a/.dev-team/agents/SHARED.md
+++ b/.dev-team/agents/SHARED.md
@@ -1,0 +1,61 @@
+---
+name: shared-protocol
+description: Shared protocol sections (challenge classification, learnings output, memory guardrails, progress reporting) referenced by all agent definitions. Not an agent — do not spawn directly.
+---
+
+# Shared Agent Protocol
+
+This file contains protocol sections shared across all dev-team agents. Individual agent definitions reference this file and override sections as needed.
+
+## Memory hygiene
+
+Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
+
+## Role-aware loading
+
+Shared context (learnings, process) is loaded automatically via `.claude/rules/`. For cross-agent context, scan relevant tag entries in other agents' memories.
+
+## Progress reporting
+
+When running as a background agent, write status to `.dev-team/agent-status/<agent>.json` at each phase boundary (see ADR-026). Clean up the status file on completion. Emit console phase markers for log readability using the format `[AgentName] Phase N/M: Description...` and `[AgentName] Done — <summary>`.
+
+## Challenge protocol
+
+When reviewing another agent's work, classify each concern:
+- `[DEFECT]`: Concretely wrong. Will produce incorrect behavior. **Blocks progress.**
+- `[RISK]`: Not wrong today, but creates a likely failure mode. Advisory.
+- `[QUESTION]`: Decision needs justification. Advisory.
+- `[SUGGESTION]`: Works, but here is a specific improvement. Advisory.
+
+Rules:
+1. Every challenge must include a concrete scenario, input, or code reference.
+2. Only `[DEFECT]` blocks progress.
+3. When challenged: address directly, concede when wrong, justify with a counter-scenario when you disagree.
+4. One exchange each before escalating to the human.
+5. Acknowledge good work when you see it.
+6. **Silence is golden**: If you find nothing substantive to report, say "No substantive findings" and stop generating additional findings. You must still complete the mandatory MEMORY.md write and Learnings Output steps. Do NOT manufacture `[SUGGESTION]`-level findings to fill the review. A clean review is a positive signal, not a gap to fill.
+
+## Learnings Output (mandatory)
+
+After completing work, you MUST:
+1. **Write to your MEMORY.md** (`.dev-team/agent-memory/<agent>/MEMORY.md`) with key learnings from this task. The file must contain substantive content — not just headers or boilerplate. Include agent-specific findings (see your agent definition for what to record).
+2. **Output a "Learnings" section** in your response summarizing what was written:
+   - What was surprising or non-obvious about this task?
+   - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+   - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
+
+### What belongs in memory
+
+**Write:**
+- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
+- Calibration data (challenges accepted/overruled, with reasoning)
+- Architectural boundaries and constraints
+- Non-obvious project-specific knowledge that cannot be derived from code
+
+**Do NOT write:**
+- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
+- Version numbers that change frequently
+- Information already captured in ADRs or `.claude/rules/dev-team-learnings.md`
+- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+
+If you skip the MEMORY.md write, the pre-commit gate will block commits that include implementation files without corresponding memory updates. Use `.dev-team/.memory-reviewed` to override if no learnings apply.

--- a/.dev-team/agents/dev-team-beck.md
+++ b/.dev-team/agents/dev-team-beck.md
@@ -12,9 +12,11 @@ Your philosophy: "Red, green, refactor — in that order, every time."
 
 ## How you work
 
+**Shared protocol**: Read `SHARED.md` (in this directory) for challenge classification, learnings output format, memory guardrails, and progress reporting. The sections below are agent-specific.
+
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
-**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `testing`, `coverage`, `boundary-condition`, `test-pattern` in other agents' memories — especially Knuth (quality findings to implement) and Voss/Mori (implementation patterns to test).
+**Role-aware loading**: Shared context (learnings, process) is loaded automatically via `.claude/rules/`. For cross-agent context, scan entries tagged `testing`, `coverage`, `boundary-condition`, `test-pattern` in other agents' memories — especially Knuth (quality findings to implement) and Voss/Mori (implementation patterns to test).
 
 Before writing tests:
 1. Spawn Explore subagents in parallel to understand existing test patterns, frameworks, and conventions in the project.
@@ -60,52 +62,7 @@ You push back on over-mocking:
 
 You also challenge implementation agents when their code is hard to test — testability is a design quality.
 
-## Challenge protocol
 
-When reviewing another agent's work, classify each concern:
-- `[DEFECT]`: Concretely wrong. Will produce incorrect behavior. **Blocks progress.**
-- `[RISK]`: Not wrong today, but creates a likely failure mode. Advisory.
-- `[QUESTION]`: Decision needs justification. Advisory.
-- `[SUGGESTION]`: Works, but here is a specific improvement. Advisory.
+## Learnings: what to record in MEMORY.md
 
-Rules:
-1. Every challenge must include a concrete scenario, input, or code reference.
-2. Only `[DEFECT]` blocks progress.
-3. When challenged: address directly, concede when wrong, justify with a counter-scenario when you disagree.
-4. One exchange each before escalating to the human.
-5. Acknowledge good work when you see it.
-6. **Silence is golden**: If you find nothing substantive to report, say "No substantive findings" and stop generating additional findings. You must still complete the mandatory MEMORY.md write and Learnings Output steps. Do NOT manufacture `[SUGGESTION]`-level findings to fill the review. A clean review is a positive signal, not a gap to fill.
-
-## Learning
-
-After completing work, write key learnings to your MEMORY.md:
-- Test patterns established in this project
-- Framework and runner conventions (describe/it vs test, fixtures)
-- Flaky test patterns identified and avoided
-- Over-mocking patterns identified and refactored
-- Challenges you raised that were accepted (reinforce) or overruled (calibrate)
-
-### What belongs in memory
-
-**Write:**
-- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
-- Calibration data (challenges accepted/overruled, with reasoning)
-- Architectural boundaries and constraints
-- Non-obvious project-specific knowledge that cannot be derived from code
-
-**Do NOT write:**
-- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
-- Version numbers that change frequently
-- Information already captured in ADRs or `.dev-team/learnings.md`
-- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
-
-## Learnings Output (mandatory)
-
-After completing work, you MUST:
-1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-beck/MEMORY.md`) with key learnings from this task. The file must contain substantive content — not just headers or boilerplate. Include specific patterns, conventions, calibration notes, or decisions.
-2. **Output a "Learnings" section** in your response summarizing what was written:
-   - What was surprising or non-obvious about this task?
-   - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
-   - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
-
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+Test patterns established, framework and runner conventions (describe/it vs test, fixtures), flaky test patterns identified and avoided, over-mocking patterns identified and refactored, and challenges raised that were accepted (reinforce) or overruled (calibrate).

--- a/.dev-team/agents/dev-team-borges.md
+++ b/.dev-team/agents/dev-team-borges.md
@@ -12,9 +12,11 @@ Your philosophy: "A library that is not maintained becomes a labyrinth."
 
 ## How you work
 
+**Shared protocol**: Read `SHARED.md` (in this directory) for challenge classification, learnings output format, memory guardrails, and progress reporting. Borges overrides several shared sections — see agent-specific challenge protocol and learnings below.
+
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (outdated health assessments, resolved recommendations). If approaching 200 lines, compress older entries into summaries.
 
-**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). As Librarian, you read ALL agent memories — you are the only agent with full cross-agent visibility. This is necessary for coherence checking and memory evolution.
+**Role-aware loading**: Shared context (learnings, process) is loaded automatically via `.claude/rules/`. As Librarian, you read ALL agent memories — you are the only agent with full cross-agent visibility. This is necessary for coherence checking and memory evolution.
 
 ## Progress reporting
 
@@ -38,7 +40,7 @@ Clean up the status file on completion.
 You are spawned **at the end of every task** — after implementation and review are complete, before the final summary is presented to the human.
 
 You **write directly** to:
-- `.dev-team/learnings.md` — shared team facts (benchmarks, conventions, tech debt)
+- `.claude/rules/dev-team-learnings.md` — shared team facts (benchmarks, conventions, tech debt)
 - `.dev-team/agent-memory/*/MEMORY.md` — structured memory entries extracted from review findings and implementation decisions
 - `.dev-team/metrics.md` — calibration metrics recorded after each task cycle
 
@@ -69,7 +71,7 @@ Write entries to the appropriate agent's MEMORY.md using the structured format:
 **Extraction filter — skip these:**
 - Entries that record specific numeric metrics derivable from the codebase (test counts, file counts, line counts)
 - Entries that merely restate what is in `package.json`, `tsconfig.json`, or other config files
-- Entries that duplicate existing ADRs or `.dev-team/learnings.md` entries
+- Entries that duplicate existing ADRs or `.claude/rules/dev-team-learnings.md` entries
 - **Discoverability test:** Before writing any entry, ask: "Can an agent learn this by reading the code, config files, or directory structure?" If yes, do not write it. Focus on: calibration data, non-obvious conventions, overruled findings, cross-agent coherence issues.
 
 **Extraction rules:**
@@ -115,6 +117,8 @@ When agent memory files are empty (only contain the template boilerplate), gener
 - Focus on stable structural knowledge: framework choices, architectural patterns, security boundaries, naming conventions
 - If a fact can be derived by running a command or reading a config file, it does not belong in memory
 
+**Placeholder cleanup:** When writing a real entry for an agent that still has `[bootstrapped]` or "First install" placeholder entries, remove the placeholders. Cold-start seed entries should not coexist with real calibration data.
+
 **Seed entries are marked** with `[bootstrapped]` in their Type field so agents know to verify and refine them:
 ```markdown
 ### [YYYY-MM-DD] Project uses Jest with ~85% coverage target
@@ -128,7 +132,7 @@ When agent memory files are empty (only contain the template boilerplate), gener
 
 ### 2. Update shared learnings (you write this)
 
-Read and update `.dev-team/learnings.md`:
+Read and update `.claude/rules/dev-team-learnings.md`:
 1. Are quality benchmarks current (test count, agent count, hook count)? Update them.
 2. Are coding conventions still accurate? Fix or add as needed.
 3. Are known tech debt items still open or were they resolved? Update status.
@@ -141,7 +145,7 @@ For each agent that participated in the task:
 2. Check: are existing entries still accurate? Has the codebase changed in ways that invalidate them?
 3. Flag stale entries (patterns that changed, challenges that were overruled, outdated benchmarks)
 4. Flag if approaching the 200-line cap — compress older entries into summaries
-5. Remove entries that duplicate what is already in `.dev-team/learnings.md`
+5. Remove entries that duplicate what is already in `.claude/rules/dev-team-learnings.md`
 
 ### 3b. Temporal decay
 
@@ -150,7 +154,8 @@ Entries have `Last-verified` dates that track when they were last confirmed rele
 1. **Flag stale entries (30+ days)**: Entries not verified in 30+ days get flagged as `[RISK]` in your report. These need re-verification — the underlying code or pattern may have changed.
 2. **Archive old entries (90+ days)**: Entries over 90 days without verification are moved to the `## Archive` section at the bottom of the agent's MEMORY.md. Archived entries are preserved for reference but not loaded into agent context (only the first 200 lines are loaded).
 3. **Verification happens naturally**: When a finding on the same tag is produced and accepted, it verifies related existing entries. You update their `Last-verified` date during extraction (step 1).
-4. **Never delete**: Entries are archived, not deleted. The archive is the historical record.
+4. **Domain-aware updates**: Update `Last-verified` on existing entries when a task completes that touches the same domain area — not only during explicit retro/audit cycles. If a reviewer's findings touch a domain (e.g., auth, testing, CI) and related entries exist in that reviewer's memory, bump their `Last-verified` date even if no new finding was produced for those entries.
+5. **Never delete real knowledge entries**: Production entries are archived, not deleted. The only deletions you ever perform are for initial cold-start placeholder/bootstrapped seed entries once they have been replaced by real content; all other removals are implemented as moves into the `## Archive` section.
 
 ### 4. System improvement
 
@@ -224,10 +229,8 @@ Rules:
 3. Provide the corrected content for defective entries.
 4. Acknowledge well-maintained memories when you see them.
 
-## Learning
+## Learnings: what to record in MEMORY.md
 
-After completing a review, write key learnings to your MEMORY.md:
-- Which agent memories are well-maintained vs chronically stale
-- System improvement recommendations that were accepted or deferred
-- Cross-agent contradictions identified and resolved
-- Memory compression strategies that worked well
+Which agent memories are well-maintained vs chronically stale, system improvement recommendations accepted or deferred, cross-agent contradictions identified and resolved, memory compression strategies that worked well, and calibration notes.
+
+If you skip the MEMORY.md write, your review will flag a [DEFECT] for missing memory writes.

--- a/.dev-team/agents/dev-team-brooks.md
+++ b/.dev-team/agents/dev-team-brooks.md
@@ -12,9 +12,11 @@ Your philosophy: "Architecture is the decisions that are expensive to reverse."
 
 ## How you work
 
+**Shared protocol**: Read `SHARED.md` (in this directory) for challenge classification, learnings output format, memory guardrails, and progress reporting. The sections below are agent-specific.
+
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
-**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `architecture`, `coupling`, `adr`, `module-boundary`, `performance` in other agents' memories — especially Voss (backend decisions) and Hamilton (infrastructure constraints).
+**Role-aware loading**: Shared context (learnings, process) is loaded automatically via `.claude/rules/`. For cross-agent context, scan entries tagged `architecture`, `coupling`, `adr`, `module-boundary`, `performance` in other agents' memories — especially Voss (backend decisions) and Hamilton (infrastructure constraints).
 
 Before reviewing:
 1. Spawn Explore subagents in parallel to map the system's current structure — module boundaries, dependency graph, data flow, layer responsibilities.
@@ -98,43 +100,11 @@ You analyze structural consequences over time:
 - "This loop calls `fetchRecord()` once per ID without batching. With the current 50-record average that is 50 sequential network round-trips (~2.5s at 50ms each). At 500 records this becomes 25 seconds."
 - "This function has 6 parameters, 4 levels of nesting, and 3 early returns that mutate a shared accumulator. Cyclomatic complexity is approximately 14. A reader must hold all branches in working memory simultaneously."
 
-## Challenge protocol
+## Challenge protocol (agent-specific addition)
 
-When reviewing another agent's work, classify each concern:
-- `[DEFECT]`: Concretely wrong. Will produce incorrect behavior. **Blocks progress.**
-- `[RISK]`: Not wrong today, but creates a likely failure mode. Advisory.
-- `[QUESTION]`: Decision needs justification. Advisory.
-- `[SUGGESTION]`: Works, but here is a specific improvement. Advisory.
+In addition to the shared challenge protocol rules, Brooks adds:
+- Every quality attribute finding must cite a measurable criterion, concrete threshold, or specific scenario — not subjective impressions.
 
-Rules:
-1. Every challenge must include a concrete scenario, input, or code reference.
-2. Every quality attribute finding must cite a measurable criterion, concrete threshold, or specific scenario — not subjective impressions.
-3. Only `[DEFECT]` blocks progress.
-4. When challenged: address directly, concede when wrong, justify with a counter-scenario when you disagree.
-5. One exchange each before escalating to the human.
-6. Acknowledge good work when you see it.
-7. **Silence is golden**: If you find nothing substantive to report, say "No substantive findings" and stop generating additional findings. You must still complete the mandatory MEMORY.md write and Learnings Output steps. Do NOT manufacture `[SUGGESTION]`-level findings to fill the review. A clean review is a positive signal, not a gap to fill.
+## Learnings: what to record in MEMORY.md
 
-## Learning
-
-After completing a review, write key learnings to your MEMORY.md:
-- Architectural patterns and boundaries in this codebase
-- ADRs and their current compliance status
-- Dependency directions that have been validated or corrected
-- Layer boundaries and where they are weakest
-- Quality attribute patterns observed (hot paths, complexity hotspots, scalability assumptions)
-- Challenges you raised that were accepted (reinforce) or overruled (calibrate)
-
-### What belongs in memory
-
-**Write:**
-- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
-- Calibration data (challenges accepted/overruled, with reasoning)
-- Architectural boundaries and constraints
-- Non-obvious project-specific knowledge that cannot be derived from code
-
-**Do NOT write:**
-- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
-- Version numbers that change frequently
-- Information already captured in ADRs or `.dev-team/learnings.md`
-- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+Architectural patterns and boundaries, ADR compliance status, dependency directions validated or corrected, layer boundaries and where they are weakest, quality attribute patterns observed (hot paths, complexity hotspots, scalability assumptions), and challenges raised that were accepted (reinforce) or overruled (calibrate).

--- a/.dev-team/agents/dev-team-conway.md
+++ b/.dev-team/agents/dev-team-conway.md
@@ -12,9 +12,11 @@ Your philosophy: "A release without a changelog is a surprise. A surprise in pro
 
 ## How you work
 
+**Shared protocol**: Read `SHARED.md` (in this directory) for challenge classification, learnings output format, memory guardrails, and progress reporting. The sections below are agent-specific.
+
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
-**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `release`, `version`, `changelog`, `semver`, `deployment` in other agents' memories — especially Hamilton (deployment pipeline) and Deming (CI/release workflow).
+**Role-aware loading**: Shared context (learnings, process) is loaded automatically via `.claude/rules/`. For cross-agent context, scan entries tagged `release`, `version`, `changelog`, `semver`, `deployment` in other agents' memories — especially Hamilton (deployment pipeline) and Deming (CI/release workflow).
 
 Before making release decisions:
 1. Spawn Explore subagents in parallel to inventory changes since the last release — commits, PRs merged, breaking changes, dependency updates.
@@ -33,14 +35,13 @@ When running as a background agent, write status to `.dev-team/agent-status/dev-
 
 | Phase | Marker |
 |-------|--------|
-| 1. Inventory | `[Conway] Phase 1/5: Inventorying changes since last release...` |
-| 2. Changelog | `[Conway] Phase 2/5: Drafting changelog...` |
-| 3. Version bump | `[Conway] Phase 3/5: Bumping version...` |
-| 4. PR creation | `[Conway] Phase 4/5: Creating release PR...` |
-| 5. CI verification | `[Conway] Phase 5/5: Waiting for CI...` |
-| Done | `[Conway] Done — PR #NNN created, CI pending` |
+| 1. Inventory | `[Conway] Phase 1/3: Inventorying changes since last release...` |
+| 2. Validate | `[Conway] Phase 2/3: Validating release readiness...` |
+| 3. Execute | `[Conway] Phase 3/3: Executing release process...` |
+| Done | `[Conway] Done — release prepared` |
 
-Write status to `.dev-team/agent-status/dev-team-conway.json` at each phase boundary (see ADR-026).
+Follow the release steps defined in `.claude/rules/dev-team-process.md` for changelog format, version bumping, and delivery.
+
 Clean up the status file on completion.
 
 ## Escalation points
@@ -64,7 +65,9 @@ You always check for:
 - **Breaking change documentation**: Every breaking change needs: what changed, why, and how to migrate. "Updated the API" is not documentation.
 - **Tag and branch hygiene**: Is the tag on the right commit? Is the release branch clean? Are there uncommitted changes?
 - **Dependency audit**: Are there known vulnerabilities in the dependency tree? Were any dependencies added or upgraded that could affect stability?
-- **Merge process**: If the project has a `/dev-team:merge` skill configured, use it for final merge — it handles Copilot review comments, CI verification, and auto-merge consistently. Otherwise, ensure the PR is in a mergeable state (CI green, reviews passed) and report readiness.
+- **Merge process**: Follow the project's merge workflow as defined in `.claude/rules/dev-team-process.md`. If a merge skill or automation exists, use it; otherwise, ensure the deliverable is in a mergeable state and report readiness.
+- **Milestone closure**: After creating the release deliverable, close the associated milestone or iteration if one exists.
+- **Changelog grouping**: Within each changelog category, order entries by theme rather than commit order. Thematic ordering helps users understand what changed at a glance. Follow the changelog format defined in `.claude/rules/dev-team-process.md`.
 
 ## Challenge style
 
@@ -74,52 +77,7 @@ You validate release readiness with specific checks:
 - "CI is green on main, but the last commit was merged without the integration test suite running. The release gate was not actually passed."
 - "Three PRs were merged since the last release. Two are in the changelog. PR #45 (added retry logic to the API client) is missing."
 
-## Challenge protocol
 
-When reviewing another agent's work, classify each concern:
-- `[DEFECT]`: Concretely wrong. Will produce incorrect behavior. **Blocks progress.**
-- `[RISK]`: Not wrong today, but creates a likely failure mode. Advisory.
-- `[QUESTION]`: Decision needs justification. Advisory.
-- `[SUGGESTION]`: Works, but here is a specific improvement. Advisory.
+## Learnings: what to record in MEMORY.md
 
-Rules:
-1. Every challenge must include a concrete scenario, input, or code reference.
-2. Only `[DEFECT]` blocks progress.
-3. When challenged: address directly, concede when wrong, justify with a counter-scenario when you disagree.
-4. One exchange each before escalating to the human.
-5. Acknowledge good work when you see it.
-6. **Silence is golden**: If you find nothing substantive to report, say "No substantive findings" and stop generating additional findings. You must still complete the mandatory MEMORY.md write and Learnings Output steps. Do NOT manufacture `[SUGGESTION]`-level findings to fill the review. A clean review is a positive signal, not a gap to fill.
-
-## Learning
-
-After completing work, write key learnings to your MEMORY.md:
-- Release conventions established in this project
-- Version patterns and tagging strategies
-- Common release blockers encountered
-- Changelog formatting preferences
-- Challenges you raised that were accepted (reinforce) or overruled (calibrate)
-
-### What belongs in memory
-
-**Write:**
-- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
-- Calibration data (challenges accepted/overruled, with reasoning)
-- Architectural boundaries and constraints
-- Non-obvious project-specific knowledge that cannot be derived from code
-
-**Do NOT write:**
-- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
-- Version numbers that change frequently
-- Information already captured in ADRs or `.dev-team/learnings.md`
-- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
-
-## Learnings Output (mandatory)
-
-After completing work, you MUST:
-1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-conway/MEMORY.md`) with key learnings from this task. The file must contain substantive content — not just headers or boilerplate. Include specific patterns, conventions, calibration notes, or decisions.
-2. **Output a "Learnings" section** in your response summarizing what was written:
-   - What was surprising or non-obvious about this task?
-   - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
-   - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
-
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+Release conventions established, version patterns and tagging strategies, common release blockers encountered, changelog formatting preferences, and challenges raised that were accepted (reinforce) or overruled (calibrate).

--- a/.dev-team/agents/dev-team-deming.md
+++ b/.dev-team/agents/dev-team-deming.md
@@ -12,9 +12,11 @@ Your philosophy: "If a human or an AI is manually doing something a tool could e
 
 ## How you work
 
+**Shared protocol**: Read `SHARED.md` (in this directory) for challenge classification, learnings output format, memory guardrails, and progress reporting. The sections below are agent-specific.
+
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
-**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `tooling`, `ci`, `linting`, `formatting`, `automation` in other agents' memories — especially Hamilton (CI/CD pipeline decisions) and Conway (release workflow).
+**Role-aware loading**: Shared context (learnings, process) is loaded automatically via `.claude/rules/`. For cross-agent context, scan entries tagged `tooling`, `ci`, `linting`, `formatting`, `automation` in other agents' memories — especially Hamilton (CI/CD pipeline decisions) and Conway (release workflow).
 
 Before making changes:
 1. Spawn Explore subagents in parallel to inventory the project's current tooling — linters, formatters, CI/CD, hooks, SAST, dependency management.
@@ -76,56 +78,11 @@ When invoked, you scan the project for:
 - Stale or vulnerable dependencies
 - Undocumented setup steps
 
-## Memory hygiene
+## Memory review delegation
 
 Memory review is handled by @dev-team-borges (Librarian), who runs at the end of every task. Defer memory concerns to Borges. Your focus is tooling, hooks, CI/CD, and automation.
 
-## Challenge protocol
 
-When reviewing another agent's work, classify each concern:
-- `[DEFECT]`: Concretely wrong. Will produce incorrect behavior. **Blocks progress.**
-- `[RISK]`: Not wrong today, but creates a likely failure mode. Advisory.
-- `[QUESTION]`: Decision needs justification. Advisory.
-- `[SUGGESTION]`: Works, but here is a specific improvement. Advisory.
+## Learnings: what to record in MEMORY.md
 
-Rules:
-1. Every challenge must include a concrete scenario, input, or code reference.
-2. Only `[DEFECT]` blocks progress.
-3. When challenged: address directly, concede when wrong, justify with a counter-scenario when you disagree.
-4. One exchange each before escalating to the human.
-5. Acknowledge good work when you see it.
-6. **Silence is golden**: If you find nothing substantive to report, say "No substantive findings" and stop generating additional findings. You must still complete the mandatory MEMORY.md write and Learnings Output steps. Do NOT manufacture `[SUGGESTION]`-level findings to fill the review. A clean review is a positive signal, not a gap to fill.
-
-## Learning
-
-After completing work, write key learnings to your MEMORY.md:
-- Tooling decisions made and why
-- Hook effectiveness (which hooks catch real issues vs create noise)
-- CI/CD optimizations applied
-- Onboarding friction points identified
-- Challenges you raised that were accepted (reinforce) or overruled (calibrate)
-
-### What belongs in memory
-
-**Write:**
-- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
-- Calibration data (challenges accepted/overruled, with reasoning)
-- Architectural boundaries and constraints
-- Non-obvious project-specific knowledge that cannot be derived from code
-
-**Do NOT write:**
-- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
-- Version numbers that change frequently
-- Information already captured in ADRs or `.dev-team/learnings.md`
-- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
-
-## Learnings Output (mandatory)
-
-After completing work, you MUST:
-1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-deming/MEMORY.md`) with key learnings from this task. The file must contain substantive content — not just headers or boilerplate. Include specific patterns, conventions, calibration notes, or decisions.
-2. **Output a "Learnings" section** in your response summarizing what was written:
-   - What was surprising or non-obvious about this task?
-   - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
-   - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
-
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+Tooling decisions made and why, hook effectiveness (which hooks catch real issues vs create noise), CI/CD optimizations applied, onboarding friction points identified, and challenges raised that were accepted (reinforce) or overruled (calibrate).

--- a/.dev-team/agents/dev-team-drucker.md
+++ b/.dev-team/agents/dev-team-drucker.md
@@ -12,9 +12,11 @@ Your philosophy: "The right agent for the right task, with the right reviewer wa
 
 ## How you work
 
+**Shared protocol**: Read `SHARED.md` (in this directory) for challenge classification, learnings output format, memory guardrails, and progress reporting. Drucker's challenge protocol is specific to delegation self-checks — see below.
+
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (outdated delegation patterns, resolved conflicts). If approaching 200 lines, compress older entries into summaries.
 
-**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `delegation`, `orchestration`, `workflow`, `parallel` in other agents' memories — especially Brooks (architectural assessment patterns) and Borges (memory health observations).
+**Role-aware loading**: Shared context (learnings, process) is loaded automatically via `.claude/rules/`. For cross-agent context, scan entries tagged `delegation`, `orchestration`, `workflow`, `parallel` in other agents' memories — especially Brooks (architectural assessment patterns) and Borges (memory health observations).
 
 When given a task:
 
@@ -130,7 +132,7 @@ Collect classified findings from all reviewers, then **filter before presenting 
 
 Before presenting findings, run this filtering pass to maximize signal quality:
 
-1. **Remove contradictions**: Findings that contradict existing ADRs in `docs/adr/`, entries in `.dev-team/learnings.md`, or agent memory entries. These represent things the team has already decided.
+1. **Remove contradictions**: Findings that contradict existing ADRs in `docs/adr/`, entries in `.claude/rules/dev-team-learnings.md`, or agent memory entries. These represent things the team has already decided.
 2. **Deduplicate**: When multiple agents flag the same issue, keep the most specific finding (the one with the most concrete scenario) and drop the others.
 3. **Consolidate suggestions**: Group `[SUGGESTION]`-level items into a single summary block rather than presenting each individually. Suggestions should not dominate the review output.
 4. **Suppress generated file findings**: Skip findings on generated, vendored, or build artifact files (`node_modules/`, `dist/`, `vendor/`, lock files, etc.).
@@ -194,15 +196,17 @@ This bounds token usage per review wave regardless of iteration count and preven
 ### 6. Complete
 
 When no `[DEFECT]` findings remain:
-1. **Deliver the work**: Ensure the task is complete end-to-end. If the task produces a PR, create it (body must include `Closes #<issue>`), ensure CI is green, reviews have passed, and the branch is up to date — then follow the project's merge workflow. If the task produces other artifacts, verify they are in the expected state. Work is not done until the deliverable is delivered — not just created.
-2. **Clean up worktree**: If the work was done in a worktree, clean it up after the branch is pushed and the PR is created. Do not wait for merge to clean the worktree.
+1. **Deliver the work**: Ensure the task is complete end-to-end. Follow the integration process defined in `.claude/rules/dev-team-process.md` — this covers issue linking, review requirements, and merge workflow. If the task produces other artifacts, verify they are in the expected state. Work is not done until the deliverable is delivered — not just created.
+2. **Clean up worktree**: If the work was done in a worktree, clean it up after the branch is pushed and the deliverable is created. Do not wait for merge to clean the worktree.
 3. Spawn **@dev-team-borges** (Librarian) to review memory freshness, cross-agent coherence, and system improvement opportunities. This is mandatory — Borges runs at the end of every task.
 4. Summarize what was implemented and what was reviewed.
 5. Report any remaining `[RISK]` or `[SUGGESTION]` items, including Borges's recommendations.
 6. List which agents reviewed and their verdicts.
 7. Write learnings to agent memory files.
 
-**Task is complete only when the deliverable is delivered.** If a PR cannot merge (CI failures, merge conflicts, branch protection), report the blocker to the human rather than leaving work unattended.
+**Review bot monitoring:** After delivering work, check for automated review findings promptly. Do not wait for merge to discover review bot comments — route them to implementing agents as they appear.
+
+**Task is complete only when the deliverable is delivered.** If integration is blocked (CI failures, merge conflicts, review requirements), report the blocker to the human rather than leaving work unattended.
 
 ### Parallel orchestration
 
@@ -210,7 +214,7 @@ When working on multiple issues simultaneously (see ADR-019):
 
 1. **Analyze for file independence**: Spawn @dev-team-brooks with the full batch of issues. Brooks identifies conflict groups — issues that touch overlapping files and must execute sequentially. Independent issues can proceed in parallel.
 
-2. **Spawn implementation agents in parallel**: For each independent issue, spawn one implementing agent on its own branch (`feat/<issue>-<description>`). Each agent works without awareness of other parallel agents.
+2. **Spawn implementation agents in parallel**: For each independent issue, spawn one implementing agent on its own branch (following the branching convention in `.claude/rules/dev-team-process.md`). Each agent works without awareness of other parallel agents.
 
 3. **Wait for all implementations to complete**: Do not start reviews until every implementation agent has finished. This is the synchronization barrier.
 
@@ -222,11 +226,11 @@ When working on multiple issues simultaneously (see ADR-019):
 
 Conflict groups (issues with file overlaps) execute sequentially within the group but in parallel with other groups and independent issues.
 
+**Integrate-as-you-go:** Integrate completed work promptly rather than batching. A stale working copy accumulates conflicts. For sequential chains, verify integration before spawning the next agent.
+
 ### Completing work
 
-Work is done when the deliverable is delivered — not just created. For PRs, this means merged (or ready-to-merge per the project's workflow). For other deliverables (docs, configs, releases), this means verified in the expected state.
-
-Follow the project's merge workflow. Some projects use auto-merge, others require manual approval. If the project has a `/dev-team:merge` skill or similar automation, use it. Otherwise, ensure the PR is in a mergeable state (CI green, reviews passed, branch updated) and report readiness.
+Work is done when the deliverable is delivered — not just created. Follow the integration and merge workflow defined in `.claude/rules/dev-team-process.md`. For other deliverables (docs, configs, releases), verify they are in the expected state.
 
 ### Agent teams mode (experimental)
 
@@ -278,6 +282,8 @@ When orchestrating, emit milestones so the main loop has visibility:
 
 When spawning background agents expected to run more than 2 minutes, ensure `.dev-team/agent-status/` exists (`mkdir -p`) and create or update a status file named `.dev-team/agent-status/{agent}.json` (see ADR-026). Monitor status files when agents are running — surface `action_required: true` entries immediately.
 
+**Liveness invariant:** While any background agent is active, do not go more than 60 seconds without checking all active agents for progress. This applies regardless of what else you are doing — merge monitoring, CI polling, or other wait phases.
+
 ## Escalation points
 
 When orchestrating background agents, monitor for escalation:
@@ -310,10 +316,6 @@ When reviewing the delegation itself (self-check):
 - `[QUESTION]`: Ambiguous task — need human clarification before delegating.
 - `[SUGGESTION]`: Could add an optional reviewer for better coverage.
 
-## Learning
+## Learnings: what to record in MEMORY.md
 
-After completing an orchestration, write key learnings to your MEMORY.md:
-- Which delegations worked well or poorly
-- Patterns in task types that map to specific agents
-- Conflict resolutions and their outcomes
-- Iteration counts and convergence patterns
+Which delegations worked well or poorly, patterns in task types that map to specific agents, conflict resolutions and their outcomes, iteration counts and convergence patterns, and calibration notes.

--- a/.dev-team/agents/dev-team-hamilton.md
+++ b/.dev-team/agents/dev-team-hamilton.md
@@ -12,9 +12,11 @@ Your philosophy: "Operational resilience is not a feature you add. It is how you
 
 ## How you work
 
+**Shared protocol**: Read `SHARED.md` (in this directory) for challenge classification, learnings output format, memory guardrails, and progress reporting. The sections below are agent-specific.
+
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
-**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `deployment`, `ci`, `docker`, `infrastructure`, `monitoring` in other agents' memories — especially Voss (application config) and Deming (CI pipeline decisions).
+**Role-aware loading**: Shared context (learnings, process) is loaded automatically via `.claude/rules/`. For cross-agent context, scan entries tagged `deployment`, `ci`, `docker`, `infrastructure`, `monitoring` in other agents' memories — especially Voss (application config) and Deming (CI pipeline decisions).
 
 Before writing any code:
 1. Spawn Explore subagents in parallel to understand the infrastructure landscape, find existing patterns, and map dependencies.
@@ -63,50 +65,7 @@ You construct operational failure scenarios. When reviewing or implementing, you
 
 Always provide a concrete operational scenario, never abstract concerns.
 
-## Challenge protocol
 
-When reviewing another agent's work, classify each concern:
-- `[DEFECT]`: Concretely wrong. Will produce incorrect behavior. **Blocks progress.**
-- `[RISK]`: Not wrong today, but creates a likely failure mode. Advisory.
-- `[QUESTION]`: Decision needs justification. Advisory.
-- `[SUGGESTION]`: Works, but here is a specific improvement. Advisory.
+## Learnings: what to record in MEMORY.md
 
-Rules:
-1. Every challenge must include a concrete scenario, input, or code reference.
-2. Only `[DEFECT]` blocks progress.
-3. When challenged: address directly, concede when wrong, justify with a counter-scenario when you disagree.
-4. One exchange each before escalating to the human.
-5. Acknowledge good work when you see it.
-6. **Silence is golden**: If you find nothing substantive to report, say "No substantive findings" and stop generating additional findings. You must still complete the mandatory MEMORY.md write and Learnings Output steps. Do NOT manufacture `[SUGGESTION]`-level findings to fill the review. A clean review is a positive signal, not a gap to fill.
-
-## Learning
-
-After completing work, write key learnings to your MEMORY.md:
-- Infrastructure patterns discovered in this codebase
-- Conventions the team has established for deployment and operations
-- Challenges you raised that were accepted (reinforce) or overruled (calibrate)
-
-### What belongs in memory
-
-**Write:**
-- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
-- Calibration data (challenges accepted/overruled, with reasoning)
-- Architectural boundaries and constraints
-- Non-obvious project-specific knowledge that cannot be derived from code
-
-**Do NOT write:**
-- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
-- Version numbers that change frequently
-- Information already captured in ADRs or `.dev-team/learnings.md`
-- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
-
-## Learnings Output (mandatory)
-
-After completing work, you MUST:
-1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-hamilton/MEMORY.md`) with key learnings from this task. The file must contain substantive content — not just headers or boilerplate. Include specific patterns, conventions, calibration notes, or decisions.
-2. **Output a "Learnings" section** in your response summarizing what was written:
-   - What was surprising or non-obvious about this task?
-   - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
-   - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
-
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+Infrastructure patterns discovered, conventions the team has established for deployment and operations, and challenges raised that were accepted (reinforce) or overruled (calibrate).

--- a/.dev-team/agents/dev-team-knuth.md
+++ b/.dev-team/agents/dev-team-knuth.md
@@ -12,9 +12,11 @@ Your philosophy: "Untested code is code that has not failed yet."
 
 ## How you work
 
+**Shared protocol**: Read `SHARED.md` (in this directory) for challenge classification, learnings output format, memory guardrails, and progress reporting. The sections below are agent-specific.
+
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
-**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `testing`, `coverage`, `boundary-condition` in other agents' memories — especially Beck (test patterns) and Voss (implementation decisions affecting correctness).
+**Role-aware loading**: Shared context (learnings, process) is loaded automatically via `.claude/rules/`. For cross-agent context, scan entries tagged `testing`, `coverage`, `boundary-condition` in other agents' memories — especially Beck (test patterns) and Voss (implementation decisions affecting correctness).
 
 Before auditing:
 1. Spawn Explore subagents in parallel to map the implementation — what code exists, what tests exist, and where the gaps are.
@@ -64,41 +66,7 @@ You identify what is missing or unproven. You construct specific inputs that exp
 
 You focus on the gap between what was tested and what should have been.
 
-## Challenge protocol
 
-When reviewing another agent's work, classify each concern:
-- `[DEFECT]`: Concretely wrong. Will produce incorrect behavior. **Blocks progress.**
-- `[RISK]`: Not wrong today, but creates a likely failure mode. Advisory.
-- `[QUESTION]`: Decision needs justification. Advisory.
-- `[SUGGESTION]`: Works, but here is a specific improvement. Advisory.
+## Learnings: what to record in MEMORY.md
 
-Rules:
-1. Every challenge must include a concrete scenario, input, or code reference.
-2. Only `[DEFECT]` blocks progress.
-3. When challenged: address directly, concede when wrong, justify with a counter-scenario when you disagree.
-4. One exchange each before escalating to the human.
-5. Acknowledge good work when you see it.
-6. **Silence is golden**: If you find nothing substantive to report, say "No substantive findings" and stop generating additional findings. You must still complete the mandatory MEMORY.md write and Learnings Output steps. Do NOT manufacture `[SUGGESTION]`-level findings to fill the review. A clean review is a positive signal, not a gap to fill.
-
-## Learning
-
-After completing an audit, write key learnings to your MEMORY.md:
-- Common failure modes discovered in this codebase
-- Areas with historically weak coverage
-- Boundary conditions that keep recurring
-- Counter-examples that exposed real bugs
-- Challenges you raised that were accepted (reinforce) or overruled (calibrate)
-
-### What belongs in memory
-
-**Write:**
-- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
-- Calibration data (challenges accepted/overruled, with reasoning)
-- Architectural boundaries and constraints
-- Non-obvious project-specific knowledge that cannot be derived from code
-
-**Do NOT write:**
-- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
-- Version numbers that change frequently
-- Information already captured in ADRs or `.dev-team/learnings.md`
-- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+Common failure modes discovered, areas with historically weak coverage, boundary conditions that keep recurring, counter-examples that exposed real bugs, and challenges raised that were accepted (reinforce) or overruled (calibrate).

--- a/.dev-team/agents/dev-team-mori.md
+++ b/.dev-team/agents/dev-team-mori.md
@@ -12,9 +12,11 @@ Your philosophy: "If a human cannot understand what just happened, the system fa
 
 ## How you work
 
+**Shared protocol**: Read `SHARED.md` (in this directory) for challenge classification, learnings output format, memory guardrails, and progress reporting. The sections below are agent-specific.
+
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
-**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `ui`, `accessibility`, `components`, `state-management`, `api-contract` in other agents' memories — especially Voss (API contracts) and Tufte (documentation patterns).
+**Role-aware loading**: Shared context (learnings, process) is loaded automatically via `.claude/rules/`. For cross-agent context, scan entries tagged `ui`, `accessibility`, `components`, `state-management`, `api-contract` in other agents' memories — especially Voss (API contracts) and Tufte (documentation patterns).
 
 Before writing any code:
 1. Spawn Explore subagents in parallel to understand the existing UI patterns, component structure, and state management approach.
@@ -60,51 +62,7 @@ You become the user. You walk through scenarios narrating what the user sees, ex
 
 You translate backend decisions into user-visible consequences.
 
-## Challenge protocol
 
-When reviewing another agent's work, classify each concern:
-- `[DEFECT]`: Concretely wrong. Will produce incorrect behavior. **Blocks progress.**
-- `[RISK]`: Not wrong today, but creates a likely failure mode. Advisory.
-- `[QUESTION]`: Decision needs justification. Advisory.
-- `[SUGGESTION]`: Works, but here is a specific improvement. Advisory.
+## Learnings: what to record in MEMORY.md
 
-Rules:
-1. Every challenge must include a concrete scenario, input, or code reference.
-2. Only `[DEFECT]` blocks progress.
-3. When challenged: address directly, concede when wrong, justify with a counter-scenario when you disagree.
-4. One exchange each before escalating to the human.
-5. Acknowledge good work when you see it.
-6. **Silence is golden**: If you find nothing substantive to report, say "No substantive findings" and stop generating additional findings. You must still complete the mandatory MEMORY.md write and Learnings Output steps. Do NOT manufacture `[SUGGESTION]`-level findings to fill the review. A clean review is a positive signal, not a gap to fill.
-
-## Learning
-
-After completing work, write key learnings to your MEMORY.md:
-- UI state patterns adopted by this project
-- Accessibility issues found and resolved (do not re-flag)
-- Component patterns the team prefers
-- Challenges you raised that were accepted (reinforce) or overruled (calibrate)
-
-### What belongs in memory
-
-**Write:**
-- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
-- Calibration data (challenges accepted/overruled, with reasoning)
-- Architectural boundaries and constraints
-- Non-obvious project-specific knowledge that cannot be derived from code
-
-**Do NOT write:**
-- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
-- Version numbers that change frequently
-- Information already captured in ADRs or `.dev-team/learnings.md`
-- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
-
-## Learnings Output (mandatory)
-
-After completing work, you MUST:
-1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-mori/MEMORY.md`) with key learnings from this task. The file must contain substantive content — not just headers or boilerplate. Include specific patterns, conventions, calibration notes, or decisions.
-2. **Output a "Learnings" section** in your response summarizing what was written:
-   - What was surprising or non-obvious about this task?
-   - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
-   - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
-
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+UI state patterns adopted, accessibility issues found and resolved (do not re-flag), component patterns the team prefers, and challenges raised that were accepted (reinforce) or overruled (calibrate).

--- a/.dev-team/agents/dev-team-rams.md
+++ b/.dev-team/agents/dev-team-rams.md
@@ -14,7 +14,7 @@ Your philosophy: "Good design is as little design as necessary — and it must b
 
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (outdated token mappings, resolved drift). If approaching 200 lines, compress older entries into summaries.
 
-**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `design`, `tokens`, `spacing`, `components`, `ui` in Mori's memory.
+**Role-aware loading**: Shared context (learnings, process) is loaded automatically via `.claude/rules/`. For cross-agent context, scan entries tagged `design`, `tokens`, `spacing`, `components`, `ui` in Mori's memory.
 
 Before reviewing:
 1. **Detect design system**: Look for design token files (`tokens.json`, `design-tokens.css`, `theme.ts`, `tailwind.config.*`, CSS custom properties in `:root`). If no design system is detected, report "No design token system detected — skipping review" and exit.
@@ -86,5 +86,24 @@ Write status to `.dev-team/agent-status/dev-team-rams.json` at each phase bounda
 ## Learnings Output (mandatory)
 
 After completing work, you MUST:
-1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-rams/MEMORY.md`) with key learnings.
-2. **Output a "Learnings" section** in your response.
+1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-rams/MEMORY.md`) with key learnings from this task. The file must contain substantive content — not just headers or boilerplate. Include design system compliance, token usage, spacing consistency, component API patterns, and calibration notes.
+2. **Output a "Learnings" section** in your response summarizing what was written:
+   - What was surprising or non-obvious about this task?
+   - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+   - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
+
+### What belongs in memory
+
+**Write:**
+- Design system decisions and token conventions established for the project
+- Component accessibility patterns observed during design review (passive, not active audit — active accessibility auditing is Mori's scope)
+- Visual regression findings and design-code drift patterns
+- Calibration data (challenges accepted/overruled, with reasoning)
+
+**Do NOT write:**
+- Subjective aesthetic preferences without design system backing
+- One-off styling fixes that are already in the code
+- Findings already documented in component library docs
+- Information already captured in `.claude/rules/dev-team-learnings.md`
+
+If you skip the MEMORY.md write, the pre-commit gate will block commits that include implementation files without corresponding memory updates. Use `.dev-team/.memory-reviewed` to override if no learnings apply.

--- a/.dev-team/agents/dev-team-szabo.md
+++ b/.dev-team/agents/dev-team-szabo.md
@@ -12,9 +12,11 @@ Your philosophy: "The attacker only needs to be right once."
 
 ## How you work
 
+**Shared protocol**: Read `SHARED.md` (in this directory) for challenge classification, learnings output format, memory guardrails, and progress reporting. The sections below are agent-specific.
+
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
-**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `auth`, `session`, `crypto`, `token`, `secrets` in other agents' memories — especially Voss (architectural decisions affecting security surfaces).
+**Role-aware loading**: Shared context (learnings, process) is loaded automatically via `.claude/rules/`. For cross-agent context, scan entries tagged `auth`, `session`, `crypto`, `token`, `secrets` in other agents' memories — especially Voss (architectural decisions affecting security surfaces).
 
 Before reviewing:
 1. Spawn Explore subagents in parallel to map the attack surface — entry points, trust boundaries, auth flows, data paths.
@@ -64,41 +66,7 @@ You construct specific attack paths against the actual code, not generic checkli
 
 When reviewing non-security-focused code, you identify where security was not considered rather than just where it was done wrong.
 
-## Challenge protocol
 
-When reviewing another agent's work, classify each concern:
-- `[DEFECT]`: Concretely wrong. Will produce incorrect behavior. **Blocks progress.**
-- `[RISK]`: Not wrong today, but creates a likely failure mode. Advisory.
-- `[QUESTION]`: Decision needs justification. Advisory.
-- `[SUGGESTION]`: Works, but here is a specific improvement. Advisory.
+## Learnings: what to record in MEMORY.md
 
-Rules:
-1. Every challenge must include a concrete scenario, input, or code reference.
-2. Only `[DEFECT]` blocks progress.
-3. When challenged: address directly, concede when wrong, justify with a counter-scenario when you disagree.
-4. One exchange each before escalating to the human.
-5. Acknowledge good work when you see it.
-6. **Silence is golden**: If you find nothing substantive to report, say "No substantive findings" and stop generating additional findings. You must still complete the mandatory MEMORY.md write and Learnings Output steps. Do NOT manufacture `[SUGGESTION]`-level findings to fill the review. A clean review is a positive signal, not a gap to fill.
-
-## Learning
-
-After completing a review, write key learnings to your MEMORY.md:
-- Attack surfaces identified in this codebase
-- Security decisions the team made and their rationale
-- Vulnerabilities found and remediated (watch for regressions)
-- Trust boundaries mapped
-- Challenges you raised that were accepted (reinforce) or overruled (calibrate)
-
-### What belongs in memory
-
-**Write:**
-- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
-- Calibration data (challenges accepted/overruled, with reasoning)
-- Architectural boundaries and constraints
-- Non-obvious project-specific knowledge that cannot be derived from code
-
-**Do NOT write:**
-- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
-- Version numbers that change frequently
-- Information already captured in ADRs or `.dev-team/learnings.md`
-- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
+Attack surfaces identified, security decisions and their rationale, vulnerabilities found and remediated (watch for regressions), trust boundaries mapped, and challenges raised that were accepted (reinforce) or overruled (calibrate).

--- a/.dev-team/agents/dev-team-tufte.md
+++ b/.dev-team/agents/dev-team-tufte.md
@@ -12,9 +12,11 @@ Your philosophy: "If the docs say one thing and the code does another, both are 
 
 ## How you work
 
+**Shared protocol**: Read `SHARED.md` (in this directory) for challenge classification, learnings output format, memory guardrails, and progress reporting. The sections below are agent-specific.
+
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
-**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `documentation`, `api-docs`, `readme`, `doc-code-sync` in other agents' memories — especially Voss (API changes) and Mori (UI documentation needs).
+**Role-aware loading**: Shared context (learnings, process) is loaded automatically via `.claude/rules/`. For cross-agent context, scan entries tagged `documentation`, `api-docs`, `readme`, `doc-code-sync` in other agents' memories — especially Voss (API changes) and Mori (UI documentation needs).
 
 Before reviewing or writing documentation:
 1. Spawn Explore subagents in parallel to map the actual behavior — read the implementation, trace the call graph, run the code if needed.
@@ -22,6 +24,7 @@ Before reviewing or writing documentation:
 3. Compare actual behavior against existing documentation. Every claim in the docs must be verifiable in the code.
 4. Return concise findings to the main thread with specific file and line references.
 
+**Documentation locations**: Write user-facing guides to `docs/guides/`, design notes to `docs/design/`, and benchmark reports to `docs/benchmarks/`. See `docs/README.md` for the full folder structure.
 After completing documentation work:
 1. Report any code behavior that surprised you — if it surprised you, the docs were probably wrong.
 2. Flag documentation that other agents should verify: @dev-team-voss for API docs, @dev-team-mori for UI docs, @dev-team-szabo for security-related docs.
@@ -75,51 +78,7 @@ You compare documentation claims against code reality:
 - "This JSDoc says the function returns `string | null`, but the implementation throws on null input instead of returning null. Which is correct?"
 - "The migration guide says to run `npm run migrate` but that script was removed in commit abc123. A developer following this guide will fail."
 
-## Challenge protocol
 
-When reviewing another agent's work, classify each concern:
-- `[DEFECT]`: Concretely wrong. Will produce incorrect behavior. **Blocks progress.**
-- `[RISK]`: Not wrong today, but creates a likely failure mode. Advisory.
-- `[QUESTION]`: Decision needs justification. Advisory.
-- `[SUGGESTION]`: Works, but here is a specific improvement. Advisory.
+## Learnings: what to record in MEMORY.md
 
-Rules:
-1. Every challenge must include a concrete scenario, input, or code reference.
-2. Only `[DEFECT]` blocks progress.
-3. When challenged: address directly, concede when wrong, justify with a counter-scenario when you disagree.
-4. One exchange each before escalating to the human.
-5. Acknowledge good work when you see it.
-6. **Silence is golden**: If you find nothing substantive to report, say "No substantive findings" and stop generating additional findings. You must still complete the mandatory MEMORY.md write and Learnings Output steps. Do NOT manufacture `[SUGGESTION]`-level findings to fill the review. A clean review is a positive signal, not a gap to fill.
-
-## Learning
-
-After completing work, write key learnings to your MEMORY.md:
-- Documentation patterns established in this project
-- Areas where docs chronically drift from code
-- Conventions the team has adopted for doc style and structure
-- Challenges you raised that were accepted (reinforce) or overruled (calibrate)
-
-### What belongs in memory
-
-**Write:**
-- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
-- Calibration data (challenges accepted/overruled, with reasoning)
-- Architectural boundaries and constraints
-- Non-obvious project-specific knowledge that cannot be derived from code
-
-**Do NOT write:**
-- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
-- Version numbers that change frequently
-- Information already captured in ADRs or `.dev-team/learnings.md`
-- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
-
-## Learnings Output (mandatory)
-
-After completing work, you MUST:
-1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-tufte/MEMORY.md`) with key learnings from this task. The file must contain substantive content — not just headers or boilerplate. Include specific patterns, conventions, calibration notes, or decisions.
-2. **Output a "Learnings" section** in your response summarizing what was written:
-   - What was surprising or non-obvious about this task?
-   - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
-   - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
-
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+Documentation patterns established, areas where docs chronically drift from code, conventions the team has adopted for doc style and structure, and challenges raised that were accepted (reinforce) or overruled (calibrate).

--- a/.dev-team/agents/dev-team-turing.md
+++ b/.dev-team/agents/dev-team-turing.md
@@ -14,16 +14,16 @@ Your philosophy: "Understand the problem completely before writing a line."
 
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (outdated research, superseded findings). If approaching 200 lines, compress older entries into summaries.
 
-**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). Check `.dev-team/research/` for existing briefs on the topic — avoid re-researching what was already investigated.
+**Role-aware loading**: Shared context (learnings, process) is loaded automatically via `.claude/rules/`. Check `docs/research/` for existing briefs on the topic — avoid re-researching what was already investigated.
 
 When given a research task:
 1. Identify the core question and scope constraints
 2. Search official documentation, changelogs, and ecosystem resources
 3. Evaluate multiple approaches with concrete evidence
 4. Produce a structured research brief
-5. Write the brief to `.dev-team/research/<topic>-<date>.md`
+5. Write the brief to `docs/research/<topic>-<date>.md`
 
-You are **read-only for production code**. You write research briefs (markdown) to `.dev-team/research/`, not to `src/`, `templates/`, or any production path.
+You are **read-only for production code**. You write research briefs (markdown) to `docs/research/`, not to `src/`, `templates/`, or any production path. Use the naming convention `{issue}-{kebab-title}-{date}.md` (e.g., `325-non-jsts-benchmark-2026-03-26.md`).
 
 ## Research brief format
 
@@ -43,7 +43,15 @@ Every brief follows this structure:
 [Risks, edge cases, limitations]
 ### Confidence level
 [High / Medium / Low — with explanation of what would increase confidence]
+### Recommended Actions
+[Each finding decomposed into a concrete issue for triage]
+- **Title**: [concise issue title]
+  **Severity**: P0 / P1 / P2
+  **Files affected**: [list]
+  **Scope**: S / M / L
 ```
+
+End every research brief with the `Recommended Actions` section. The orchestrator triages these — Turing does not create issues directly, but provides triage-ready output so research always produces actionable next steps.
 
 ## Focus areas
 
@@ -84,14 +92,31 @@ When running as a background agent:
 | 2. Search | `[Turing] Phase 2/4: Searching documentation and sources...` |
 | 3. Evaluate | `[Turing] Phase 3/4: Evaluating approaches...` |
 | 4. Brief | `[Turing] Phase 4/4: Writing research brief...` |
-| Done | `[Turing] Done — brief written to .dev-team/research/<file>` |
+| Done | `[Turing] Done — brief written to docs/research/<file>` |
 
 Write status to `.dev-team/agent-status/dev-team-turing.json` at each phase boundary, following the standard agent-status JSON convention documented in the ADR index (`docs/adr/README.md`).
 
 ## Learnings Output (mandatory)
 
 After completing work, you MUST:
-1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-turing/MEMORY.md`) with key learnings. Include: research topics investigated, quality of sources found, recommendations that were accepted/rejected, and calibration notes.
-2. **Output a "Learnings" section** in your response.
+1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-turing/MEMORY.md`) with key learnings from this task. The file must contain substantive content — not just headers or boilerplate. Include research topics investigated, quality of sources found, recommendations that were accepted/rejected, and calibration notes.
+2. **Output a "Learnings" section** in your response summarizing what was written:
+   - What was surprising or non-obvious about this task?
+   - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
+   - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
 
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+### What belongs in memory
+
+**Write:**
+- Research conclusions and recommendations that were accepted or rejected
+- Library evaluations (ecosystem health, maintenance status, license findings)
+- Migration path decisions and trade-off analyses
+- Decisions and evaluations (judgment calls) that inform future research scoping
+
+**Do NOT write:**
+- Raw search results or temporary investigation notes
+- Raw findings already documented in ADRs or research briefs (write the decisions, not the data)
+- Version-specific details that will go stale quickly
+- Information already captured in `.claude/rules/dev-team-learnings.md`
+
+If you skip the MEMORY.md write, the pre-commit gate will block commits that include implementation files without corresponding memory updates. Use `.dev-team/.memory-reviewed` to override if no learnings apply.

--- a/.dev-team/agents/dev-team-voss.md
+++ b/.dev-team/agents/dev-team-voss.md
@@ -12,9 +12,11 @@ Your philosophy: "Build as if the next developer inherits your mistakes at 3 AM 
 
 ## How you work
 
+**Shared protocol**: Read `SHARED.md` (in this directory) for challenge classification, learnings output format, memory guardrails, and progress reporting. The sections below are agent-specific.
+
 **Memory hygiene**: Read your MEMORY.md at session start. Remove stale entries (overruled challenges, outdated patterns). If approaching 200 lines, compress older entries into summaries.
 
-**Role-aware loading**: Also read `.dev-team/learnings.md` (Tier 1). For cross-agent context, scan entries tagged `api`, `database`, `migration`, `config`, `architecture` in other agents' memories — especially Brooks (architectural decisions) and Hamilton (deployment constraints).
+**Role-aware loading**: Shared context (learnings, process) is loaded automatically via `.claude/rules/`. For cross-agent context, scan entries tagged `api`, `database`, `migration`, `config`, `architecture` in other agents' memories — especially Brooks (architectural decisions) and Hamilton (deployment constraints).
 
 Before writing any code:
 1. Spawn Explore subagents in parallel to understand the codebase area, find existing patterns, and map dependencies.
@@ -61,50 +63,7 @@ You construct failure scenarios. When reviewing code, you ask "what happens when
 
 Always provide a concrete scenario, never abstract concerns.
 
-## Challenge protocol
 
-When reviewing another agent's work, classify each concern:
-- `[DEFECT]`: Concretely wrong. Will produce incorrect behavior. **Blocks progress.**
-- `[RISK]`: Not wrong today, but creates a likely failure mode. Advisory.
-- `[QUESTION]`: Decision needs justification. Advisory.
-- `[SUGGESTION]`: Works, but here is a specific improvement. Advisory.
+## Learnings: what to record in MEMORY.md
 
-Rules:
-1. Every challenge must include a concrete scenario, input, or code reference.
-2. Only `[DEFECT]` blocks progress.
-3. When challenged: address directly, concede when wrong, justify with a counter-scenario when you disagree.
-4. One exchange each before escalating to the human.
-5. Acknowledge good work when you see it.
-6. **Silence is golden**: If you find nothing substantive to report, say "No substantive findings" and stop generating additional findings. You must still complete the mandatory MEMORY.md write and Learnings Output steps. Do NOT manufacture `[SUGGESTION]`-level findings to fill the review. A clean review is a positive signal, not a gap to fill.
-
-## Learning
-
-After completing work, write key learnings to your MEMORY.md:
-- Patterns discovered in this codebase
-- Conventions the team has established
-- Challenges you raised that were accepted (reinforce) or overruled (calibrate)
-
-### What belongs in memory
-
-**Write:**
-- Stable patterns and conventions (frameworks, architecture decisions, naming patterns)
-- Calibration data (challenges accepted/overruled, with reasoning)
-- Architectural boundaries and constraints
-- Non-obvious project-specific knowledge that cannot be derived from code
-
-**Do NOT write:**
-- Specific numeric counts (test count, ADR count, agent count, file count) — these are volatile and trivially derivable on demand
-- Version numbers that change frequently
-- Information already captured in ADRs or `.dev-team/learnings.md`
-- Trivially observable facts derivable from config files (e.g., "uses TypeScript" when tsconfig.json exists)
-
-## Learnings Output (mandatory)
-
-After completing work, you MUST:
-1. **Write to your MEMORY.md** (`.dev-team/agent-memory/dev-team-voss/MEMORY.md`) with key learnings from this task. The file must contain substantive content — not just headers or boilerplate. Include specific patterns, conventions, calibration notes, or decisions.
-2. **Output a "Learnings" section** in your response summarizing what was written:
-   - What was surprising or non-obvious about this task?
-   - What should be calibrated for next time? (e.g., assumptions that were wrong, patterns that worked well)
-   - Where was this recorded? (`agent memory` for agent-specific calibration / `team learnings` for shared process rules / `ADR` for architectural decisions)
-
-If you skip the MEMORY.md write, the pre-commit gate will block the commit and Borges will flag a [DEFECT].
+Patterns discovered in this codebase, conventions the team has established, and challenges raised that were accepted (reinforce) or overruled (calibrate).

--- a/.dev-team/config.json
+++ b/.dev-team/config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.0",
+  "version": "1.7.0",
   "platform": "github",
   "agents": [
     "Voss",

--- a/.dev-team/hooks/agent-patterns.json
+++ b/.dev-team/hooks/agent-patterns.json
@@ -178,6 +178,7 @@
     "pattern": "\\.(js|ts|jsx|tsx|py|rb|go|java|rs|c|cpp|cs)$"
   },
   "testFile": {
-    "pattern": "\\.(test|spec)\\.|__tests__|\\/tests?\\/"
+    "pattern": "\\.(test|spec)\\.|_test\\.|__tests__|\\/tests?\\/",
+    "_note": "Minimal pattern covering common conventions. Agents apply built-in knowledge of language-specific test conventions (e.g., Go _test.go, Python test_*.py, Java *Test.java) beyond this pattern."
   }
 }

--- a/.dev-team/hooks/dev-team-agent-teams-guide.js
+++ b/.dev-team/hooks/dev-team-agent-teams-guide.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+/**
+ * dev-team-agent-teams-guide.js
+ * PreToolUse hook on Agent.
+ *
+ * Advisory guidance for agent team isolation patterns.
+ * Always exits 0 (never blocks) — prints reminders to stderr.
+ *
+ * Conditions:
+ * 1. Implementing agent with team_name but no worktree isolation →
+ *    remind to add isolation: "worktree"
+ * 2. Agent with worktree isolation but no team_name (when agentTeams enabled) →
+ *    suggest using TeamCreate for coordination
+ * 3. Read-only agent spawned →
+ *    remind to consider whether it needs the implementer's worktree
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || "{}");
+} catch {
+  // Malformed input — advisory hook, just exit cleanly
+  process.exit(0);
+}
+
+const toolInput = input.tool_input || {};
+const prompt = (toolInput.prompt || "").toLowerCase();
+const teamName = toolInput.team_name || "";
+const agentName = toolInput.name || "";
+const isolation = toolInput.isolation || "";
+const subagentType = toolInput.subagent_type || "";
+
+// Detect read-only agents by name or prompt keywords
+const READ_ONLY_AGENTS = [
+  "szabo",
+  "knuth",
+  "brooks",
+  "borges",
+  "tufte",
+  "turing",
+  "rams",
+  "conway",
+  "deming",
+];
+
+const agentNameLower = agentName.toLowerCase();
+const isReadOnly =
+  READ_ONLY_AGENTS.some((a) => agentNameLower.includes(a) || prompt.includes(`@dev-team-${a}`)) ||
+  subagentType === "read-only" ||
+  prompt.includes("review") ||
+  prompt.includes("audit");
+
+// Implementing agents: have team_name but no worktree isolation
+if (teamName && isolation !== "worktree" && !isReadOnly) {
+  console.error(
+    `[dev-team agent-teams-guide] Advisory: implementing teammate "${agentName || "(unnamed)"}" has team_name but no isolation: "worktree". ` +
+      `Add isolation: "worktree" to prevent branch conflicts between parallel teammates.`,
+  );
+}
+
+// Worktree isolation without team coordination (when agent teams are available)
+if (isolation === "worktree" && !teamName) {
+  let agentTeamsEnabled = false;
+  try {
+    const configPath = path.join(process.cwd(), ".dev-team", "config.json");
+    const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    agentTeamsEnabled = !!config.agentTeams;
+  } catch {
+    // No config or parse error — skip this check
+  }
+
+  if (agentTeamsEnabled) {
+    console.error(
+      `[dev-team agent-teams-guide] Advisory: agent "${agentName || "(unnamed)"}" uses worktree isolation without a team_name. ` +
+        `Consider using TeamCreate for coordinated parallel work — it provides progress tracking and message passing between teammates.`,
+    );
+  }
+}
+
+// Read-only agent reminder
+if (isReadOnly && teamName) {
+  console.error(
+    `[dev-team agent-teams-guide] Advisory: read-only agent "${agentName || "(unnamed)"}" spawned as teammate. ` +
+      `Consider whether it needs access to an implementer's worktree (to run tests or read changed files in context), ` +
+      `or should work in its own isolation for independent analysis.`,
+  );
+}
+
+process.exit(0);

--- a/.dev-team/hooks/dev-team-post-change-review.js
+++ b/.dev-team/hooks/dev-team-post-change-review.js
@@ -7,8 +7,7 @@
  * After a file is modified, flags which agents should review based on
  * the file's domain. Advisory only — always exits 0.
  *
- * Patterns are loaded from agent-patterns.json (shared with dev-team-review-gate.js).
- * Falls back to hardcoded patterns if the JSON file is missing or malformed.
+ * Patterns are loaded from agent-patterns.json via the shared lib/agent-patterns module.
  */
 
 "use strict";
@@ -31,205 +30,29 @@ if (!filePath) {
   process.exit(0);
 }
 
-// ─── Load agent patterns from shared JSON ────────────────────────────────────
+// ─── Load agent patterns from shared module ─────────────────────────────────
 
-/**
- * Compile a pattern entry from the JSON into a RegExp.
- * Entries are either a string (no flags) or [source, flags].
- */
-function compilePattern(entry) {
-  if (Array.isArray(entry)) {
-    return new RegExp(entry[0], entry[1] || "");
-  }
-  return new RegExp(entry);
-}
+const {
+  loadPatterns,
+  getPatterns: gp,
+  getSinglePattern: gsp,
+  getLabel: label,
+} = require("./lib/agent-patterns");
 
-/**
- * Load pattern categories from agent-patterns.json.
- * Returns null on failure (caller falls back to hardcoded).
- */
-function loadPatternsFromJSON() {
-  try {
-    const jsonPath = path.join(__dirname, "agent-patterns.json");
-    const data = JSON.parse(fs.readFileSync(jsonPath, "utf-8"));
-    const result = {};
-    for (const [key, value] of Object.entries(data)) {
-      if (value.patterns) {
-        result[key] = {
-          agent: value.agent,
-          label: value.label,
-          matchOn: value.matchOn || ["fullPath"],
-          compiled: value.patterns.map(compilePattern),
-        };
-      } else if (value.pattern) {
-        result[key] = { compiled: compilePattern(value.pattern) };
-      }
-    }
-    return result;
-  } catch {
-    return null;
-  }
-}
+const loaded = loadPatterns();
 
-// Hardcoded fallback patterns (kept in sync with agent-patterns.json)
-const FALLBACK_SECURITY_PATTERNS = [
-  /auth/,
-  /login/,
-  /password/,
-  /token/,
-  /session/,
-  /crypto/,
-  /encrypt/,
-  /decrypt/,
-  /secret/,
-  /permission/,
-  /rbac/,
-  /acl/,
-  /oauth/,
-  /jwt/,
-  /cors/,
-  /csrf/,
-  /sanitiz/,
-  /escap/,
-];
-const FALLBACK_API_PATTERNS = [
-  /\/api\//,
-  /\/routes?\//,
-  /\/endpoints?\//,
-  /schema/,
-  /\.graphql$/,
-  /\.proto$/,
-  /openapi/,
-  /swagger/,
-];
-const FALLBACK_FRONTEND_PATTERNS = [
-  /\/components?\//,
-  /\/pages?\//,
-  /\/views?\//,
-  /\/layouts?\//,
-  /\/ui\//,
-  /\.(css|scss|sass|less|styl)$/,
-  /\.(jsx|tsx)$/,
-  /tailwind/,
-  /styled/,
-];
-const FALLBACK_APP_CONFIG_PATTERNS = [/\.env/, /config/, /migration/, /database/, /\.sql$/];
-const FALLBACK_TOOLING_PATTERNS = [
-  /eslint/,
-  /prettier/,
-  /\.github\/workflows/,
-  /\.claude\//,
-  /tsconfig/,
-  /jest\.config/,
-  /vitest/,
-  /package\.json$/,
-  /\.husky/,
-];
-const FALLBACK_DOC_PATTERNS = [
-  /readme/,
-  /changelog/,
-  /\.md$/,
-  /\.mdx$/,
-  /\/docs?\//,
-  /api-doc/,
-  /jsdoc/,
-  /typedoc/,
-];
-const FALLBACK_DOC_DRIFT_PATTERNS = [
-  /(?:^|\/)src\/.*\.(ts|js)$/,
-  /(?:^|\/)templates\/agents\//,
-  /(?:^|\/)templates\/skills\//,
-  /(?:^|\/)templates\/hooks\//,
-  /(?:^|\/)src\/init\.(ts|js)$/,
-  /(?:^|\/)src\/cli\.(ts|js)$/,
-  /(?:^|\/)bin\//,
-  /(?:^|\/)package\.json$/,
-];
-const FALLBACK_ARCH_PATTERNS = [
-  /\/adr\//,
-  /architecture/,
-  /\/modules?\//,
-  /\/layers?\//,
-  /\/core\//,
-  /\/domain\//,
-  /\/shared\//,
-  /\/lib\//,
-  /\/plugins?\//,
-  /\/middleware\//,
-  /tsconfig/,
-  /webpack|vite|rollup|esbuild/,
-];
-const FALLBACK_RELEASE_PATTERNS = [
-  /package\.json$/,
-  /pyproject\.toml$/,
-  /cargo\.toml$/i,
-  /changelog/i,
-  /version/,
-  /\.github\/workflows\/.*release/,
-  /\.github\/workflows\/.*publish/,
-  /\.github\/workflows\/.*deploy/,
-  /\.npmrc$/,
-  /\.npmignore$/,
-  /release\.config/,
-  /lerna\.json$/,
-];
-const FALLBACK_OPS_PATTERNS = [
-  /dockerfile/,
-  /docker-compose/,
-  /\.dockerignore$/,
-  /\.github\/workflows\//,
-  /\.gitlab-ci/,
-  /jenkinsfile/i,
-  /terraform\//,
-  /pulumi\//,
-  /cloudformation\//,
-  /helm\//,
-  /k8s\//,
-  /\.tf$/,
-  /\.tfvars$/,
-  /health[-_]?check/,
-  /(?:^|\/)(?:monitoring|prometheus|grafana|datadog)\.(?:ya?ml|json|conf|config|toml)$/,
-  /(?:^|\/)(?:logging|logs)\.(?:ya?ml|json|conf|config|toml)$/,
-  /(?:^|\/)(?:alerting|alerts?)\.(?:ya?ml|json|conf|config|toml)$/,
-  /(?:^|\/)(?:observability|otel|opentelemetry)\.(?:ya?ml|json|conf|config|toml)$/,
-  /(?<!\/src)\/(?:monitoring|logging|alerting|observability)\//,
-  /\.env\.example$/,
-  /\.env\.template$/,
-  /env\.template$/,
-];
-const FALLBACK_CODE_FILE = /\.(js|ts|jsx|tsx|py|rb|go|java|rs|c|cpp|cs)$/;
-const FALLBACK_TEST_FILE = /\.(test|spec)\.|__tests__|\/tests?\//;
-
-const loaded = loadPatternsFromJSON();
-
-function getPatterns(key) {
-  return loaded && loaded[key] ? loaded[key].compiled : null;
-}
-function getCategory(key) {
-  return loaded && loaded[key] ? loaded[key] : null;
-}
-function getSinglePattern(key) {
-  return loaded && loaded[key] ? loaded[key].compiled : null;
-}
-
-const SECURITY_PATTERNS = getPatterns("security") || FALLBACK_SECURITY_PATTERNS;
-const API_PATTERNS = getPatterns("api") || FALLBACK_API_PATTERNS;
-const FRONTEND_PATTERNS = getPatterns("frontend") || FALLBACK_FRONTEND_PATTERNS;
-const APP_CONFIG_PATTERNS = getPatterns("appConfig") || FALLBACK_APP_CONFIG_PATTERNS;
-const TOOLING_PATTERNS = getPatterns("tooling") || FALLBACK_TOOLING_PATTERNS;
-const DOC_PATTERNS = getPatterns("docs") || FALLBACK_DOC_PATTERNS;
-const DOC_DRIFT_PATTERNS = getPatterns("docDrift") || FALLBACK_DOC_DRIFT_PATTERNS;
-const ARCH_PATTERNS = getPatterns("architecture") || FALLBACK_ARCH_PATTERNS;
-const RELEASE_PATTERNS = getPatterns("release") || FALLBACK_RELEASE_PATTERNS;
-const OPS_PATTERNS = getPatterns("operations") || FALLBACK_OPS_PATTERNS;
-const codeFilePattern = getSinglePattern("codeFile") || FALLBACK_CODE_FILE;
-const testFilePattern = getSinglePattern("testFile") || FALLBACK_TEST_FILE;
-
-// Resolve labels from JSON or use defaults
-function label(key, fallback) {
-  const cat = getCategory(key);
-  return cat && cat.label ? cat.label : fallback;
-}
+const SECURITY_PATTERNS = gp(loaded, "security");
+const API_PATTERNS = gp(loaded, "api");
+const FRONTEND_PATTERNS = gp(loaded, "frontend");
+const APP_CONFIG_PATTERNS = gp(loaded, "appConfig");
+const TOOLING_PATTERNS = gp(loaded, "tooling");
+const DOC_PATTERNS = gp(loaded, "docs");
+const DOC_DRIFT_PATTERNS = gp(loaded, "docDrift");
+const ARCH_PATTERNS = gp(loaded, "architecture");
+const RELEASE_PATTERNS = gp(loaded, "release");
+const OPS_PATTERNS = gp(loaded, "operations");
+const codeFilePattern = gsp(loaded, "codeFile");
+const testFilePattern = gsp(loaded, "testFile");
 
 // ─── Pattern matching ────────────────────────────────────────────────────────
 
@@ -240,32 +63,32 @@ const flags = [];
 
 // Security-sensitive patterns → flag for Szabo
 if (SECURITY_PATTERNS.some((p) => p.test(fullPath) || p.test(basename))) {
-  flags.push(`@dev-team-szabo (${label("security", "security surface changed")})`);
+  flags.push(`@dev-team-szabo (${label(loaded, "security", "security surface changed")})`);
 }
 
 // API/contract patterns → flag for Mori
 if (API_PATTERNS.some((p) => p.test(fullPath))) {
-  flags.push(`@dev-team-mori (${label("api", "API contract may affect UI")})`);
+  flags.push(`@dev-team-mori (${label(loaded, "api", "API contract may affect UI")})`);
 }
 
 // Frontend/UI component patterns → flag for Rams (design system review)
 if (FRONTEND_PATTERNS.some((p) => p.test(fullPath))) {
-  flags.push(`@dev-team-rams (${label("frontend", "design system compliance review")})`);
+  flags.push(`@dev-team-rams (${label(loaded, "frontend", "design system compliance review")})`);
 }
 
 // App config patterns → flag for Voss
 if (APP_CONFIG_PATTERNS.some((p) => p.test(fullPath))) {
-  flags.push(`@dev-team-voss (${label("appConfig", "app config/data change")})`);
+  flags.push(`@dev-team-voss (${label(loaded, "appConfig", "app config/data change")})`);
 }
 
 // Tooling patterns → flag for Deming
 if (TOOLING_PATTERNS.some((p) => p.test(fullPath))) {
-  flags.push(`@dev-team-deming (${label("tooling", "tooling change")})`);
+  flags.push(`@dev-team-deming (${label(loaded, "tooling", "tooling change")})`);
 }
 
 // Documentation patterns → flag for Tufte
 if (DOC_PATTERNS.some((p) => p.test(fullPath))) {
-  flags.push(`@dev-team-tufte (${label("docs", "documentation changed")})`);
+  flags.push(`@dev-team-tufte (${label(loaded, "docs", "documentation changed")})`);
 }
 
 // Doc-drift patterns → flag Tufte for implementation changes that may need doc updates
@@ -273,23 +96,27 @@ if (DOC_PATTERNS.some((p) => p.test(fullPath))) {
 const alreadyFlaggedTufte = flags.some((f) => f.startsWith("@dev-team-tufte"));
 if (!alreadyFlaggedTufte && DOC_DRIFT_PATTERNS.some((p) => p.test(fullPath))) {
   flags.push(
-    `@dev-team-tufte (${label("docDrift", "implementation changed — check for doc drift")})`,
+    `@dev-team-tufte (${label(loaded, "docDrift", "implementation changed — check for doc drift")})`,
   );
 }
 
 // Architecture patterns → flag for Brooks
 if (ARCH_PATTERNS.some((p) => p.test(fullPath))) {
-  flags.push(`@dev-team-brooks (${label("architecture", "architectural boundary touched")})`);
+  flags.push(
+    `@dev-team-brooks (${label(loaded, "architecture", "architectural boundary touched")})`,
+  );
 }
 
 // Release patterns → flag for Conway
 if (RELEASE_PATTERNS.some((p) => p.test(fullPath))) {
-  flags.push(`@dev-team-conway (${label("release", "version/release artifact changed")})`);
+  flags.push(`@dev-team-conway (${label(loaded, "release", "version/release artifact changed")})`);
 }
 
 // Operations/infra patterns → flag for Hamilton
 if (OPS_PATTERNS.some((p) => p.test(fullPath) || p.test(basename))) {
-  flags.push(`@dev-team-hamilton (${label("operations", "infrastructure/operations change")})`);
+  flags.push(
+    `@dev-team-hamilton (${label(loaded, "operations", "infrastructure/operations change")})`,
+  );
 }
 
 // Always flag Knuth and Brooks for non-test implementation files
@@ -327,21 +154,33 @@ function scoreComplexity(toolInput, scorePath) {
   const linesChanged = oldLines + newLines;
   score += Math.min(linesChanged, 50); // Cap at 50 to avoid single large file dominating
 
-  // Complexity indicators in the new content
-  const complexityPatterns = [
-    /\bfunction\b/g, // new functions
-    /\bclass\b/g, // new classes
-    /\bif\b.*\belse\b/g, // control flow
-    /\bcatch\b/g, // error handling
-    /\bthrow\b/g, // error throwing
-    /\basync\b/g, // async operations
-    /\bawait\b/g, // async operations
-    /\bexport\b/g, // API surface changes
-  ];
+  // Language-agnostic complexity indicators.
+  // Instead of hardcoding language-specific keywords, use structural proxies:
+  // nesting depth and control flow density work across all languages.
+  const lines = newStr.split("\n");
 
-  for (const pattern of complexityPatterns) {
+  // Nesting depth: count max indent level as a proxy for cyclomatic complexity
+  let maxNesting = 0;
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const leading = line.match(/^(\s*)/)[1];
+    // Normalize: treat 1 tab or 2+ spaces as one indent level
+    const depth = leading.includes("\t")
+      ? leading.split("\t").length - 1
+      : Math.floor(leading.length / 2);
+    if (depth > maxNesting) maxNesting = depth;
+  }
+  score += Math.min(maxNesting * 3, 30); // Cap nesting contribution
+
+  // Control flow density: count lines with braces/brackets that indicate branching or blocks
+  // This is language-agnostic -- works for C-family, Python (colons), Ruby (do/end), etc.
+  const controlFlowPatterns = [
+    /[{}]/g, // braces (C-family block delimiters)
+    /\b(if|else|elif|elsif|case|when|switch|match|for|while|do|try|catch|except|finally|rescue)\b/g,
+  ];
+  for (const pattern of controlFlowPatterns) {
     const matches = newStr.match(pattern);
-    if (matches) score += matches.length * 2;
+    if (matches) score += matches.length;
   }
 
   // Security-sensitive files get a boost

--- a/.dev-team/hooks/dev-team-pre-commit-gate.js
+++ b/.dev-team/hooks/dev-team-pre-commit-gate.js
@@ -15,59 +15,13 @@
 
 "use strict";
 
-const { createHash } = require("crypto");
 const { execFileSync } = require("child_process");
 const fs = require("fs");
-const os = require("os");
 const path = require("path");
 
-/**
- * Cached git diff — reads from a temp file if it was written < 5 seconds ago,
- * otherwise shells out to git and writes the result for subsequent hooks.
- * Cache key includes cwd hash so different repos don't share cache.
- */
-function cachedGitDiff(args, timeoutMs) {
-  const cwdHash = createHash("md5").update(process.cwd()).digest("hex").slice(0, 8);
-  const argsKey = args.join("-").replace(/[^a-zA-Z0-9-]/g, "");
-  const cacheFile = path.join(os.tmpdir(), `dev-team-git-cache-${cwdHash}-${argsKey}.txt`);
-  let skipWrite = false;
-  try {
-    const stat = fs.lstatSync(cacheFile);
-    // Reject symlinks to prevent symlink attacks (attacker could point cache
-    // file at a sensitive path and have us overwrite it on the next write)
-    if (stat.isSymbolicLink()) {
-      try {
-        fs.unlinkSync(cacheFile);
-      } catch {
-        // If we can't remove the symlink, skip writing to avoid following it
-        skipWrite = true;
-      }
-    } else if (Date.now() - stat.mtimeMs < 5000) {
-      return fs.readFileSync(cacheFile, "utf-8");
-    }
-  } catch {
-    // No cache or stale — fall through to git call
-  }
-  const result = execFileSync("git", args, { encoding: "utf-8", timeout: timeoutMs });
-  if (!skipWrite) {
-    try {
-      // Atomic write: write to a temp file then rename to close the TOCTOU window
-      const tmpFile = `${cacheFile}.${process.pid}.tmp`;
-      fs.writeFileSync(tmpFile, result, { mode: 0o600 });
-      fs.renameSync(tmpFile, cacheFile);
-      // Best-effort permission tightening for cache files from older versions
-      try {
-        fs.chmodSync(cacheFile, 0o600);
-      } catch {
-        /* best effort */
-      }
-    } catch {
-      // Best effort — don't fail the hook over caching
-    }
-  }
-  return result;
-}
+const { safeRegex } = require("./lib/safe-regex");
 
+const { cachedGitDiff } = require("./lib/git-cache");
 let stagedFiles = "";
 try {
   stagedFiles = cachedGitDiff(["diff", "--cached", "--name-only"], 2000);
@@ -175,13 +129,13 @@ if (hasImplFiles && !hasMemoryUpdates) {
     if (unstagedMemory) {
       console.error(
         "[dev-team pre-commit] BLOCKED: Memory files were updated but not staged. " +
-          "Run `git add .dev-team/learnings.md .dev-team/agent-memory/` to include learnings, " +
+          "Run `git add .claude/rules/dev-team-learnings.md .dev-team/agent-memory/` to include learnings, " +
           "or create an empty `.dev-team/.memory-reviewed` file to acknowledge that memory was reviewed.",
       );
     } else {
       console.error(
         "[dev-team pre-commit] BLOCKED: Implementation files staged without memory updates. " +
-          "Update .dev-team/learnings.md or agent memory with any patterns, conventions, or decisions from this work. " +
+          "Update .claude/rules/dev-team-learnings.md or agent memory with any patterns, conventions, or decisions from this work. " +
           "If no learnings apply, create an empty `.dev-team/.memory-reviewed` file to acknowledge.",
       );
     }
@@ -203,7 +157,23 @@ try {
   // Ignore — best effort
 }
 
-if (/^(feat|fix)\//.test(currentBranch)) {
+// Read taskBranchPattern from config, default to (feat|fix)\/
+let taskBranchPattern = "(feat|fix)\\/";
+try {
+  const configPath = path.join(process.cwd(), ".dev-team", "config.json");
+  const configStat = fs.lstatSync(configPath);
+  if (configStat.isFile() && !configStat.isSymbolicLink()) {
+    const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    if (typeof config.taskBranchPattern === "string" && config.taskBranchPattern) {
+      taskBranchPattern = config.taskBranchPattern;
+    }
+  }
+} catch {
+  // Config missing or invalid — use default
+}
+
+const branchResult = safeRegex("^" + taskBranchPattern);
+if (branchResult.safe && branchResult.regex.test(currentBranch)) {
   const hasMetricsUpdate = files.some((f) => f.endsWith(".dev-team/metrics.md"));
   if (!hasMetricsUpdate) {
     console.warn(

--- a/.dev-team/hooks/dev-team-review-gate.js
+++ b/.dev-team/hooks/dev-team-review-gate.js
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+
+/**
+ * dev-team-review-gate.js
+ * PreToolUse hook on Bash — stateless commit gates for adversarial review enforcement.
+ *
+ * Intercepts `git commit` and enforces two gates:
+ *   Gate 1 — Review evidence: required review sidecar files must exist
+ *   Gate 2 — Findings resolution: no unresolved [DEFECT] findings
+ *
+ * Sidecar files are written by review agents to `.dev-team/.reviews/`.
+ * Each sidecar is named `<agent>--<content-hash>.json` where content-hash
+ * is derived from the file's staged content, ensuring stale reviews don't match.
+ *
+ * Escape hatches:
+ *   - --skip-review in the commit command bypasses both gates (logged)
+ *   - LIGHT review depth (from sidecar metadata) is advisory only
+ *   - Non-code files are not gated
+ *
+ * See ADR-029 for design rationale.
+ */
+
+"use strict";
+
+const { createHash } = require("crypto");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const { cachedGitDiff } = require("./lib/git-cache");
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || "{}");
+} catch {
+  // Fail open on parse error — not a safety hook
+  process.exit(0);
+}
+
+const command = (input.tool_input && input.tool_input.command) || "";
+
+// Only intercept git commit commands (not commit-tree, commit-graph, etc.)
+if (!/\bgit\s+commit(\s|$)/.test(command)) {
+  process.exit(0);
+}
+
+// Escape hatch: --skip-review bypasses both gates (only match as a flag, not in commit messages)
+const argsBeforeMessage = command.replace(/\s+-m\s+(['"].*|[^\s]*).*$/, "");
+if (/--skip-review\b/.test(argsBeforeMessage)) {
+  console.warn(
+    "[dev-team review-gate] WARNING: --skip-review used — review gates bypassed. " +
+      "This is logged as a process deviation for Borges calibration.",
+  );
+  process.exit(0);
+}
+
+// ─── Pattern matching (shared with dev-team-post-change-review.js) ───────────
+// Patterns loaded from agent-patterns.json via the shared lib module.
+
+const { loadPatterns, getPatterns: gp, getSinglePattern: gsp } = require("./lib/agent-patterns");
+
+const loaded = loadPatterns();
+
+const SECURITY_PATTERNS = gp(loaded, "security");
+const API_PATTERNS = gp(loaded, "api");
+const FRONTEND_PATTERNS = gp(loaded, "frontend");
+const APP_CONFIG_PATTERNS = gp(loaded, "appConfig");
+const TOOLING_PATTERNS = gp(loaded, "tooling");
+const DOC_PATTERNS = gp(loaded, "docs");
+const ARCH_PATTERNS = gp(loaded, "architecture");
+const RELEASE_PATTERNS = gp(loaded, "release");
+const OPS_PATTERNS = gp(loaded, "operations");
+const codeFilePattern = gsp(loaded, "codeFile");
+const testFilePattern = gsp(loaded, "testFile");
+
+/**
+ * Derive which agents are required for a given file path.
+ * Returns an array of agent names (e.g., ["dev-team-szabo", "dev-team-knuth"]).
+ */
+function deriveRequiredAgents(filePath) {
+  const basename = path.basename(filePath).toLowerCase();
+  const fullPath = filePath.split("\\").join("/").toLowerCase();
+  const agents = [];
+
+  if (SECURITY_PATTERNS.some((p) => p.test(fullPath) || p.test(basename))) {
+    agents.push("dev-team-szabo");
+  }
+  if (API_PATTERNS.some((p) => p.test(fullPath))) {
+    agents.push("dev-team-mori");
+  }
+  if (FRONTEND_PATTERNS.some((p) => p.test(fullPath))) {
+    agents.push("dev-team-rams");
+  }
+  if (APP_CONFIG_PATTERNS.some((p) => p.test(fullPath))) {
+    agents.push("dev-team-voss");
+  }
+  if (TOOLING_PATTERNS.some((p) => p.test(fullPath))) {
+    agents.push("dev-team-deming");
+  }
+  if (DOC_PATTERNS.some((p) => p.test(fullPath))) {
+    agents.push("dev-team-tufte");
+  }
+  if (ARCH_PATTERNS.some((p) => p.test(fullPath))) {
+    agents.push("dev-team-brooks");
+  }
+  if (RELEASE_PATTERNS.some((p) => p.test(fullPath))) {
+    agents.push("dev-team-conway");
+  }
+  if (OPS_PATTERNS.some((p) => p.test(fullPath) || p.test(basename))) {
+    agents.push("dev-team-hamilton");
+  }
+
+  // Always flag Knuth and Brooks for non-test implementation files
+  const isTestFile = testFilePattern.test(fullPath);
+  const isCodeFile = codeFilePattern.test(fullPath);
+
+  if (isCodeFile && !isTestFile) {
+    if (!agents.includes("dev-team-knuth")) {
+      agents.push("dev-team-knuth");
+    }
+    if (!agents.includes("dev-team-brooks")) {
+      agents.push("dev-team-brooks");
+    }
+  }
+
+  if (isTestFile && isCodeFile) {
+    agents.push("dev-team-beck");
+  }
+
+  return agents;
+}
+
+/**
+ * Returns true if the file is an implementation file that requires review gating.
+ * Non-code files (markdown, config, etc.) get reviews but are not gated.
+ */
+function isGatedFile(filePath) {
+  const fullPath = filePath.split("\\").join("/").toLowerCase();
+  const isCodeFile = codeFilePattern.test(fullPath);
+  const isTestFile = testFilePattern.test(fullPath);
+  // Gate implementation code files, not test files or non-code files
+  return isCodeFile && !isTestFile;
+}
+
+/**
+ * Compute the content hash of a staged file using git show :<file>.
+ * Returns a hex string (first 12 chars of SHA-256).
+ */
+function stagedContentHash(filePath) {
+  try {
+    const content = execFileSync("git", ["show", `:${filePath}`], {
+      encoding: "buffer",
+      timeout: 5000,
+    });
+    return createHash("sha256").update(content).digest("hex").slice(0, 12);
+  } catch {
+    // File may be deleted or binary — skip
+    return null;
+  }
+}
+
+// ─── Main gate logic ────────────────────────────────────────────────────────
+
+let stagedFiles = "";
+try {
+  stagedFiles = cachedGitDiff(["diff", "--cached", "--name-only"], 2000);
+} catch {
+  // Not in a git repo or git not available — allow
+  process.exit(0);
+}
+
+const files = stagedFiles
+  .split("\n")
+  .filter(Boolean)
+  .map((f) => f.split("\\").join("/"));
+
+if (files.length === 0) {
+  process.exit(0);
+}
+
+// Only gate implementation files
+const gatedFiles = files.filter(isGatedFile);
+
+if (gatedFiles.length === 0) {
+  process.exit(0);
+}
+
+// Read configurable thresholds from config.json
+let lightThreshold = 10;
+try {
+  const configPath = path.join(process.cwd(), ".dev-team", "config.json");
+  const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+  if (config.reviewThresholds && config.reviewThresholds.light) {
+    lightThreshold = config.reviewThresholds.light;
+  }
+} catch {
+  // Use defaults
+}
+
+const reviewsDir = path.join(process.cwd(), ".dev-team", ".reviews");
+
+/**
+ * Find all sidecar files for a given agent and file content hash.
+ * Sidecar naming: <agent>--<contentHash>.json
+ */
+function findSidecar(agent, contentHash) {
+  const expectedName = `${agent}--${contentHash}.json`;
+  const sidecarPath = path.join(reviewsDir, expectedName);
+  try {
+    const stat = fs.lstatSync(sidecarPath);
+    if (stat.isSymbolicLink()) return null; // Reject symlinks
+    if (!stat.isFile()) return null;
+    const content = fs.readFileSync(sidecarPath, "utf-8");
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+// ─── Gate 1: Review evidence ────────────────────────────────────────────────
+
+const missingReviews = [];
+
+for (const file of gatedFiles) {
+  const contentHash = stagedContentHash(file);
+  if (!contentHash) continue; // Deleted files — skip
+
+  const requiredAgents = deriveRequiredAgents(file);
+  if (requiredAgents.length === 0) continue;
+
+  for (const agent of requiredAgents) {
+    const sidecar = findSidecar(agent, contentHash);
+    if (!sidecar) {
+      missingReviews.push({ file, agent });
+    }
+  }
+}
+
+if (missingReviews.length > 0) {
+  console.error("[dev-team review-gate] BLOCKED — required reviews missing:\n");
+  // Group by file for readability
+  const byFile = {};
+  for (const { file, agent } of missingReviews) {
+    if (!byFile[file]) byFile[file] = [];
+    byFile[file].push(agent);
+  }
+  for (const [file, agents] of Object.entries(byFile)) {
+    console.error(`  ${file}:`);
+    for (const agent of agents) {
+      console.error(`    - ${agent}`);
+    }
+  }
+  console.error("\nRun the post-change review agents, or use --skip-review to bypass.");
+  process.exit(2);
+}
+
+// ─── Gate 2: Findings resolution ────────────────────────────────────────────
+
+const unresolvedDefects = [];
+
+for (const file of gatedFiles) {
+  const contentHash = stagedContentHash(file);
+  if (!contentHash) continue;
+
+  const requiredAgents = deriveRequiredAgents(file);
+  for (const agent of requiredAgents) {
+    const sidecar = findSidecar(agent, contentHash);
+    if (!sidecar) continue; // Already caught by Gate 1
+
+    // LIGHT reviews are advisory only — skip defect check
+    if (sidecar.reviewDepth === "LIGHT") continue;
+
+    const findings = sidecar.findings;
+    if (!Array.isArray(findings)) continue; // Malformed sidecar — skip
+    for (const finding of findings) {
+      if (finding.classification === "[DEFECT]" && !finding.resolved) {
+        unresolvedDefects.push({
+          file,
+          agent,
+          description: finding.description,
+          line: finding.line,
+        });
+      }
+    }
+  }
+}
+
+if (unresolvedDefects.length > 0) {
+  console.error("[dev-team review-gate] BLOCKED — unresolved [DEFECT] findings:\n");
+  for (const { file, agent, description, line } of unresolvedDefects) {
+    const loc = line ? `:${line}` : "";
+    console.error(`  ${file}${loc} (${agent}):`);
+    console.error(`    ${description}`);
+  }
+  console.error(
+    "\nFix the defects and re-run reviews, dismiss findings explicitly, or use --skip-review to bypass.",
+  );
+  process.exit(2);
+}
+
+// ─── Cleanup: remove stale sidecars for committed files ─────────────────────
+// After a successful gate pass, schedule cleanup of sidecar files for the
+// files being committed. We don't delete them here (commit hasn't happened yet)
+// but mark them for post-commit cleanup by writing a manifest.
+
+try {
+  if (fs.existsSync(reviewsDir)) {
+    const manifest = [];
+    for (const file of gatedFiles) {
+      const contentHash = stagedContentHash(file);
+      if (!contentHash) continue;
+      const requiredAgents = deriveRequiredAgents(file);
+      for (const agent of requiredAgents) {
+        manifest.push(`${agent}--${contentHash}.json`);
+      }
+    }
+    if (manifest.length > 0) {
+      const manifestPath = path.join(reviewsDir, ".cleanup-manifest.json");
+      const tmpFile = `${manifestPath}.${process.pid}.tmp`;
+      fs.writeFileSync(tmpFile, JSON.stringify(manifest, null, 2), { mode: 0o600 });
+      fs.renameSync(tmpFile, manifestPath);
+    }
+  }
+} catch {
+  // Best effort — don't block commit over cleanup bookkeeping
+}
+
+process.exit(0);

--- a/.dev-team/hooks/dev-team-tdd-enforce.js
+++ b/.dev-team/hooks/dev-team-tdd-enforce.js
@@ -14,58 +14,10 @@
 
 "use strict";
 
-const { createHash } = require("crypto");
-const { execFileSync } = require("child_process");
 const fs = require("fs");
-const os = require("os");
 const path = require("path");
 
-/**
- * Cached git diff — reads from a temp file if it was written < 5 seconds ago,
- * otherwise shells out to git and writes the result for subsequent hooks.
- * Cache key includes cwd hash so different repos don't share cache.
- */
-function cachedGitDiff(args, timeoutMs) {
-  const cwdHash = createHash("md5").update(process.cwd()).digest("hex").slice(0, 8);
-  const argsKey = args.join("-").replace(/[^a-zA-Z0-9-]/g, "");
-  const cacheFile = path.join(os.tmpdir(), `dev-team-git-cache-${cwdHash}-${argsKey}.txt`);
-  let skipWrite = false;
-  try {
-    const stat = fs.lstatSync(cacheFile);
-    // Reject symlinks to prevent symlink attacks (attacker could point cache
-    // file at a sensitive path and have us overwrite it on the next write)
-    if (stat.isSymbolicLink()) {
-      try {
-        fs.unlinkSync(cacheFile);
-      } catch {
-        // If we can't remove the symlink, skip writing to avoid following it
-        skipWrite = true;
-      }
-    } else if (Date.now() - stat.mtimeMs < 5000) {
-      return fs.readFileSync(cacheFile, "utf-8");
-    }
-  } catch {
-    // No cache or stale — fall through to git call
-  }
-  const result = execFileSync("git", args, { encoding: "utf-8", timeout: timeoutMs });
-  if (!skipWrite) {
-    try {
-      // Atomic write: write to a temp file then rename to close the TOCTOU window
-      const tmpFile = `${cacheFile}.${process.pid}.tmp`;
-      fs.writeFileSync(tmpFile, result, { mode: 0o600 });
-      fs.renameSync(tmpFile, cacheFile);
-      // Best-effort permission tightening for cache files from older versions
-      try {
-        fs.chmodSync(cacheFile, 0o600);
-      } catch {
-        /* best effort */
-      }
-    } catch {
-      // Best effort — don't fail the hook over caching
-    }
-  }
-  return result;
-}
+const { cachedGitDiff } = require("./lib/git-cache");
 
 let input = {};
 try {
@@ -107,7 +59,15 @@ if (SKIP_EXTENSIONS.includes(ext)) {
 }
 
 // Skip if the file IS a test file
-const TEST_PATTERNS = [/\.test\./, /\.spec\./, /_test\./, /\/__tests__\//, /\/test\//, /\/tests\//];
+const TEST_PATTERNS = [
+  /\.test\./,
+  /\.spec\./,
+  /_test\./,
+  /\/test_[^/]+$/,
+  /\/__tests__\//,
+  /\/test\//,
+  /\/tests\//,
+];
 
 if (TEST_PATTERNS.some((p) => p.test(filePath))) {
   process.exit(0);
@@ -155,11 +115,21 @@ if (hasTestChanges) {
 const dir = path.dirname(filePath);
 const name = path.basename(filePath, ext);
 
+// Language-aware candidate test file patterns.
+// Covers JS/TS (.test, .spec, __tests__), Go (_test), Python (test_), and Java (Test suffix).
+// For languages beyond these, the agent fallback message below delegates to agent knowledge.
 const CANDIDATE_PATTERNS = [
+  // JS/TS conventions
   path.join(dir, `${name}.test${ext}`),
   path.join(dir, `${name}.spec${ext}`),
   path.join(dir, "__tests__", `${name}${ext}`),
   path.join(dir, "__tests__", `${name}.test${ext}`),
+  // Go convention: foo_test.go alongside foo.go
+  path.join(dir, `${name}_test${ext}`),
+  // Python convention: test_foo.py alongside foo.py
+  path.join(dir, `test_${name}${ext}`),
+  // Java convention: FooTest.java alongside Foo.java
+  path.join(dir, `${name}Test${ext}`),
 ];
 
 const hasExistingTests = CANDIDATE_PATTERNS.some((candidate) => {
@@ -175,8 +145,10 @@ if (hasExistingTests) {
   process.exit(0);
 }
 
-// No test changes AND no existing test file — block
+// No test changes AND no existing test file — block.
+// The message delegates language-specific test discovery to the agent.
 console.error(
-  `[dev-team tdd-enforce] TDD violation: "${basename}" modified but no corresponding test file exists. Write tests first.`,
+  `[dev-team tdd-enforce] TDD violation: "${basename}" modified but no corresponding test file found. ` +
+    `If no candidate test file matches the patterns above, use your knowledge of this language's test conventions to locate or create the appropriate test file. Write tests first.`,
 );
 process.exit(2);

--- a/.dev-team/hooks/dev-team-watch-list.js
+++ b/.dev-team/hooks/dev-team-watch-list.js
@@ -22,6 +22,8 @@
 const fs = require("fs");
 const path = require("path");
 
+const { safeRegex } = require("./lib/safe-regex");
+
 let input = {};
 try {
   input = JSON.parse(process.argv[2] || "{}");
@@ -60,8 +62,14 @@ for (const entry of watchLists) {
   if (!entry.pattern || !entry.agents) continue;
 
   try {
-    const regex = new RegExp(entry.pattern);
-    if (regex.test(filePath)) {
+    const result = safeRegex(entry.pattern);
+    if (!result.safe) {
+      console.warn(
+        `[dev-team watch-list] Skipping unsafe pattern "${entry.pattern}": ${result.reason}`,
+      );
+      continue;
+    }
+    if (result.regex.test(filePath)) {
       for (const agent of entry.agents) {
         if (!matches.some((m) => m.agent === agent)) {
           matches.push({

--- a/.dev-team/hooks/lib/agent-patterns.js
+++ b/.dev-team/hooks/lib/agent-patterns.js
@@ -1,0 +1,87 @@
+/**
+ * agent-patterns.js — shared agent pattern loading for dev-team hooks.
+ *
+ * Loads and compiles file-matching patterns from agent-patterns.json.
+ * Used by both post-change-review and review-gate hooks to determine
+ * which agents should review a given file path.
+ *
+ * agent-patterns.json is the single source of truth for file-to-agent routing.
+ * It is always deployed alongside hooks (copied by init and update).
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * Compile a pattern entry from the JSON into a RegExp.
+ * Entries are either a string (no flags) or [source, flags].
+ */
+function compilePattern(entry) {
+  if (Array.isArray(entry)) {
+    return new RegExp(entry[0], entry[1] || "");
+  }
+  return new RegExp(entry);
+}
+
+/**
+ * Load all pattern categories from agent-patterns.json.
+ * Returns an object keyed by category name with compiled RegExp arrays,
+ * plus agent/label/matchOn metadata where present.
+ *
+ * Throws if agent-patterns.json is missing or malformed — hooks should
+ * not silently degrade when the authoritative pattern source is absent.
+ */
+function loadPatterns() {
+  const jsonPath = path.join(__dirname, "..", "agent-patterns.json");
+  const data = JSON.parse(fs.readFileSync(jsonPath, "utf-8"));
+  const result = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (value.patterns) {
+      result[key] = {
+        agent: value.agent,
+        label: value.label,
+        matchOn: value.matchOn || ["fullPath"],
+        compiled: value.patterns.map(compilePattern),
+      };
+    } else if (value.pattern) {
+      result[key] = { compiled: compilePattern(value.pattern) };
+    }
+  }
+  return result;
+}
+
+/**
+ * Get compiled pattern array for a category.
+ * @param {object} loaded - Result of loadPatterns()
+ * @param {string} key - Category name (e.g., "security", "api")
+ * @returns {RegExp[]} Array of compiled patterns
+ */
+function getPatterns(loaded, key) {
+  return loaded[key] ? loaded[key].compiled : [];
+}
+
+/**
+ * Get a single compiled pattern for a category.
+ * @param {object} loaded - Result of loadPatterns()
+ * @param {string} key - Category name (e.g., "codeFile", "testFile")
+ * @returns {RegExp} Compiled pattern
+ */
+function getSinglePattern(loaded, key) {
+  return loaded[key] ? loaded[key].compiled : null;
+}
+
+/**
+ * Get the label for a category, falling back to a default.
+ * @param {object} loaded - Result of loadPatterns()
+ * @param {string} key - Category name
+ * @param {string} fallback - Default label
+ * @returns {string}
+ */
+function getLabel(loaded, key, fallback) {
+  const cat = loaded[key];
+  return cat && cat.label ? cat.label : fallback;
+}
+
+module.exports = { loadPatterns, getPatterns, getSinglePattern, getLabel };

--- a/.dev-team/hooks/lib/git-cache.js
+++ b/.dev-team/hooks/lib/git-cache.js
@@ -1,0 +1,72 @@
+/**
+ * git-cache.js — shared cached git diff for dev-team hooks.
+ *
+ * Reads from a temp file if it was written < 5 seconds ago,
+ * otherwise shells out to git and writes the result for subsequent hooks.
+ * Cache key includes cwd hash so different repos don't share cache.
+ *
+ * Security: rejects symlinks on the cache file to prevent symlink attacks,
+ * uses atomic writes (write-to-tmp + rename) to close TOCTOU windows,
+ * and restricts cache file permissions to owner-only (0o600).
+ */
+
+"use strict";
+
+const { createHash } = require("crypto");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+/**
+ * Cached git diff — reads from a temp file if it was written < 5 seconds ago,
+ * otherwise shells out to git and writes the result for subsequent hooks.
+ * Cache key includes cwd hash so different repos don't share cache.
+ *
+ * @param {string[]} args - Arguments to pass to git (e.g., ["diff", "--cached", "--name-only"])
+ * @param {number} timeoutMs - Timeout in milliseconds for the git command
+ * @returns {string} The git command output
+ */
+function cachedGitDiff(args, timeoutMs) {
+  const cwdHash = createHash("md5").update(process.cwd()).digest("hex").slice(0, 8);
+  const argsKey = args.join("-").replace(/[^a-zA-Z0-9-]/g, "");
+  const cacheFile = path.join(os.tmpdir(), `dev-team-git-cache-${cwdHash}-${argsKey}.txt`);
+  let skipWrite = false;
+  try {
+    const stat = fs.lstatSync(cacheFile);
+    // Reject symlinks to prevent symlink attacks (attacker could point cache
+    // file at a sensitive path and have us overwrite it on the next write)
+    if (stat.isSymbolicLink()) {
+      try {
+        fs.unlinkSync(cacheFile);
+      } catch {
+        // If we can't remove the symlink, skip writing to avoid following it
+        skipWrite = true;
+      }
+    } else if (Date.now() - stat.mtimeMs < 5000) {
+      return fs.readFileSync(cacheFile, "utf-8");
+    }
+  } catch {
+    // No cache or stale — fall through to git call
+  }
+  const result = execFileSync("git", args, { encoding: "utf-8", timeout: timeoutMs });
+  if (!skipWrite) {
+    try {
+      // Atomic write: write to a temp file then rename to close the TOCTOU window
+      const tmpFile = `${cacheFile}.${process.pid}.tmp`;
+      fs.writeFileSync(tmpFile, result, { mode: 0o600 });
+      fs.renameSync(tmpFile, cacheFile);
+      // Best-effort permission tightening for cache files from older versions
+      try {
+        fs.chmodSync(cacheFile, 0o600);
+      } catch {
+        /* best effort */
+      }
+    } catch {
+      // Best effort — don't fail the hook over caching
+    }
+  }
+  return result;
+}
+
+module.exports = { cachedGitDiff };

--- a/.dev-team/hooks/lib/safe-regex.js
+++ b/.dev-team/hooks/lib/safe-regex.js
@@ -1,0 +1,52 @@
+/**
+ * safe-regex.js — ReDoS guard for user-controlled regex patterns.
+ *
+ * Detects patterns likely to cause catastrophic backtracking:
+ * - Nested quantifiers: (.*)*  (.+)+  (a*)*  (\d+)+  etc.
+ * - Overlapping alternations with quantifiers: (a|a)+
+ *
+ * Returns { safe: true, regex } on success, { safe: false, reason } on rejection.
+ * Does NOT add npm dependencies — pure string analysis.
+ */
+
+"use strict";
+
+/**
+ * Check whether a regex pattern is likely safe from ReDoS.
+ *
+ * @param {string} pattern - The regex source string
+ * @returns {{ safe: true, regex: RegExp } | { safe: false, reason: string }}
+ */
+function safeRegex(pattern) {
+  if (typeof pattern !== "string" || pattern.length === 0) {
+    return { safe: false, reason: "pattern must be a non-empty string" };
+  }
+
+  // Reject patterns over a reasonable length — very long patterns
+  // are themselves a DoS vector during compilation
+  if (pattern.length > 1024) {
+    return { safe: false, reason: "pattern exceeds 1024 characters" };
+  }
+
+  // Detect nested quantifiers — the primary ReDoS vector.
+  // Matches: group with quantifier inside, followed by outer quantifier.
+  // Examples: (.*)+  (a+)*  (\d*)+  ([^x]+)*  (a{1,}){2,}
+  if (/\([^)]*[+*{][^)]*\)[+*{]/.test(pattern)) {
+    return { safe: false, reason: "nested quantifiers detected (potential ReDoS)" };
+  }
+
+  // Detect quantified backreferences — another ReDoS vector
+  if (/\\[1-9]\d*[+*{]/.test(pattern)) {
+    return { safe: false, reason: "quantified backreference detected (potential ReDoS)" };
+  }
+
+  // Try to compile — catches syntax errors
+  try {
+    const regex = new RegExp(pattern);
+    return { safe: true, regex };
+  } catch (err) {
+    return { safe: false, reason: `invalid regex: ${err.message}` };
+  }
+}
+
+module.exports = { safeRegex };

--- a/.dev-team/skills/dev-team-audit/SKILL.md
+++ b/.dev-team/skills/dev-team-audit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: dev-team:audit
 description: Full codebase audit combining security, quality, and tooling assessments. Use to run a comprehensive scan with Szabo (security), Knuth (quality), and Deming (tooling) in parallel. Can be scoped to specific directories or file patterns.
+disable-model-invocation: true
 ---
 
 Run a comprehensive audit of: $ARGUMENTS
@@ -16,6 +17,10 @@ Run a comprehensive audit of: $ARGUMENTS
    - **@dev-team-szabo** — Security audit
    - **@dev-team-knuth** — Quality and correctness audit
    - **@dev-team-deming** — Tooling and automation audit
+
+## Security preamble
+
+Before starting the audit, check for open security alerts using the project's security monitoring process (e.g., a `/security-status` skill or CLAUDE.md guidance). If no such process, skill, or guidance is available, explicitly note this in your report and proceed by reviewing recent security-related issues and scanning for common vulnerabilities manually. Include any findings in the audit scope.
 
 ## Execution
 
@@ -84,13 +89,14 @@ Same grouping. Include actionable recommendations.
 
 Numbered list of concrete actions, ordered by priority. Each action should reference the specific finding it addresses.
 
-### Security preamble
+### Platform detection
 
-Before starting the audit, check for open security alerts: run `/dev-team:security-status` if available, or use the project's security monitoring tools. Include these in the audit scope.
+Before issuing any `gh issue`, `gh pr`, or other platform-specific CLI commands, check `.dev-team/config.json` for the `platform` and `issueTracker` fields. If the project specifies a non-GitHub platform (e.g., `"gitlab"`, `"bitbucket"`, `"other"`), adapt issue tracker and PR commands accordingly — use `glab` for GitLab, the Bitbucket API, or the appropriate CLI for the configured platform. If `platform` is absent from config.json, default to `"github"`. The steps in this skill assume GitHub by default.
 
 ### Completion
 
 After the audit report is delivered:
 1. You MUST spawn **@dev-team-borges** as `borges-extract` (Librarian) as the final step to review memory freshness and capture learnings from the audit findings. Do NOT skip this.
 2. If Borges was not spawned, the audit is INCOMPLETE.
-3. Include Borges's recommendations in the final report.
+3. **Metrics completion gate**: Read `.dev-team/metrics.md` and verify that a new `Task: <reference>` entry was appended after this audit started. A stale metrics file (no new entry) means Borges did not complete successfully. If metrics.md has no new entry after Borges reports completion, flag this as a system failure and re-run Borges with explicit instruction to record metrics.
+4. Include Borges's recommendations in the final report.

--- a/.dev-team/skills/dev-team-retro/SKILL.md
+++ b/.dev-team/skills/dev-team-retro/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: dev-team:retro
 description: Audit the health of your project's dev-team knowledge base — learnings, agent memory, and CLAUDE.md. Finds stale entries, contradictions, enforcement gaps, and promotion opportunities. Use periodically or after major changes.
+disable-model-invocation: true
 ---
 
 Assess the health of the dev-team knowledge base for: $ARGUMENTS
@@ -9,7 +10,7 @@ Assess the health of the dev-team knowledge base for: $ARGUMENTS
 
 This skill audits **only update-safe files** — files that survive `dev-team update`:
 
-- `.dev-team/learnings.md` — shared project learnings
+- `.claude/rules/dev-team-learnings.md` — shared project learnings
 - `.dev-team/agent-memory/*/MEMORY.md` — per-agent calibration memory
 - Project `CLAUDE.md` — project instructions (content outside `<!-- dev-team:begin/end -->` markers)
 
@@ -18,15 +19,16 @@ This skill audits **only update-safe files** — files that survive `dev-team up
 ## Setup
 
 1. Read the following files to build a complete picture:
-   - `.dev-team/learnings.md`
+   - `.claude/rules/dev-team-learnings.md`
    - All `.dev-team/agent-memory/*/MEMORY.md` files (use Glob to discover them)
    - The project's `CLAUDE.md` (root of repo)
    - `.dev-team/config.json` (to know which agents are installed)
+   - `.claude/rules/dev-team-process.md` (orchestration protocol and workflow rules)
    - `.dev-team/metrics.md` (if it exists — calibration metrics log)
 
 2. If `$ARGUMENTS` specifies a focus area (e.g., "learnings", "memory", "claude.md"), scope the audit to that area only. Otherwise, audit all three.
 
-## Phase 1: Learnings audit (`.dev-team/learnings.md`)
+## Phase 1: Learnings audit (`.claude/rules/dev-team-learnings.md`)
 
 Check for:
 
@@ -65,6 +67,30 @@ Apply this classification to:
 - Learnings that are really agent-specific calibration and should move to the appropriate agent's `MEMORY.md`
 - Learnings currently in `CLAUDE.md` that are purely discoverable — flag for removal
 
+## Phase 1b: Process file audit (`.claude/rules/dev-team-process.md`)
+
+Check `.claude/rules/dev-team-process.md` for:
+
+### Staleness
+- References to agent names, hook scripts, or workflow steps that no longer exist
+- Orchestration rules that describe removed or renamed commands
+- References to old file paths, deprecated tools, or outdated conventions
+
+### Contradictions
+- Rules that conflict with `.claude/rules/dev-team-learnings.md` (e.g., process says "sequential reviews" but learnings say "parallel reviews")
+- Instructions that contradict the project's `CLAUDE.md`
+- Workflow descriptions that disagree with actual hook or agent behavior
+
+### Completeness
+- Workflow rules documented in `.claude/rules/dev-team-learnings.md` that describe process but are missing from `process.md`
+- Orchestration patterns that agents follow in practice but are not documented here
+- Missing sections that a new agent or developer would need to understand the workflow
+
+### Accuracy
+- Verify orchestration claims against actual agent definitions in `.dev-team/agents/`
+- Verify hook trigger descriptions against actual hook scripts in `.dev-team/hooks/`
+- Verify naming conventions and parallel execution rules against observed behavior in recent git history
+
 ## Phase 2: Agent memory audit (`.dev-team/agent-memory/*/MEMORY.md`)
 
 Check each agent's memory file for:
@@ -76,10 +102,10 @@ Check each agent's memory file for:
 ### Staleness
 - Memory entries that reference files, patterns, or decisions that no longer exist
 - Calibration notes about overruled findings when the underlying code has since changed
-- Entries that duplicate what is already in `.dev-team/learnings.md` (should be deduplicated)
+- Entries that duplicate what is already in `.claude/rules/dev-team-learnings.md` (should be deduplicated)
 
 ### Inconsistencies
-- Agent memory that contradicts `.dev-team/learnings.md`
+- Agent memory that contradicts `.claude/rules/dev-team-learnings.md`
 - Agent memory that contradicts another agent's memory (e.g., Szabo says "auth uses sessions" but Voss says "auth uses JWT")
 - Agent memory that contradicts `CLAUDE.md`
 
@@ -91,7 +117,7 @@ Check each agent's memory file for:
 - Scan each agent's `MEMORY.md` for entries that describe project-wide patterns, conventions, or rules rather than agent-specific calibration
 - Examples of promotable entries: "all API endpoints require rate limiting" (Szabo), "we always use transactions for multi-table writes" (Voss), "components must support keyboard navigation" (Mori)
 - Examples of non-promotable entries: "I tend to over-flag SQL injection in parameterized queries" (agent-specific calibration), "coverage is weak in the parser module" (agent-specific observation)
-- Flag entries that would benefit other agents if promoted to `.dev-team/learnings.md`
+- Flag entries that would benefit other agents if promoted to `.claude/rules/dev-team-learnings.md`
 - Classify each as `[SUGGESTION]` with the specific entry text and recommended shared learning wording
 - After an entry is promoted to shared learnings, the original agent memory entry should be removed or replaced with a cross-reference to avoid the duplication that the Staleness check flags
 
@@ -105,7 +131,7 @@ Check the project's `CLAUDE.md` for:
 - Agent descriptions or hook triggers that are outdated
 
 ### Completeness
-- Important patterns from `.dev-team/learnings.md` that should be in `CLAUDE.md` but are not
+- Important patterns from `.claude/rules/dev-team-learnings.md` that should be in `CLAUDE.md` but are not
 - Missing sections that a new developer would need (build commands, test commands, architecture overview)
 - Installed agents or hooks not mentioned in `CLAUDE.md`
 
@@ -118,7 +144,7 @@ Check the project's `CLAUDE.md` for:
 
 ### Instruction surface health
 - Count lines in the CLAUDE.md managed section (between `<!-- dev-team:begin -->` and `<!-- dev-team:end -->` markers) — flag as `[RISK]` if over 100 lines
-- Scan `.dev-team/learnings.md` using the **AGENTS.md Verdict** classification (see Phase 1 table):
+- Scan `.claude/rules/dev-team-learnings.md` using the **AGENTS.md Verdict** classification (see Phase 1 table):
   - Entries in PROMOTE categories (tool preferences, test quirks, legacy traps, custom middleware warnings) belong in learnings or `CLAUDE.md` — do NOT flag these for removal
   - Entries in DO NOT PROMOTE categories (codebase structure, language/framework, directory tree, tech stack overview) are discoverable — flag each for removal
 - Report a "discoverable content ratio": number of discoverable-flagged entries / total entries (excluding tool preferences and quirks from the count)
@@ -207,6 +233,7 @@ Provide a simple health score:
 | Area | Status | Issues |
 |------|--------|--------|
 | Learnings | healthy / needs attention / unhealthy | count by severity |
+| Process | healthy / needs attention / unhealthy | count by severity |
 | Agent Memory | healthy / needs attention / unhealthy | count by severity |
 | CLAUDE.md | healthy / needs attention / unhealthy | count by severity |
 | Metrics | healthy / needs attention / unhealthy | count by severity |

--- a/.dev-team/skills/dev-team-review/SKILL.md
+++ b/.dev-team/skills/dev-team-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: dev-team:review
 description: Orchestrated multi-agent parallel review. Use to review a PR, branch, or set of changes with multiple specialist agents simultaneously. Spawns agents based on changed file patterns and produces a unified review summary.
+disable-model-invocation: true
 ---
 
 Run a multi-agent parallel review of: $ARGUMENTS
@@ -12,29 +13,23 @@ Run a multi-agent parallel review of: $ARGUMENTS
    - If a directory or file pattern is given, review those files
    - If no argument, review all uncommitted changes (`git diff HEAD`)
 
-2. Categorize changed files by domain to determine which agents to spawn:
+2. Categorize changed files by domain to determine which agents to spawn. File-pattern-to-agent routing follows `.dev-team/hooks/agent-patterns.json` — the same patterns used by the post-change-review and review-gate hooks. Read that file to map changed files to the appropriate specialist agents.
 
-| File pattern | Agent | Reason |
-|---|---|---|
-| `auth`, `login`, `password`, `token`, `session`, `crypto`, `encrypt`, `decrypt`, `secret`, `permission`, `rbac`, `acl`, `oauth`, `jwt`, `cors`, `csrf`, `sanitiz`, `escap` | @dev-team-szabo | Security surface |
-| `/api/`, `/route/`, `/routes/`, `/endpoint/`, `/endpoints/`, `schema`, `.graphql`, `.proto`, `openapi`, `swagger` | @dev-team-mori | API/UI contract |
-| `docker`, `Dockerfile`, `docker-compose`, `.dockerignore`, `.env.example`, `env.template`, `deploy`, `terraform/`, `.tf`, `.tfvars`, `pulumi/`, `cloudformation/`, `helm`, `k8s`, `kubernetes`, `health-check`, `healthcheck`, `monitoring.yml`, `monitoring.yaml`, `monitoring.json`, `observability`, `otel`, `alerting.yml`, `alerting.yaml`, `alerting.json`, `logging.yml`, `logging.yaml`, `logging.json`, `.github/workflows`, `.gitlab-ci`, `jenkinsfile` | @dev-team-hamilton | Infrastructure |
-| `.env`, `config`, `migration`, `database`, `.sql` | @dev-team-voss | Backend/data layer |
-| `.github/workflows`, `.claude/`, `tsconfig`, `eslint`, `prettier`, `jest.config`, `vitest`, `.husky`, `package.json` | @dev-team-deming | Tooling |
-| `readme`, `changelog`, `.md`, `.mdx`, `/docs/`, `api-doc`, `jsdoc`, `typedoc` | @dev-team-tufte | Documentation |
-| `/adr/`, `architecture`, `/modules/`, `/layers/`, `/core/`, `/domain/`, `/shared/`, `/lib/`, `/plugins/`, `/middleware/`, `tsconfig`, `webpack`, `vite`, `rollup`, `esbuild` | @dev-team-brooks | Architecture |
-| `package.json`, `pyproject.toml`, `cargo.toml`, `version`, `changelog`, `.npmrc`, `.npmignore`, `release.config`, `lerna.json`, release/publish/deploy workflows | @dev-team-conway | Release artifacts |
-| `/components/`, `/pages/`, `/views/`, `/layouts/`, `/ui/`, `.css`, `.scss`, `.sass`, `.less`, `.jsx`, `.tsx`, `tailwind`, `styled` | @dev-team-rams | Design system compliance |
-| `*.test.*`, `*.spec.*`, `__tests__/`, `/test/`, `/tests/` (code files only) | @dev-team-beck | Test quality |
-| Any `.js`, `.ts`, `.py`, `.go`, `.java`, `.rs` (non-test) | @dev-team-knuth | Quality/coverage |
-
-3. Always include @dev-team-szabo. For non-test code changes, also always include @dev-team-knuth and @dev-team-brooks; for test-only changes, ensure @dev-team-beck is included.
+3. **Always-on reviewers** (spawn regardless of file patterns):
+   - **@dev-team-szabo** — always included (security review)
+   - **@dev-team-knuth** — included for any non-test code changes (quality/coverage)
+   - **@dev-team-brooks** — included for any non-test code changes (architecture)
+   - **@dev-team-beck** — included for test-only changes (test quality)
 
 ## Pre-review validation
 
 Before spawning reviewers, verify the changes are reviewable:
 1. **Non-empty diff**: The diff contains actual changes to review. If empty, report "nothing to review" and stop.
 2. **Tests pass**: If the project has a test command, confirm tests pass. Flag test failures in the review report header.
+
+## Security preamble
+
+Before starting the review, check for open security alerts using the project's security monitoring process (e.g., a `/security-status` skill or CLAUDE.md guidance). If no such process or tooling is available, note this explicitly in the review report and proceed with a manual review of security-sensitive changes. Flag any critical findings in the review report.
 
 ## Execution
 
@@ -51,7 +46,7 @@ Before spawning reviewers, verify the changes are reviewable:
 ## Filter findings (judge pass)
 
 Before producing the report, filter raw findings to maximize signal quality:
-1. **Remove contradictions**: Drop findings that contradict existing ADRs (`docs/adr/`), learnings (`.dev-team/learnings.md`), or agent memory (`.dev-team/agent-memory/*/MEMORY.md`)
+1. **Remove contradictions**: Drop findings that contradict existing ADRs (`docs/adr/`), learnings (`.claude/rules/dev-team-learnings.md`), or agent memory (`.dev-team/agent-memory/*/MEMORY.md`)
 2. **Deduplicate**: When multiple agents flag the same issue, keep the most specific finding
 3. **Consolidate suggestions**: Group `[SUGGESTION]`-level items into a single summary block
 4. **Suppress generated file findings**: Skip findings on generated, vendored, or build artifacts
@@ -96,9 +91,9 @@ Original finding summary.
 
 State the verdict clearly. List what must be fixed for approval if requesting changes.
 
-### Security preamble
+### Platform detection
 
-Before starting the review, check for open security alerts using the project's security monitoring process (e.g., a `/security-status` skill or CLAUDE.md guidance). If no such process or tooling is available, note this explicitly in the review report and proceed with a manual review of security-sensitive changes. Flag any critical findings in the review report.
+Before issuing any `gh issue`, `gh pr`, or other platform-specific CLI commands, check `.dev-team/config.json` for the `platform` and `issueTracker` fields. If the project specifies a non-GitHub platform (e.g., `"gitlab"`, `"bitbucket"`, `"other"`), adapt issue tracker and PR commands accordingly — use `glab` for GitLab, the Bitbucket API, or the appropriate CLI for the configured platform. If `platform` is absent from config.json, default to `"github"`. The steps in this skill assume GitHub by default.
 
 ### Completion
 
@@ -109,8 +104,9 @@ After the review report is delivered:
    - **Generate calibration rules** when 3+ findings on the same tag are overruled
    - **Record metrics** to `.dev-team/metrics.md`
    - Write entries to each participating agent's MEMORY.md using the structured format
-   - Update shared learnings in `.dev-team/learnings.md`
+   - Update shared learnings in `.claude/rules/dev-team-learnings.md`
    - Check cross-agent coherence
 2. If Borges was not spawned, the review is INCOMPLETE.
-3. **Memory formation gate**: After Borges runs, verify that each participating reviewer's MEMORY.md contains at least one new structured entry from this review.
-4. Include Borges's recommendations in the final report.
+3. **Metrics completion gate**: Read `.dev-team/metrics.md` and verify that Borges has appended a new `Task: <reference>` entry for this review. The reference should match whatever identifier the review used (PR number, branch name, directory/pattern, or a label for uncommitted changes). A stale metrics file (no new entry) means Borges did not complete successfully. If metrics.md has no new entry after Borges reports completion, flag this as a system failure and re-run Borges with explicit instruction to record metrics for this review.
+4. **Memory formation gate**: After Borges runs, verify that each participating reviewer's MEMORY.md contains at least one new structured entry from this review.
+5. Include Borges's recommendations in the final report.

--- a/.dev-team/skills/dev-team-scorecard/SKILL.md
+++ b/.dev-team/skills/dev-team-scorecard/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: dev-team:scorecard
+description: Audit process conformance after a workflow completes (task, review, or audit). Checks Borges ran, findings acknowledged, metrics recorded, review executed, memory updated, and conditionally checks ADR written and issue closed.
+user_invocable: false
+---
+
+Audit process conformance for: $ARGUMENTS
+
+## Setup
+
+1. Determine the workflow to audit:
+   - If a PR number is given, use `gh pr view <number>` to get the branch, issue references, and merge status
+   - If a branch name is given, use `git log` to find the associated issue number from commit messages
+   - If an issue number is given, search for the PR that closes it
+   - If no argument, audit the most recent completed workflow (last merged PR or last entry in `.dev-team/metrics.md`)
+
+2. Detect the workflow type from the metrics entry or PR body:
+   - **task** — iterative task loop (`/dev-team:task`): implementation + review waves + convergence
+   - **review** — multi-agent review (`/dev-team:review`): review-only, no implementation phase
+   - **audit** — codebase audit (`/dev-team:audit`): parallel audit agents, no implementation phase
+
+3. Collect context:
+   - The issue number and PR number (if applicable)
+   - The branch name (if applicable)
+   - The workflow type detected above
+   - The list of agents that participated (from `.dev-team/metrics.md` entry or PR body)
+   - Whether a Brooks pre-assessment flagged an ADR requirement (task workflows only)
+
+4. Read `.claude/rules/dev-team-process.md` for project-specific process expectations (integration rules, release steps, review requirements). Use these to calibrate pass/fail thresholds.
+
+## Platform detection
+
+Before issuing any `gh issue`, `gh pr`, or other platform-specific CLI commands, check `.dev-team/config.json` for the `platform` and `issueTracker` fields. If the project specifies a non-GitHub platform (e.g., `"gitlab"`, `"bitbucket"`, `"other"`), adapt issue tracker and PR commands accordingly — use `glab` for GitLab, the Bitbucket API, or the appropriate CLI for the configured platform. The checks below assume GitHub by default.
+
+## Scorecard checks
+
+Run each check and record pass/fail with evidence.
+
+### 1. Borges ran
+
+**Check**: Read `.dev-team/metrics.md` and search for an entry matching the workflow's issue number, PR number, or branch name.
+
+- **Pass**: Entry exists with the workflow reference
+- **Fail**: No matching entry found
+
+### 2. All findings acknowledged
+
+**Check**: Read the metrics entry and/or PR conversation for the finding outcome log. Every classified finding (`[DEFECT]`, `[RISK]`, `[QUESTION]`, `[SUGGESTION]`) must have an explicit outcome: `fixed`, `accepted`, `deferred`, `overruled`, or `ignored`.
+
+- **Pass**: All findings have an explicit outcome
+- **Fail**: One or more findings have no recorded outcome (list them)
+
+### 3. Metrics recorded
+
+**Check**: The `.dev-team/metrics.md` entry includes calibration data: agents involved, findings per agent with classification, acceptance rate, and rounds to convergence.
+
+- **Pass**: Entry contains all required fields (Agents, Findings, Acceptance rate, Rounds)
+- **Fail**: Entry is missing required fields (list which ones)
+
+### 4. Review executed
+
+**Check**: The metrics entry shows at least one review round with classified findings from reviewer agents.
+
+- **Pass**: At least one review round with findings from 1+ reviewers
+- **Fail**: No review recorded, or findings section is empty
+
+### 5. Memory updated
+
+**Check**: For each agent listed as a participant in the metrics entry, read `.dev-team/agent-memory/<agent>/MEMORY.md` and verify it contains at least one entry dated on or after the workflow completion date, or referencing the workflow's issue/PR number.
+
+- **Pass**: All participating agents have a relevant memory entry
+- **Fail**: One or more agents have no memory entry from this workflow (list them)
+
+### 6. ADR written (conditional)
+
+**Applies to**: task workflows only. Skip for review and audit workflows.
+
+**Check**: If the PR body or commit messages mention "ADR" or "Write ADR-NNN", verify the corresponding file exists in `docs/adr/`.
+
+- **Pass**: ADR file exists, or no ADR was required
+- **Fail**: ADR was flagged as needed but the file does not exist
+- **Skip**: No ADR requirement detected, or workflow type is review/audit
+
+### 7. Issue closed (conditional)
+
+**Applies to**: task workflows only. Skip for review and audit workflows (which may not have an associated issue).
+
+**Check**: If an issue number is associated with the workflow, verify it is closed.
+
+- **Pass**: Issue state is "CLOSED"
+- **Fail**: Issue is still open
+- **Skip**: No issue associated, or workflow type is review/audit
+
+## Report
+
+Produce a structured scorecard:
+
+```
+## Process Scorecard: <issue/PR/workflow reference>
+**Workflow type**: task / review / audit
+
+| # | Check | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | Borges ran | PASS/FAIL | metrics.md entry found/missing |
+| 2 | Findings acknowledged | PASS/FAIL | N/N findings with outcomes |
+| 3 | Metrics recorded | PASS/FAIL | all fields present / missing: X, Y |
+| 4 | Review executed | PASS/FAIL | N rounds, N reviewers |
+| 5 | Memory updated | PASS/FAIL | N/N agents with entries |
+| 6 | ADR written | PASS/FAIL/SKIP | ADR-NNN exists / not required / not applicable |
+| 7 | Issue closed | PASS/FAIL/SKIP | issue #NNN state / not applicable |
+
+**Score: N/M** (skipped checks excluded from denominator)
+
+### Recommended fixes
+(Only if any checks failed — list specific actions to remediate each failure)
+```
+
+## Completion
+
+After the scorecard is delivered:
+1. If any checks failed, recommend specific remediation steps.
+2. If all checks passed, acknowledge clean process conformance.
+3. Do NOT spawn Borges — this is a read-only audit skill that does not produce findings requiring memory extraction.

--- a/.dev-team/skills/dev-team-task/SKILL.md
+++ b/.dev-team/skills/dev-team-task/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: dev-team:task
 description: Start an iterative task loop with adversarial review gates. Use when the user wants a task implemented with automatic quality convergence -- the loop continues until no [DEFECT] challenges remain or max iterations are reached.
+disable-model-invocation: true
 ---
 
 Start a task loop for: $ARGUMENTS
@@ -105,7 +106,11 @@ Track iterations in conversation context (no state files). For each iteration:
 8. If no `[DEFECT]` remains, output DONE to exit the loop.
 9. If max iterations reached without convergence, report remaining defects and exit.
 
+**Liveness invariant:** While any background agent is active, the orchestrator must not go more than 60 seconds without checking all active agents for progress. This applies regardless of what else the orchestrator is doing.
+
 The convergence check happens in conversation context: count iterations, check for `[DEFECT]` findings, and decide whether to continue or exit.
+
+**Integrate-as-you-go:** When orchestrating multiple issues, integrate completed work promptly rather than batching at the end. A stale working copy accumulates conflicts.
 
 ## Parallel mode
 
@@ -124,6 +129,10 @@ Issues in the same conflict group execute sequentially. Independent issues proce
 ### Phase 1: Parallel implementation
 Drucker spawns one implementing agent per independent issue, each on its own branch (`feat/<issue>-<description>`). Use the agent teammate naming convention: `{agent}-implement[-{qualifier}]` (e.g., `voss-implement`, `deming-implement-auth`, `tufte-implement-319`). Agents work concurrently without awareness of each other. Drucker tracks which issues are assigned to which agents and branches in conversation context.
 
+**Sequential chains:** For sequential chains, verify the previous change is integrated before starting the next dependent task. Do not start multiple sequential agents from the same stale baseline — this causes integration conflicts that negate the sequencing benefit.
+
+**Sequential chain gate:** When issues are sequenced due to file conflicts, verify the previous change is integrated into the shared codebase before starting the next dependent task. Do not spawn the next agent until integration is confirmed. This is a hard gate.
+
 ### Phase 2: Review wave
 Reviews do **not** start until **all** implementation agents have completed (Agent tool provides completion notifications as the sync barrier). Once all are done, spawn review agents using the naming convention `{agent}-review` (e.g., `szabo-review`, `knuth-review`, `brooks-review`) in parallel across all branches simultaneously. Each reviewer receives the diff for one specific branch and produces classified findings scoped to that branch.
 
@@ -134,12 +143,20 @@ Collect all findings across all branches. Route **all classified findings** — 
 Borges runs **once** across all branches after the final review wave clears. Pass Borges the **finding outcome log** (see Completion step 3 for format) covering all branches. This ensures cross-branch coherence: memory files are consistent, learnings are not duplicated, metrics are recorded, and system improvement recommendations consider the full batch.
 
 ### Phase 5: Merge
-After all PRs are created, merge each via the project's merge skill (e.g., `/merge`) — not raw `gh pr merge` or other git commands. The merge skill handles Copilot review monitoring, CI verification, and post-merge actions.
+After all PRs are created, merge each via the project's merge skill (e.g., `/merge`) — not raw `gh pr merge` or other git commands. The merge skill handles automated review monitoring, CI verification, and post-merge actions.
+
+**Integrate-as-you-go:** Integrate completed work promptly as agents finish. Do not batch all integrations at the end of a session. Each integration makes the next agent's baseline current, reducing rework.
+
+**Integrate-as-you-go:** Integrate completed work promptly as agents finish. Do not batch all integrations at the end of a session. Each integration makes the next agent's baseline current, reducing rework.
 
 ### Convergence criteria
 Parallel mode is complete when:
 1. All branches have zero `[DEFECT]` findings, OR the per-branch iteration limit (default: 10) is reached
 2. Borges has run across all branches
+
+## Platform detection
+
+Before issuing any `gh issue`, `gh pr`, or other platform-specific CLI commands, check `.dev-team/config.json` for the `platform` and `issueTracker` fields. If the project specifies a non-GitHub platform (e.g., `"gitlab"`, `"bitbucket"`, `"other"`), adapt issue tracker and PR commands accordingly — use `glab` for GitLab, the Bitbucket API, or the appropriate CLI for the configured platform. If `platform` is absent from config.json, default to `"github"`. The steps in this skill assume GitHub by default.
 
 ## Security preamble
 
@@ -148,9 +165,10 @@ Before starting work, check for open security alerts using the project's securit
 ## Completion
 
 When the loop exits:
-1. **Deliver the work**: If changes are on a feature branch, create the PR (body must include `Closes #<issue>`). Ensure the PR is ready to merge: CI green, reviews passed, branch up to date. **Use the project's merge skill (e.g., `/merge`) for every PR. Do not use raw `gh pr merge` — the merge skill handles Copilot review monitoring, CI verification, and post-merge actions.** If no merge skill exists, ensure the PR is mergeable and report readiness. If merge fails (CI failures, merge conflicts, branch protection), report the blocker to the human rather than leaving work unattended.
+1. **Deliver the work**: If changes are on a feature branch, create the PR. The PR body must include the platform's issue-closing keyword (e.g., `Closes #NNN` for GitHub, `Closes <PROJ>-NNN` for Jira/Linear — check `.dev-team/config.json` for `platform` and `issueTracker` settings). Ensure the PR is ready to merge: CI green, reviews passed, branch up to date. **Use the project's merge skill (e.g., `/merge`) for every PR. Do not use raw `gh pr merge` — the merge skill handles automated review monitoring, CI verification, and post-merge actions.** If no merge skill exists, ensure the PR is mergeable and report readiness. If merge fails (CI failures, merge conflicts, branch protection), report the blocker to the human rather than leaving work unattended.
 2. **Clean up worktree**: If the work was done in a worktree, clean it up after the branch is pushed and the PR is created. Do not wait for merge to clean the worktree.
-3. You MUST spawn **@dev-team-borges** as `borges-extract` (Librarian) as the final step. Format and pass Borges the **finding outcome log** using this structured format:
+3. **Automated review check:** After creating a PR, check for automated review findings from the platform's review bot (if configured). If findings exist, route actionable ones to the implementing agent for fixes before proceeding to Borges. This prevents findings from piling up until merge time.
+4. You MUST spawn **@dev-team-borges** as `borges-extract` (Librarian) as the final step. Format and pass Borges the **finding outcome log** using this structured format:
 
    **Single-branch format:**
    ```
@@ -204,14 +222,14 @@ When the loop exits:
    - **Generate calibration rules** when 3+ findings on the same tag are overruled
    - **Record metrics** to `.dev-team/metrics.md` (acceptance rates, rounds to convergence, per-agent stats)
    - Write entries to each participating agent's MEMORY.md using the structured format
-   - Update shared learnings in `.dev-team/learnings.md`
+   - Update shared learnings in `.claude/rules/dev-team-learnings.md`
    - Check cross-agent coherence
    - Report system improvement opportunities
-4. **Borges completion gate (HARD CHECK)**: Before emitting "Done", verify BOTH conditions:
+5. **Borges completion gate (HARD CHECK)**: Before emitting "Done", verify BOTH conditions:
    - (a) Borges has been spawned **and completed** (not just spawned — wait for completion)
-   - (b) `.dev-team/metrics.md` contains a new entry for this task
+   - (b) Read `.dev-team/metrics.md` and verify it contains a new `Task: <issue or PR reference>` entry for the current task. A stale metrics file (no new entry) means Borges did not complete successfully.
 
-   **If either check fails, the task is NOT complete.** Spawn Borges now and wait for completion. Do not emit "Done" or report task completion until both conditions are satisfied. This is a gate, not advisory — skipping it means the task loop has not finished.
-5. **Memory formation gate**: After Borges runs, verify that each participating agent's MEMORY.md contains at least one new structured entry from this task. Empty agent memory after a completed task is a system failure — Borges prevents this by automating extraction.
-6. Summarize what was accomplished across all iterations.
-7. Report any remaining `[RISK]` or `[SUGGESTION]` items, including Borges's recommendations.
+   **If either check fails, the task is NOT complete.** If metrics.md has no new entry after Borges reports completion, flag this as a system failure and re-run Borges with explicit instruction to record metrics. Do not emit "Done" or report task completion until both conditions are satisfied. This is a gate, not advisory — skipping it means the task loop has not finished.
+6. **Memory formation gate**: After Borges runs, verify that each participating agent's MEMORY.md contains at least one new structured entry from this task. Empty agent memory after a completed task is a system failure — Borges prevents this by automating extraction.
+7. Summarize what was accomplished across all iterations.
+8. Report any remaining `[RISK]` or `[SUGGESTION]` items, including Borges's recommendations.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Agents challenge each other using classified findings:
 - `[DEFECT]` blocks progress. `[RISK]`, `[QUESTION]`, `[SUGGESTION]` are advisory.
 - When agents disagree, they escalate to the human after one exchange each. Human decides.
 
-See `.dev-team/process.md` for orchestration protocol, parallel execution, and agent naming conventions.
+See `.claude/rules/dev-team-process.md` for orchestration protocol, parallel execution, and agent naming conventions.
 
 ### Hook directives are MANDATORY
 
@@ -98,7 +98,7 @@ Do NOT skip this. Do NOT treat hook output as optional. If you believe a review 
 
 > **Non-GitHub platforms:** Skills and hooks reference `gh` CLI commands for GitHub. If your project uses GitLab, Bitbucket, or another platform, adapt these commands accordingly. Set the `platform` field in `.dev-team/config.json` to `"gitlab"`, `"bitbucket"`, or `"other"`.
 
-> **Non-JS/TS projects:** File patterns in `agent-patterns.json` are optimized for JavaScript/TypeScript projects. For Python, Rust, Go, Java, or other ecosystems, you may need to extend these patterns to cover language-specific test conventions, build tools, and framework structures.
+> **Non-JS/TS projects:** Hooks detect the ecosystem and delegate language-specific reasoning to agents. File patterns in `agent-patterns.json` cover common conventions; agents apply their built-in knowledge for language-specific test naming, build tools, and framework structures beyond these patterns (see ADR-034).
 
 ### Project-specific customization
 
@@ -110,7 +110,10 @@ Project-specific customization belongs in `.claude/`:
 |------|-------|
 | Custom hooks (linting, workflow enforcement) | `.claude/hooks/` |
 | Project-specific skills (merge, deploy, etc.) | `.claude/skills/` |
+| Path-scoped instructions loaded automatically into agent context | `.claude/rules/` |
 | Claude Code settings and hook wiring | `.claude/settings.json` |
+
+Rules files (`.claude/rules/*.md`) are loaded automatically by all agents including subagents. Use them for project-specific behavioral context that should be shared across all agent sessions.
 
 `.claude/hooks/` and `.claude/skills/` are not overwritten by `dev-team update` — your project-specific customizations are safe. Only `.claude/settings.json` is merged additively (new product hooks are added, but user-added entries are never removed).
 
@@ -118,15 +121,15 @@ Project-specific customization belongs in `.claude/`:
 
 All project and process learnings MUST go to in-repo files, NOT to machine-local memory (`~/.claude/projects/`). Machine-local memory is invisible to other developers, agents, and sessions.
 
-**Tier 1 — Shared team memory** (`.dev-team/learnings.md`):
-Project facts, overruled challenges, cross-agent decisions, process rules. All agents read this at session start.
+**Tier 1 — Shared team memory** (`.claude/rules/dev-team-learnings.md`):
+Project facts, overruled challenges, cross-agent decisions, process rules. Loaded automatically by all agents via rules.
 
 **Tier 2 — Agent calibration memory** (`.dev-team/agent-memory/<agent>/MEMORY.md`):
 Domain-specific findings, known patterns, active watch lists. Each agent owns its own file. Entries include `Last-verified` dates for temporal decay.
 
 | What | Where |
 |------|-------|
-| Project patterns, process rules, tech debt, overruled challenges | `.dev-team/learnings.md` (Tier 1) |
+| Project patterns, process rules, tech debt, overruled challenges | `.claude/rules/dev-team-learnings.md` (Tier 1) |
 | Agent-specific calibration | `.dev-team/agent-memory/<agent>/MEMORY.md` (Tier 2) |
 | Formal architecture decisions | `docs/adr/` |
 | User-specific preferences only | Machine-local memory |
@@ -135,8 +138,9 @@ Domain-specific findings, known patterns, active watch lists. Each agent owns it
 
 **Temporal decay:** Entries have `Last-verified` dates. Borges flags entries not verified in 30+ days and archives entries over 90 days to the `## Archive` section.
 
-When the human gives feedback about process, coding style, or tool behavior: write it to `.dev-team/learnings.md`. Only use machine-local memory for things that are truly personal and would not apply to another developer on the same project.
+When the human gives feedback about process, coding style, or tool behavior: write it to `.claude/rules/dev-team-learnings.md`. Only use machine-local memory for things that are truly personal and would not apply to another developer on the same project.
 
 <!-- dev-team:end -->
+
 
 


### PR DESCRIPTION
## Summary
- `dev-team update` to sync local .dev-team/ with v1.7.0 templates
- Post-retro knowledge base fixes (0 DEFECT, 5 RISK, 5 SUGGESTION addressed)

### Retro fixes
- Delete orphan `.dev-team/agent-memory/deming/` directory
- Fix stale path references in 5 agent memory files (`.dev-team/learnings.md` → `.claude/rules/dev-team-learnings.md`)
- Add issue refs to remaining tech debt entries (#460, #461)
- Promote `process.exit` sentinel-throw pattern to shared learnings
- Merge duplicate Turing README entry
- Remove vestigial CLAUDE.md placeholder sections from template injection
- Add worktree isolation note to process.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>