### PR TITLE
feat: ship worktree serialization hook to prevent parallel creation races

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -63,6 +63,28 @@
         ]
       }
     ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .dev-team/hooks/dev-team-worktree-create.js",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .dev-team/hooks/dev-team-worktree-remove.js",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
     "TaskCompleted": [
       {
         "hooks": [

--- a/.dev-team/hooks/dev-team-worktree-create.js
+++ b/.dev-team/hooks/dev-team-worktree-create.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+/**
+ * dev-team-worktree-create.js
+ * WorktreeCreate hook — serializes git worktree creation to prevent races.
+ *
+ * WORKAROUND for upstream Claude Code bugs:
+ *   - anthropics/claude-code#34645 — parallel git worktree add races on .git/config.lock
+ *   - anthropics/claude-code#39680 — EEXIST on .claude/worktrees/ directory
+ *
+ * When multiple agents spawn with isolation: "worktree" simultaneously,
+ * concurrent `git worktree add` commands race for .git/config.lock.
+ * This hook serializes creation using a lockfile so only one worktree
+ * is created at a time.
+ *
+ * Remove this hook when the upstream bugs are fixed.
+ *
+ * Input (argv[2] JSON): { base_path, worktree_name, branch_name }
+ * Output (stdout): absolute path to created worktree
+ * Exit 0 = success, non-zero = failure (stderr shown to user)
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || "{}");
+} catch {
+  process.stderr.write("[dev-team worktree-create] Failed to parse hook input\n");
+  process.exit(1);
+}
+
+const basePath = input.base_path || process.cwd();
+const worktreeName = input.worktree_name;
+const branchName = input.branch_name;
+
+if (!worktreeName) {
+  process.stderr.write("[dev-team worktree-create] Missing worktree_name\n");
+  process.exit(1);
+}
+
+const worktreesDir = path.join(basePath, ".claude", "worktrees");
+const worktreePath = path.join(worktreesDir, worktreeName);
+const lockFile = path.join(basePath, ".git", "worktree-create.lock");
+
+/**
+ * Acquire an exclusive lock using mkdir (atomic on all platforms).
+ * Retries with backoff up to ~10 seconds total.
+ */
+function acquireLock(lockPath, maxRetries = 20, baseDelayMs = 100) {
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      fs.mkdirSync(lockPath);
+      return true;
+    } catch (err) {
+      if (err.code !== "EEXIST") throw err;
+      // Check for stale lock (older than 60 seconds)
+      try {
+        const stat = fs.statSync(lockPath);
+        if (Date.now() - stat.mtimeMs > 60000) {
+          fs.rmdirSync(lockPath);
+          continue;
+        }
+      } catch {
+        // Lock disappeared between check and remove — retry
+        continue;
+      }
+      // Exponential backoff with jitter
+      const delay = baseDelayMs * Math.pow(1.5, i) + Math.random() * 50;
+      const start = Date.now();
+      while (Date.now() - start < delay) {
+        // busy-wait (no async in this sync hook)
+      }
+    }
+  }
+  return false;
+}
+
+function releaseLock(lockPath) {
+  try {
+    fs.rmdirSync(lockPath);
+  } catch {
+    // Best effort — stale lock will be cleaned up by timeout
+  }
+}
+
+try {
+  // Ensure worktrees directory exists (fixes anthropics/claude-code#39680)
+  fs.mkdirSync(worktreesDir, { recursive: true });
+
+  // Acquire lock to serialize worktree creation (fixes anthropics/claude-code#34645)
+  if (!acquireLock(lockFile)) {
+    process.stderr.write("[dev-team worktree-create] Timeout acquiring worktree creation lock\n");
+    process.exit(1);
+  }
+
+  try {
+    // Create the worktree (execFileSync avoids shell injection — inputs are from CC, not user)
+    const args = ["worktree", "add"];
+    if (branchName) {
+      args.push("-b", branchName);
+    }
+    args.push(worktreePath);
+    execFileSync("git", args, {
+      cwd: basePath,
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 30000,
+    });
+  } finally {
+    releaseLock(lockFile);
+  }
+
+  // Output the worktree path — this is what CC expects
+  process.stdout.write(worktreePath);
+  process.exit(0);
+} catch (err) {
+  releaseLock(lockFile);
+  process.stderr.write(`[dev-team worktree-create] ${err.message}\n`);
+  process.exit(1);
+}

--- a/.dev-team/hooks/dev-team-worktree-remove.js
+++ b/.dev-team/hooks/dev-team-worktree-remove.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+/**
+ * dev-team-worktree-remove.js
+ * WorktreeRemove hook — cleans up worktrees created by dev-team-worktree-create.js.
+ *
+ * Companion to dev-team-worktree-create.js. See that file for the upstream
+ * bugs this workaround addresses.
+ *
+ * Input (argv[2] JSON): { worktree_path }
+ * Exit 0 = success (failures are best-effort, logged but not fatal)
+ */
+
+"use strict";
+
+const { execFileSync } = require("child_process");
+
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || "{}");
+} catch {
+  process.stderr.write("[dev-team worktree-remove] Failed to parse hook input\n");
+  process.exit(0); // Non-fatal — CC handles cleanup fallback
+}
+
+const worktreePath = input.worktree_path;
+
+if (!worktreePath) {
+  process.stderr.write("[dev-team worktree-remove] Missing worktree_path\n");
+  process.exit(0);
+}
+
+try {
+  execFileSync("git", ["worktree", "remove", "--force", worktreePath], {
+    stdio: ["pipe", "pipe", "pipe"],
+    timeout: 15000,
+  });
+} catch (err) {
+  // Best effort — log but don't fail. CC will retry or the worktree
+  // will be cleaned up by `git worktree prune` eventually.
+  process.stderr.write(`[dev-team worktree-remove] ${err.message}\n`);
+}
+
+process.exit(0);

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -55,6 +55,8 @@ export function doctor(targetDir: string): void {
       "Pre-commit lint": "dev-team-pre-commit-lint.js",
       "Review gate": "dev-team-review-gate.js",
       "Agent teams guide": "dev-team-agent-teams-guide.js",
+      "Worktree create": "dev-team-worktree-create.js",
+      "Worktree remove": "dev-team-worktree-remove.js",
     };
     for (const label of prefs.hooks) {
       const fileName = hookFileMap[label];

--- a/src/init.ts
+++ b/src/init.ts
@@ -95,6 +95,21 @@ const ALL_AGENTS: AgentDefinition[] = [
   },
 ];
 
+// Infrastructure hooks — always installed, not user-selectable.
+// Workaround for upstream CC bugs (anthropics/claude-code#34645, #39680).
+const INFRA_HOOKS: HookDefinition[] = [
+  {
+    label: "Worktree create",
+    file: "dev-team-worktree-create.js",
+    description: "Serialize worktree creation to prevent git config.lock races",
+  },
+  {
+    label: "Worktree remove",
+    file: "dev-team-worktree-remove.js",
+    description: "Clean up worktrees created by the serialized create hook",
+  },
+];
+
 const QUALITY_HOOKS: HookDefinition[] = [
   {
     label: "TDD enforcement",
@@ -177,7 +192,7 @@ const PRESETS: Record<string, PresetDefinition> = {
   },
 };
 
-export { PRESETS, ALL_AGENTS, QUALITY_HOOKS };
+export { PRESETS, ALL_AGENTS, QUALITY_HOOKS, INFRA_HOOKS };
 
 /**
  * Main init flow.
@@ -360,6 +375,13 @@ export async function run(targetDir: string, flags: string[] = []): Promise<void
     hookCount++;
   }
 
+  // Copy infrastructure hooks (always installed)
+  for (const hook of INFRA_HOOKS) {
+    const src = path.join(templates, "hooks", hook.file);
+    const dest = path.join(hooksDir, hook.file);
+    copyFile(src, dest);
+  }
+
   // Copy shared hook support files (required by hooks at runtime)
   const hookLibSrc = path.join(templates, "hooks", "lib");
   if (dirExists(hookLibSrc)) {
@@ -382,11 +404,13 @@ export async function run(targetDir: string, flags: string[] = []): Promise<void
   }
   const settingsTemplate: HookSettings = JSON.parse(settingsContent);
 
-  // Filter settings to only include selected hooks
+  // Filter settings to only include selected hooks + infrastructure hooks
   const filteredSettings: HookSettings = { hooks: {} };
-  const selectedHookFiles = QUALITY_HOOKS.filter((h) => selectedHooks.includes(h.label)).map(
-    (h) => h.file,
-  );
+  const infraHookFiles = INFRA_HOOKS.map((h) => h.file);
+  const selectedHookFiles = [
+    ...infraHookFiles,
+    ...QUALITY_HOOKS.filter((h) => selectedHooks.includes(h.label)).map((h) => h.file),
+  ];
 
   for (const [event, entries] of Object.entries(settingsTemplate.hooks)) {
     const filteredEntries: HookMatcher[] = entries

--- a/src/update.ts
+++ b/src/update.ts
@@ -17,7 +17,7 @@ import {
 } from "./files.js";
 import type { HookSettings, HookMatcher } from "./files.js";
 import fs from "fs";
-import { ALL_AGENTS, QUALITY_HOOKS } from "./init.js";
+import { ALL_AGENTS, QUALITY_HOOKS, INFRA_HOOKS } from "./init.js";
 
 interface AgentRename {
   oldLabel: string;
@@ -238,7 +238,7 @@ const AGENT_FILES: Record<string, string> = Object.fromEntries(
 );
 
 const HOOK_FILES: Record<string, string> = Object.fromEntries(
-  QUALITY_HOOKS.map((h) => [h.label, h.file]),
+  [...QUALITY_HOOKS, ...INFRA_HOOKS].map((h) => [h.label, h.file]),
 );
 
 // Skills auto-discovered at runtime from templates/skills/

--- a/templates/hooks/dev-team-worktree-create.js
+++ b/templates/hooks/dev-team-worktree-create.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+/**
+ * dev-team-worktree-create.js
+ * WorktreeCreate hook — serializes git worktree creation to prevent races.
+ *
+ * WORKAROUND for upstream Claude Code bugs:
+ *   - anthropics/claude-code#34645 — parallel git worktree add races on .git/config.lock
+ *   - anthropics/claude-code#39680 — EEXIST on .claude/worktrees/ directory
+ *
+ * When multiple agents spawn with isolation: "worktree" simultaneously,
+ * concurrent `git worktree add` commands race for .git/config.lock.
+ * This hook serializes creation using a lockfile so only one worktree
+ * is created at a time.
+ *
+ * Remove this hook when the upstream bugs are fixed.
+ *
+ * Input (argv[2] JSON): { base_path, worktree_name, branch_name }
+ * Output (stdout): absolute path to created worktree
+ * Exit 0 = success, non-zero = failure (stderr shown to user)
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || "{}");
+} catch {
+  process.stderr.write("[dev-team worktree-create] Failed to parse hook input\n");
+  process.exit(1);
+}
+
+const basePath = input.base_path || process.cwd();
+const worktreeName = input.worktree_name;
+const branchName = input.branch_name;
+
+if (!worktreeName) {
+  process.stderr.write("[dev-team worktree-create] Missing worktree_name\n");
+  process.exit(1);
+}
+
+const worktreesDir = path.join(basePath, ".claude", "worktrees");
+const worktreePath = path.join(worktreesDir, worktreeName);
+const lockFile = path.join(basePath, ".git", "worktree-create.lock");
+
+/**
+ * Acquire an exclusive lock using mkdir (atomic on all platforms).
+ * Retries with backoff up to ~10 seconds total.
+ */
+function acquireLock(lockPath, maxRetries = 20, baseDelayMs = 100) {
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      fs.mkdirSync(lockPath);
+      return true;
+    } catch (err) {
+      if (err.code !== "EEXIST") throw err;
+      // Check for stale lock (older than 60 seconds)
+      try {
+        const stat = fs.statSync(lockPath);
+        if (Date.now() - stat.mtimeMs > 60000) {
+          fs.rmdirSync(lockPath);
+          continue;
+        }
+      } catch {
+        // Lock disappeared between check and remove — retry
+        continue;
+      }
+      // Exponential backoff with jitter
+      const delay = baseDelayMs * Math.pow(1.5, i) + Math.random() * 50;
+      const start = Date.now();
+      while (Date.now() - start < delay) {
+        // busy-wait (no async in this sync hook)
+      }
+    }
+  }
+  return false;
+}
+
+function releaseLock(lockPath) {
+  try {
+    fs.rmdirSync(lockPath);
+  } catch {
+    // Best effort — stale lock will be cleaned up by timeout
+  }
+}
+
+try {
+  // Ensure worktrees directory exists (fixes anthropics/claude-code#39680)
+  fs.mkdirSync(worktreesDir, { recursive: true });
+
+  // Acquire lock to serialize worktree creation (fixes anthropics/claude-code#34645)
+  if (!acquireLock(lockFile)) {
+    process.stderr.write("[dev-team worktree-create] Timeout acquiring worktree creation lock\n");
+    process.exit(1);
+  }
+
+  try {
+    // Create the worktree (execFileSync avoids shell injection — inputs are from CC, not user)
+    const args = ["worktree", "add"];
+    if (branchName) {
+      args.push("-b", branchName);
+    }
+    args.push(worktreePath);
+    execFileSync("git", args, {
+      cwd: basePath,
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 30000,
+    });
+  } finally {
+    releaseLock(lockFile);
+  }
+
+  // Output the worktree path — this is what CC expects
+  process.stdout.write(worktreePath);
+  process.exit(0);
+} catch (err) {
+  releaseLock(lockFile);
+  process.stderr.write(`[dev-team worktree-create] ${err.message}\n`);
+  process.exit(1);
+}

--- a/templates/hooks/dev-team-worktree-remove.js
+++ b/templates/hooks/dev-team-worktree-remove.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+/**
+ * dev-team-worktree-remove.js
+ * WorktreeRemove hook — cleans up worktrees created by dev-team-worktree-create.js.
+ *
+ * Companion to dev-team-worktree-create.js. See that file for the upstream
+ * bugs this workaround addresses.
+ *
+ * Input (argv[2] JSON): { worktree_path }
+ * Exit 0 = success (failures are best-effort, logged but not fatal)
+ */
+
+"use strict";
+
+const { execFileSync } = require("child_process");
+
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || "{}");
+} catch {
+  process.stderr.write("[dev-team worktree-remove] Failed to parse hook input\n");
+  process.exit(0); // Non-fatal — CC handles cleanup fallback
+}
+
+const worktreePath = input.worktree_path;
+
+if (!worktreePath) {
+  process.stderr.write("[dev-team worktree-remove] Missing worktree_path\n");
+  process.exit(0);
+}
+
+try {
+  execFileSync("git", ["worktree", "remove", "--force", worktreePath], {
+    stdio: ["pipe", "pipe", "pipe"],
+    timeout: 15000,
+  });
+} catch (err) {
+  // Best effort — log but don't fail. CC will retry or the worktree
+  // will be cleaned up by `git worktree prune` eventually.
+  process.stderr.write(`[dev-team worktree-remove] ${err.message}\n`);
+}
+
+process.exit(0);

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -47,6 +47,28 @@
         ]
       }
     ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .dev-team/hooks/dev-team-worktree-create.js",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .dev-team/hooks/dev-team-worktree-remove.js",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
     "TaskCompleted": [
       {
         "hooks": [

--- a/tests/scenarios/node-project.test.js
+++ b/tests/scenarios/node-project.test.js
@@ -57,7 +57,7 @@ describe("Node.js project scenario", () => {
 
     // Hooks installed in .dev-team/
     const hooks = fs.readdirSync(path.join(tmpDir, ".dev-team", "hooks"));
-    assert.equal(hooks.length, 10); // 8 hook files + lib/ directory + agent-patterns.json
+    assert.equal(hooks.length, 12); // 8 quality hooks + 2 infra hooks + lib/ directory + agent-patterns.json
 
     // Existing CLAUDE.md preserved
     const claudeMd = fs.readFileSync(path.join(tmpDir, "CLAUDE.md"), "utf-8");


### PR DESCRIPTION
## Summary
- WorktreeCreate hook serializes `git worktree add` using mkdir-based locking (atomic cross-platform)
- WorktreeRemove hook cleans up with `--force` (best-effort)
- Infrastructure hooks: always installed, not user-selectable
- Lock has 60s stale timeout, exponential backoff with jitter for contention
- Ensures `.claude/worktrees/` directory exists before creation (fixes EEXIST)

**Workaround for upstream Claude Code bugs** (remove when fixed):
- anthropics/claude-code#34645 — parallel `git worktree add` races on `.git/config.lock`
- anthropics/claude-code#39680 — `EEXIST` on `.claude/worktrees/` directory

Closes #468

## Test plan
- [x] `npm test` — 443 tests pass
- [x] Scenario test updated for new hook count (10 → 12)
- [ ] Manual test: spawn 3+ agents with `isolation: "worktree"` simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>