### PR TITLE
feat: add parent-directory symlink traversal guards

### DIFF
--- a/src/files.ts
+++ b/src/files.ts
@@ -87,6 +87,7 @@ export function assertNoSymlinkInPath(absPath: string): void {
  */
 export function copyFile(src: string, dest: string): boolean {
   assertNotSymlink(src);
+  assertNoSymlinkInPath(src);
   assertNotSymlink(dest);
   assertNoSymlinkInPath(dest);
   const dir = path.dirname(dest);
@@ -146,6 +147,7 @@ export function readFile(absPath: string): string | null {
  * Writes content to a file, creating parent directories as needed.
  */
 export function writeFile(absPath: string, content: string): void {
+  assertNotSymlink(absPath);
   assertNoSymlinkInPath(absPath);
   const dir = path.dirname(absPath);
   fs.mkdirSync(dir, { recursive: true });

--- a/src/update.ts
+++ b/src/update.ts
@@ -113,6 +113,7 @@ export function cleanupLegacyMemoryDirs(devTeamDir: string): string[] {
     } else if (fileExists(legacyMemoryPath) && !fileExists(currentMemoryPath)) {
       // Move legacy content to current location
       assertNotSymlink(legacyMemoryPath);
+      assertNoSymlinkInPath(legacyMemoryPath);
       assertNotSymlink(currentMemoryPath);
       assertNoSymlinkInPath(currentMemoryPath);
       fs.mkdirSync(path.join(memoryDir, currentDir), { recursive: true });
@@ -174,6 +175,7 @@ function runMigrations(prefs: Preferences, fromVersion: string, devTeamDir: stri
         ) {
           try {
             assertNotSymlink(path.join(oldMemDir, "MEMORY.md"));
+            assertNoSymlinkInPath(path.join(oldMemDir, "MEMORY.md"));
             assertNotSymlink(path.join(newMemDir, "MEMORY.md"));
             assertNoSymlinkInPath(path.join(newMemDir, "MEMORY.md"));
             fs.mkdirSync(newMemDir, { recursive: true });
@@ -643,6 +645,7 @@ export async function update(targetDir: string): Promise<void> {
   const oldLearningsPath = path.join(devTeamDir, "learnings.md");
   if (fileExists(oldLearningsPath) && !fileExists(learningsDest)) {
     assertNotSymlink(oldLearningsPath);
+    assertNoSymlinkInPath(oldLearningsPath);
     assertNotSymlink(learningsDest);
     assertNoSymlinkInPath(learningsDest);
     fs.mkdirSync(rulesDir, { recursive: true });
@@ -660,6 +663,7 @@ export async function update(targetDir: string): Promise<void> {
   const oldProcessPath = path.join(devTeamDir, "process.md");
   if (fileExists(oldProcessPath) && !fileExists(processDest)) {
     assertNotSymlink(oldProcessPath);
+    assertNoSymlinkInPath(oldProcessPath);
     assertNotSymlink(processDest);
     assertNoSymlinkInPath(processDest);
     fs.mkdirSync(rulesDir, { recursive: true });


### PR DESCRIPTION
## Summary
- Adds `assertNoSymlinkInPath()` that walks up from target to filesystem root checking ancestors for symlinks
- Resolves system-level symlinks (e.g. /tmp -> /private/tmp on macOS) via realpathSync before checking
- Guards applied in copyFile(), writeFile(), and all renameSync paths in update.ts

Closes #459

## Test plan
- [ ] `npm test` passes
- [ ] Verify macOS system symlinks (/tmp, /var) don't cause false positives
- [ ] Confirm guard catches actual symlink traversal attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>