### PR TITLE
chore: post-v1.8.0 retro cleanup + Borges memory extraction

### DIFF
--- a/.claude/rules/dev-team-learnings.md
+++ b/.claude/rules/dev-team-learnings.md
@@ -16,20 +16,14 @@
 - **Verify platform behavior against official docs, not third-party sources.** Turing research #406 initially got rules inheritance wrong by relying on inferred behavior. Always check official Claude Code documentation for behavioral claims about rules, subagents, and agent teams.
 - **Agent teams sharing a working directory cause cross-branch contamination.** v1.7.0 delivery had repeated issues: agents switched branches under each other, stray commits landed on wrong branches (#447→#438, #436→#446, #440→#434), stashes went stale. Worktree isolation (one worktree per agent) prevents all of these. Prefer worktree-isolated agents for multi-branch parallel work.
 - **"Require up-to-date branches" protection creates merge cascades.** Each merge makes other PRs stale, requiring sequential rebase+push. GitHub merge queues would automate this. For now, factor this into time estimates for multi-PR batches.
+- **v1.8.0 delivered without `/dev-team:task` or agent reviews — process gap.** All 12 issues implemented directly by the orchestrator with Copilot as sole reviewer. No adversarial review loop. This bypassed the dogfooding requirement. Acceptable for hotfix-level urgency, but not for feature releases. The worktree serialization hooks (#482) and task skill decomposition (#481) shipped without in-team review.
 
 ## Design Principles
 
 - **Don't encode what agents already know.** AI agents have built-in knowledge of languages, frameworks, conventions, and standards. Hardcoding language-specific patterns (test file regex, linter commands, complexity keywords) into hooks or config creates static encyclopedias that are always incomplete. Instead, hooks should detect the ecosystem (read manifest files) and delegate language-specific reasoning to the agent. Include only what agents can't discover: tool preferences, legacy traps, test quirks, custom middleware warnings. (See: "AGENTS.md Verdict" — if the agent can discover it from code, delete it.)
 
 ## Known Tech Debt
-
-- ~~`readFile()` in `src/files.ts` masks permission errors (#460, fixed v1.8.0).~~ Resolved: now throws on EACCES/EPERM instead of returning null.
-- ~~`mergeClaudeMd` duplicate BEGIN markers (#461, fixed v1.8.0).~~ Resolved: missing END marker now replaces from BEGIN to EOF instead of appending.
-- ~~`doctor.ts` hookFileMap missing Agent teams guide hook (#431, fixed v1.6.1).~~ Resolved in PR #443.
-- ~~`status.ts` checks wrong learnings path after v1.6.0 migration (#432, fixed v1.6.1).~~ Resolved in PR #443.
-- ~~File operations (renameSync, copyFile) follow symlinks without lstat guards (#433, fixed v1.7.0).~~ Resolved: assertNotSymlink() guard added to files.ts, applied to copyFile + all renameSync calls in update.ts.
-- ~~User-controlled regex patterns lack complexity bounds — ReDoS risk (#434, fixed v1.7.0).~~ Resolved: safe-regex.js shared module validates user-supplied patterns (nested quantifiers, length bounds).
-- ~~Hook code duplication (#436, #437, fixed v1.7.0).~~ Resolved: cachedGitDiff extracted to lib/git-cache.js, fallback patterns removed (agents handle language-specific knowledge per ADR-034).
+<!-- All entries resolved as of v1.8.0. Add new entries here as they are discovered. -->
 
 ## Quality Benchmarks
 
@@ -37,7 +31,6 @@
 - Finding Outcome Log vocabulary is standardized: outcomes are `fixed`, `accepted`, `deferred`, `overruled`, `ignored`. All skills and agents must use this vocabulary.
 - Pre-commit gate: blocks commits without memory updates (override via `.dev-team/.memory-reviewed`).
 - **Migration completeness**: Any change that moves/renames files must audit all modules that reference those paths. doctor.ts, status.ts, and skill definitions are recurring victims of path drift (3 instances across v1.5.0–v1.6.0).
-- **Retro must verify tech debt staleness.** v1.7.0 found 5 of 7 tech debt entries were already resolved. Retro skill should cross-check Known Tech Debt against recent PRs before reporting (#456).
 - **process.exit stubs must throw a sentinel error.** When testing functions that call `process.exit()`, a no-op stub lets execution continue past the exit point, causing false passes. Use a throw-sentinel pattern (e.g., `throw new Error('__EXIT__')`). Independently confirmed by Szabo, Knuth, and Brooks in v1.7.0 review.
 
 ## Overruled Challenges

--- a/.dev-team/agent-memory/dev-team-beck/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-beck/MEMORY.md
@@ -24,7 +24,7 @@
 - **Source**: package.json analysis
 - **Tags**: testing, ci
 - **Outcome**: verified
-- **Last-verified**: 2026-03-25
+- **Last-verified**: 2026-03-29
 - **Context**: New test files must be added to the explicit list in package.json scripts.test. CI runs tests cross-platform (ubuntu, macos, windows) with Node 22.
 
 ### [2026-03-25] TDD enforced via hook — dev-team-tdd-enforce.js
@@ -50,6 +50,14 @@
 - **Outcome**: fixed
 - **Last-verified**: 2026-03-27
 - **Context**: Three core modules had zero test coverage. Tests added using the sentinel-throw pattern for process.exit stubs. Key finding: process.exit stub must throw to halt execution — a no-op stub lets code continue past the exit point, causing crashes. This pattern is now established for all exit-testing.
+
+### [2026-03-29] v1.8.0: 18 tests for security-critical functions (#480)
+- **Type**: DECISION [new]
+- **Source**: #480, PR #480
+- **Tags**: testing, security, symlink, regex, coverage
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-29
+- **Context**: assertNotSymlink, assertNoSymlinkInPath, and safeRegex each got dedicated test suites. Tests cover: leaf rejection, ancestor traversal, realpathSync tradeoff behavior, nested quantifier patterns, length bounds. Uses the sentinel-throw pattern for process.exit. Tightened existing test assertions (#474) to reduce false positive risk — narrower assertions catch regressions that broad ones miss.
 
 ## Framework and Runner Notes
 

--- a/.dev-team/agent-memory/dev-team-borges/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-borges/MEMORY.md
@@ -90,3 +90,11 @@
 - **Outcome**: verified
 - **Last-verified**: 2026-03-27
 - **Context**: All 12 audit-derived tech debt issues resolved. 11 raw findings (7 unique after dedup), 100% acceptance, 1 round. First in-team review wave (Szabo+Knuth+Brooks) since v1.2.0. 3 agents converged independently on the same process.exit stub finding — strong cross-agent coherence signal. New entries: Szabo (2), Knuth (2), Brooks (2), Beck (1), Voss (1), Tufte (1), Turing (1), Deming already had entries from implementation. Updated 3 existing entries (Szabo symlink+ReDoS fixed, Knuth test coverage fixed). 3 tech debt items marked resolved in shared learnings. 3 new process learnings added (working dir contention, merge cascades, retro staleness). Stale `deming/` memory dir flagged and fixed (finding #5). System improvement: agent teams need worktree isolation (#456 tracked).
+
+### [2026-03-29] v1.8.0 post-hoc extraction — 12 issues, 12 PRs, Copilot-only review
+- **Type**: MILESTONE [verified]
+- **Source**: v1.8.0 task loop (12 issues, 12 PRs #470-#483)
+- **Tags**: metrics, calibration, extraction, process-gap
+- **Outcome**: verified
+- **Last-verified**: 2026-03-29
+- **Context**: Post-hoc extraction — Borges was not spawned during delivery. v1.8.0 bypassed `/dev-team:task` and agent reviews entirely. ~30 Copilot findings, all addressed. No formal DEFECTs. New entries written: Szabo (1 new + 1 updated), Knuth (2), Brooks (2), Deming (2), Beck (1), Conway (1), Voss (1). Process learning added to shared learnings (process gap). Key architectural changes: INFRA_HOOKS separation, task skill 4-step decomposition, assertNoSymlinkInPath ancestor guard. System improvement identified: v1.8.0 process gap confirms that bypassing the adversarial loop should be reserved for hotfixes, not feature releases.

--- a/.dev-team/agent-memory/dev-team-brooks/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-brooks/MEMORY.md
@@ -85,5 +85,21 @@
 - **Last-verified**: 2026-03-27
 - **Context**: Chain A hardcoded a single lib file copy in update.ts. Chain B replaced this with recursive lib/ directory copy. Accepted as the merge ordering naturally resolved this — no architectural debt remaining.
 
+### [2026-03-29] v1.8.0: INFRA_HOOKS array — infrastructure vs quality hook separation
+- **Type**: DECISION [new]
+- **Source**: #482, PR #482
+- **Tags**: architecture, hooks, init, infrastructure
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-29
+- **Context**: init.ts now separates INFRA_HOOKS (always installed, not user-selectable) from QUALITY_HOOKS (opt-in). WorktreeCreate/WorktreeRemove are infrastructure hooks — they serialize worktree creation to work around Claude Code bugs (#34645, #39680). This is a TEMPORARY architectural pattern; remove when upstream fixes land. Brooks should watch for INFRA_HOOKS growth — infrastructure hooks bypass user choice.
+
+### [2026-03-29] v1.8.0: Task skill 4-step decomposition (Implement, Review, Merge, Extract)
+- **Type**: DECISION [new]
+- **Source**: #481, PR #481
+- **Tags**: architecture, skills, task, orchestration
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-29
+- **Context**: Task skill decomposed into 4 explicit steps with shared definitions between single-issue and parallel modes. Both modes reference the same step definitions — prevents drift. Review step changed from batched waves to per-PR-as-it-lands. This is an architectural boundary: step definitions are the contract between task orchestration and agent execution.
+
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->

--- a/.dev-team/agent-memory/dev-team-conway/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-conway/MEMORY.md
@@ -107,5 +107,13 @@
 - **Last-verified**: 2026-03-27
 - **Context**: Milestone 24 (v1.7.0) closed with 11 closed / 2 open issues. The task listed 12 issues but only 11 were closed in the milestone at release time. Always verify milestone completion counts match the release brief.
 
+### [2026-03-29] v1.8.0: INFRA_HOOKS requires init.ts awareness in release testing
+- **Type**: PATTERN [new]
+- **Source**: #482, PR #482
+- **Tags**: release, init, hooks, infrastructure
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-29
+- **Context**: v1.8.0 introduced INFRA_HOOKS (always-installed, non-optional). Release testing must now verify: (1) fresh install includes infra hooks, (2) update adds infra hooks to existing projects, (3) infra hooks don't appear in user-selectable lists. This is a new install surface to validate.
+
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->

--- a/.dev-team/agent-memory/dev-team-deming/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-deming/MEMORY.md
@@ -16,7 +16,7 @@
 - **Source**: templates/hooks/ analysis
 - **Tags**: hooks, enforcement, dx
 - **Outcome**: verified
-- **Last-verified**: 2026-03-26
+- **Last-verified**: 2026-03-29
 - **Context**: dev-team-tdd-enforce.js (TDD), dev-team-safety-guard.js (safety), dev-team-post-change-review.js (review spawning), dev-team-pre-commit-lint.js (lint), dev-team-pre-commit-gate.js (blocking gate), dev-team-watch-list.js (file watch triggers). ADR-001: hooks over CLAUDE.md for enforcement.
 
 ### [2026-03-25] Agent and hook validation scripts run in CI
@@ -133,6 +133,22 @@
 - **Outcome**: fixed
 - **Last-verified**: 2026-03-27
 - **Context**: User-controlled regex from config.json (watchLists[].pattern, taskBranchPattern) was compiled without validation. Created `templates/hooks/lib/safe-regex.js` — checks for nested quantifiers and quantified backreferences, rejects patterns >1024 chars. Applied to dev-team-watch-list.js and dev-team-pre-commit-gate.js. agent-patterns.js left unchanged — it reads developer-authored agent-patterns.json (different trust boundary). Pattern: hooks should validate at system boundaries (user config) but can trust shipped data files.
+
+### [2026-03-29] v1.8.0: Worktree serialization hooks — temporary infrastructure workaround
+- **Type**: DECISION [new]
+- **Source**: #482, PR #482
+- **Tags**: hooks, worktrees, infrastructure, temporary
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-29
+- **Context**: WorktreeCreate/WorktreeRemove hooks use mkdir-based locking to serialize worktree creation (workaround for anthropics/claude-code#34645 and #39680). Classified as INFRA_HOOKS — always installed, not user-selectable. TEMPORARY: remove when upstream fixes land. Hooks are JS, no dependencies, cross-platform. Lock dir: `.dev-team/.worktree-lock`.
+
+### [2026-03-29] v1.8.0: Retro skill verifies tech debt against issue tracker (#473)
+- **Type**: DECISION [new]
+- **Source**: #456, PR #473
+- **Tags**: retro, tech-debt, staleness, dx
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-29
+- **Context**: Retro skill Phase 2 now cross-checks Known Tech Debt entries against closed issues/PRs before reporting. Addresses the v1.7.0 finding where 5 of 7 tech debt entries were already resolved. Platform-agnostic — uses config.platform to determine CLI tool.
 
 ### [2026-03-26] Audit baseline: 14 findings (0 DEFECT, 1 RISK, 1 QUESTION, 12 SUGGESTION)
 - **Type**: CALIBRATION

--- a/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
@@ -11,13 +11,21 @@
 - **Last-verified**: 2026-03-26
 - **Context**: No c8, istanbul, or similar coverage tool in devDependencies or scripts. Coverage gaps must be identified by code review, not metrics.
 
-### [2026-03-25] mergeClaudeMd append-on-missing-END-marker duplicate BEGIN edge case
-- **Type**: RISK [verified]
-- **Source**: .claude/rules/dev-team-learnings.md (known tech debt)
+### [2026-03-29] mergeClaudeMd duplicate BEGIN — FIXED in v1.8.0
+- **Type**: RISK [fixed]
+- **Source**: #461, PR #479
 - **Tags**: boundary-condition, merge-logic
-- **Outcome**: verified
-- **Last-verified**: 2026-03-25
-- **Context**: Known edge case where subsequent runs can produce duplicate BEGIN markers if END marker is missing. Tracked in shared learnings.
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-29
+- **Context**: Missing END marker now triggers replace-from-BEGIN-to-EOF instead of append. Also fixed END-before-BEGIN edge case by searching for END only after BEGIN position. Two distinct boundary conditions fixed in same PR.
+
+### [2026-03-29] v1.8.0: 18 new tests added — assertNotSymlink, assertNoSymlinkInPath, safeRegex
+- **Type**: PATTERN [new]
+- **Source**: #480, PR #480
+- **Tags**: testing, coverage, symlink, regex
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-29
+- **Context**: Test coverage expanded for security-critical functions. Tests cover: leaf symlink rejection, ancestor symlink traversal, realpathSync design tradeoff, safeRegex nested quantifier rejection. Follows sentinel-throw pattern established in v1.7.0.
 
 ## Recurring Boundary Conditions
 

--- a/.dev-team/agent-memory/dev-team-szabo/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-szabo/MEMORY.md
@@ -11,20 +11,28 @@
 - **Last-verified**: 2026-03-26
 - **Context**: dev-team is a CLI installer that copies template files into target projects. No authentication system, no user data handling, no database, no HTTP server. Primary security concern is file system operations and template injection.
 
-### [2026-03-25] readFile() returns null for both missing and permission-denied files
-- **Type**: RISK [verified]
-- **Source**: .claude/rules/dev-team-learnings.md (known tech debt)
-- **Tags**: error-handling, file-system, tech-debt
-- **Outcome**: verified
-- **Last-verified**: 2026-03-26
-- **Context**: src/files.ts readFile distinguishes ENOENT (missing file) from EACCES/EPERM (permission errors) and logs a warning on permission issues, but still returns null in both cases, which can mask security-relevant permission errors in target project file operations.
+### [2026-03-29] assertNoSymlinkInPath() — ancestor directory traversal guard
+- **Type**: PATTERN [new]
+- **Source**: #475, PR #475
+- **Tags**: symlink, path-traversal, file-system, security, defense-in-depth
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-29
+- **Context**: Extends assertNotSymlink (leaf check) with ancestor-directory traversal. Walks from target to root checking each ancestor with lstatSync. Design tradeoff: realpathSync resolves system-level symlinks first, which can resolve away attacker symlinks at the deepest level — documented and accepted. Applied in update.ts and init.ts file operations.
+
+### [2026-03-29] readFile() permission error masking — FIXED in v1.8.0
+- **Type**: RISK [fixed]
+- **Source**: #460, PR #478
+- **Tags**: error-handling, file-system
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-29
+- **Context**: readFile() now throws on any error other than ENOENT. EACCES/EPERM no longer silently return null.
 
 ### [2026-03-25] Hook scripts execute in target project context
 - **Type**: PATTERN [verified]
 - **Source**: templates/hooks/ analysis
 - **Tags**: code-execution, hooks, trust-boundary
 - **Outcome**: verified
-- **Last-verified**: 2026-03-26
+- **Last-verified**: 2026-03-29
 - **Context**: Hooks shipped as plain JS run in the target project's environment. They spawn subprocesses and read/write files. Any command injection in hook logic would execute with the user's permissions.
 
 ## Known Attack Surfaces
@@ -41,9 +49,9 @@
 - **Type**: RISK [fixed]
 - **Source**: Codebase audit (S3/S4), Issue #433, PR #454
 - **Tags**: symlink, path-traversal, file-system, security
-- **Outcome**: fixed — assertNotSymlink() guard added
-- **Last-verified**: 2026-03-27
-- **Context**: Fixed: assertNotSymlink() in files.ts uses lstatSync to reject symlinks before file operations. Applied to copyFile (guards both src and dest) and all renameSync calls in update.ts. Residual TOCTOU gap accepted as inherent to POSIX.
+- **Outcome**: fixed — assertNotSymlink() + assertNoSymlinkInPath() guards added
+- **Last-verified**: 2026-03-29
+- **Context**: Fixed in two waves: v1.7.0 added assertNotSymlink() leaf check (lstatSync on target). v1.8.0 added assertNoSymlinkInPath() ancestor traversal (walks parent dirs to root). Both applied to copyFile and renameSync calls. Residual TOCTOU gap accepted as inherent to POSIX.
 
 
 ## Calibration Log

--- a/.dev-team/agent-memory/dev-team-voss/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-voss/MEMORY.md
@@ -61,5 +61,13 @@
 - **Last-verified**: 2026-03-27
 - **Context**: ~30 lines of identical symlink creation with Windows junction fallback existed in both init.ts and update.ts. Extracted to ensureSymlink() in files.ts. ensureSymlink intentionally creates symlinks and was NOT guarded by assertNotSymlink. Removed unused fs import from init.ts.
 
+### [2026-03-29] v1.8.0: assertNoSymlinkInPath — ancestor directory traversal
+- **Type**: PATTERN [new]
+- **Source**: #475, PR #475
+- **Tags**: security, symlink, file-operations, defense-in-depth
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-29
+- **Context**: Extends the v1.7.0 assertNotSymlink leaf check. Walks from target to root checking each ancestor directory with lstatSync. realpathSync resolves system-level symlinks before the walk — design tradeoff documented (can resolve away attacker symlinks at deepest level). Applied alongside assertNotSymlink in file operation guards.
+
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->

--- a/.dev-team/config.json
+++ b/.dev-team/config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "platform": "github",
   "agents": [
     "Voss",
@@ -25,7 +25,9 @@
     "Watch list",
     "Pre-commit lint",
     "Agent teams guide",
-    "Review gate"
+    "Review gate",
+    "Worktree create",
+    "Worktree remove"
   ],
   "agentTeams": true
 }

--- a/.dev-team/metrics.md
+++ b/.dev-team/metrics.md
@@ -106,3 +106,16 @@
 - **Duration**: single session, 7 PRs (#449-#455)
 - **Notes**: First formal review wave with in-team agents since v1.2.0 (v1.5.0-v1.6.0 used Copilot-only). 12 issues addressed (10 closed via PRs, 2 moved to v1.8.0), all audit-derived tech debt from v1.6.0. Key themes: symlink hardening (Szabo), path correctness (Knuth — 4th instance), process.exit stub pattern (cross-agent convergence by Szabo+Knuth+Brooks on same finding). Operational issue: agent teams sharing working directory caused cross-branch contamination — 3 stray commits on wrong branches, 1 agent re-spawn needed. Worktree isolation recommended for future multi-branch work.
 
+### [2026-03-29] Task: v1.8.0 delivery (#447, #456, #457, #458, #459, #460, #461, #462, #465, #466, #467, #468)
+- **Agents**: implementing: orchestrator (direct), reviewers: Copilot
+- **Rounds**: 1 per branch
+- **Findings**:
+  - Copilot: ~30 inline findings across 12 PRs (all fixed or acknowledged)
+  - dev-team agents: 0 (not spawned — process gap)
+- **Acceptance rate**: 100% (all Copilot findings addressed)
+- **Overrule rate**: 0%
+- **Fix rate (DEFECTs)**: N/A (0 formal DEFECTs)
+- **Defer rate (advisory)**: 0%
+- **Duration**: single session, 12 PRs (#470-#483)
+- **Notes**: v1.8.0 delivered without `/dev-team:task` or dev-team agent reviews. All implementation by orchestrator directly. Copilot was sole reviewer. ~30 Copilot findings across 12 PRs, all addressed. Key PRs with substantive findings: #475 (8 findings on symlink guards — 5 fixed, 3 acknowledged), #479 (mergeClaudeMd edge case), #478 (readFile docstring). Process gap: no adversarial review loop, no Borges extraction during delivery. This post-hoc extraction fills the memory gap. Key deliverables: worktree serialization hooks (INFRA_HOOKS), task skill 4-step decomposition, assertNoSymlinkInPath, readFile error hardening, mergeClaudeMd boundary fix, 18 new tests.
+

--- a/.dev-team/skills/dev-team-retro/SKILL.md
+++ b/.dev-team/skills/dev-team-retro/SKILL.md
@@ -37,6 +37,30 @@ Check for:
 - Entries contradicted by current code (e.g., "We use Express" when the codebase uses Fastify)
 - Date-stamped entries older than 6 months without recent revalidation
 
+### Tech debt verification
+
+Cross-check the **Known Tech Debt** section against the issue tracker and release history to remove stale entries:
+
+1. **Closed-issue check**: For each tech debt entry that references an issue number (e.g., `#433`), check the issue tracker to see if the issue is closed (strip the `#` prefix when querying). If the issue is closed, the entry is likely stale — flag as:
+   ```
+   **[DEFECT]** Learnings — Stale tech debt entry: "<entry summary>" references #<number> which is closed.
+   Concrete impact: developers waste time investigating already-resolved debt.
+   Suggested fix: remove the entry or mark it as resolved with a strikethrough.
+   ```
+
+2. **Released-version check**: For each entry that references a target version (e.g., `v1.8.0`), check if that version has been released by running `git tag --list 'v*'` and comparing. If the version tag exists, the fix should have shipped — verify and flag as:
+   ```
+   **[DEFECT]** Learnings — Tech debt entry targets released version: "<entry summary>" targets <version> which has been released.
+   Concrete impact: entry may describe already-resolved debt, creating confusion about actual outstanding work.
+   Suggested fix: verify the fix shipped in that release, then remove or strikethrough the entry.
+   ```
+
+3. **Untracked debt check**: For each tech debt entry that does NOT reference an issue number, flag as:
+   ```
+   **[RISK]** Learnings — Untracked tech debt: "<entry summary>" has no issue reference.
+   Why this matters: tech debt without a tracking issue tends to be forgotten. It cannot be prioritized, assigned, or verified.
+   ```
+
 ### Contradictions
 - Entries that contradict each other (e.g., one says "always use snake_case" and another says "we adopted camelCase")
 - Entries that contradict the project's `CLAUDE.md` instructions

--- a/.dev-team/skills/merge/SKILL.md
+++ b/.dev-team/skills/merge/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: merge
+description: Merge a PR with monitoring -- checks Copilot comments, sets auto-merge, monitors until complete, triggers next steps.
+user_invocable: true
+---
+
+Merge a pull request with full monitoring: $ARGUMENTS
+
+## Release PRs
+
+**Release PRs MUST use this merge skill.** Release PRs (version bumps, changelog updates, release branches) require the same Copilot review handling and CI verification as any other PR — do not bypass this process for releases. When merging a release PR, pay extra attention to:
+- Changelog completeness (all PRs since last release are documented)
+- Version bump correctness (semver compliance)
+- No draft or WIP markers left in release notes
+
+## Setup
+
+1. Determine the PR number:
+   - If provided as argument, use it directly
+   - Otherwise, detect from current branch: `gh pr view --json number --jq .number`
+   - If no PR found, report error and stop
+
+2. Capture repo context:
+   - `gh repo view --json nameWithOwner --jq .nameWithOwner` to get {owner}/{repo}
+
+## Step 1: Wait for and address Copilot review
+
+Before proceeding with merge, **wait for Copilot review to complete** using multi-signal detection (check run, requested reviewers, and submitted reviews).
+
+### 1a. Wait for Copilot review via multi-signal detection
+
+Copilot can appear as a check run, a requested reviewer, or both. Detect all signals before deciding how to wait.
+
+Get the HEAD commit SHA for the PR, then probe all three signals sequentially:
+
+```bash
+# Get the PR's HEAD commit SHA
+PR_SHA=$(gh pr view {number} --json headRefOid --jq .headRefOid)
+
+# Signal 1: Check runs API
+gh api repos/{owner}/{repo}/commits/${PR_SHA}/check-runs \
+  --jq '.check_runs[] | select(.app.slug == "copilot-pull-request-reviewer" or .name == "Copilot") | {name, status, conclusion}'
+
+# Signal 2: Requested reviewers API (Copilot pending as reviewer)
+gh api repos/{owner}/{repo}/pulls/{number}/requested_reviewers \
+  --jq '[.users[] | select(.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$"))] | length'
+
+# Signal 3: Reviews API (Copilot already submitted a review — terminal states only)
+gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews \
+  --jq '[.[] | select((.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$")) and (.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "COMMENTED"))] | length'
+```
+
+**Decision logic (evaluate in order):**
+
+1. **If a Copilot check run exists AND status is `queued` or `in_progress`:** poll the check-runs API every 15 seconds until `completed` (max 12 polls, ~3 minutes). If after the final (12th) poll the status is still `queued` or `in_progress`, **treat this as a timeout**: surface a clear error, do **not** proceed to comment reading or merge, and stop the workflow without setting auto-merge.
+   - Once status is `completed` within the polling limit: proceed to 1a-read below.
+
+2. **If Copilot is in requested_reviewers (Signal 2 count > 0):** Copilot has been requested but hasn't submitted a review yet. Poll the reviews API every 15 seconds until a review from Copilot appears with state `APPROVED`, `CHANGES_REQUESTED`, or `COMMENTED` (max 12 polls, ~3 minutes):
+   ```bash
+   gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews \
+     --jq '[.[] | select((.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$")) and (.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "COMMENTED"))] | length'
+   ```
+   - If a completed review appears within the polling limit: proceed to 1a-read below.
+   - If after the final (12th) poll no completed review exists, **treat this as a timeout**: surface a clear error, do **not** proceed to comment reading or merge, and stop the workflow without setting auto-merge.
+
+3. **If Copilot already submitted a review (Signal 3 count > 0, but not in requested_reviewers and no check run):** review is already done. Proceed directly to 1a-read below.
+
+4. **If none of the three signals detect Copilot:** fall back to a single 30-second wait, then check comments once. This maintains backward compatibility for repos without Copilot configured.
+
+- Do NOT set auto-merge before this step completes.
+
+### 1a-read. Read Copilot comments
+
+Once the check run is completed (or after the fallback wait), read comments once:
+
+```bash
+# Inline review comments (check both Copilot logins)
+gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments --jq '[.[] | select(.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$"))] | length'
+
+# Summary reviews (check both Copilot logins)
+gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews --jq '[.[] | select(.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$"))] | length'
+```
+
+- If either count > 0: Copilot review has findings, proceed to 1b
+- If both counts == 0: no Copilot comments were detected. If a Copilot check run was observed and completed, treat this as a clean review; if no Copilot check run exists, this likely means Copilot review is not configured or did not run. Then proceed to Step 2.
+- Use `--paginate` on all API calls to avoid missing results on PRs with many comments
+
+### 1b. Address Copilot findings
+
+```bash
+# Inline comments (include node_id for thread resolution, check both Copilot logins)
+gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | select(.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$")) | {id: .id, node_id: .node_id, path: .path, line: .line, body: .body}'
+
+# Summary reviews (check both Copilot logins)
+gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews --jq '.[] | select(.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$")) | {id: .id, state: .state, body: .body}'
+```
+
+For each Copilot comment:
+1. Read the finding and assess: is it actionable?
+2. **Actionable** (bug, ambiguity, missing logic): fix in code, commit, push
+3. **Style/minor**: acknowledge but skip if not substantive
+4. **Reply to the Copilot thread** explaining what was fixed (or why it was skipped). Use the inline comment reply API:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies -f body="Fixed: <brief explanation of the change>"
+   ```
+   Note: GitHub's API does not support programmatically resolving review threads. The `minimizeComment` mutation only hides comments (collapses them), it does not mark threads as resolved. Threads must be resolved manually in the GitHub UI, or will be resolved when the PR is merged. Replying with the fix explanation is sufficient.
+   To get the `node_id` for a comment, include it in the initial fetch (already updated above).
+5. **Deferred findings must be tracked.** For findings acknowledged but NOT fixed (style/minor skips, intentional deferrals, or "won't fix" decisions):
+   - Create a GitHub issue to track the deferred finding:
+     ```bash
+     gh issue create \
+       --title "Deferred Copilot finding: <short description>" \
+       --body "$(cat <<'EOF'
+     ## Copilot Finding
+
+     **PR:** #{number}
+     **File:** {path}
+     **Line:** {line}
+
+     ### Finding
+     {copilot_comment_body}
+
+     ### Reason for deferral
+     {explanation of why it was not fixed in this PR}
+
+     ---
+     *Auto-created by merge skill from Copilot review on PR #{number}.*
+     EOF
+     )"
+     ```
+   - Reply to the Copilot thread with the tracking issue number:
+     ```bash
+     gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies \
+       -f body="Tracked in #NNN — deferred: <brief reason>"
+     ```
+6. **Validation gate before merge.** Before proceeding to Step 2 (auto-merge), verify that every Copilot inline comment has been addressed with one of:
+   - A code fix (reply mentioning "Fixed:")
+   - A tracking issue (reply mentioning "Tracked in #NNN")
+
+   Empty acknowledgments, bare "acknowledged" replies, or comments without either a fix or an issue number are **not valid**. If any comment lacks proper resolution, go back and either fix it or create a tracking issue.
+
+   To verify, re-fetch all Copilot inline comments and check that each has at least one reply from the PR author or bot containing "Fixed:" or "Tracked in #":
+   ```bash
+   # Get all Copilot comment IDs
+   COPILOT_COMMENTS=$(gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments \
+     --jq '[.[] | select(.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$")) | .id]')
+
+   # For each comment, verify it has a valid reply
+   for COMMENT_ID in $(echo "$COPILOT_COMMENTS" | jq -r '.[]'); do
+     REPLIES=$(gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments \
+       --jq "[.[] | select(.in_reply_to_id == ${COMMENT_ID}) | .body]")
+     HAS_FIX=$(echo "$REPLIES" | jq 'any(test("Fixed:"))')
+     HAS_ISSUE=$(echo "$REPLIES" | jq 'any(test("Tracked in #"))')
+     if [ "$HAS_FIX" != "true" ] && [ "$HAS_ISSUE" != "true" ]; then
+       echo "UNRESOLVED: Comment $COMMENT_ID has no fix or tracking issue"
+     fi
+   done
+   ```
+   If any comments are unresolved, **do not proceed** — address them before continuing.
+7. After addressing all actionable findings, re-push and wait for CI to restart
+
+### 1c. Verify no new Copilot comments after push
+
+If you pushed fixes, Copilot may re-review. Re-run the check run monitoring from 1a (get the new HEAD SHA, wait for the Copilot check run to complete, then read comments once).
+
+If new comments appeared, repeat 1b. Otherwise proceed to Step 2.
+
+## Step 2: Set auto-merge
+
+```bash
+gh pr merge {number} --squash --auto --delete-branch
+```
+
+This tells GitHub to merge automatically once all required checks pass.
+
+## Step 3: Check CI status and monitor
+
+Check current CI status:
+
+```bash
+gh pr checks {number}
+```
+
+**If all checks are passing:**
+- The PR will merge immediately (or within seconds)
+- Verify by checking: `gh pr view {number} --json state --jq .state`
+- If state is `MERGED`, proceed to Step 4
+
+**If checks are pending:**
+- Inform the user that auto-merge is set and CI is running
+- Spawn a background monitoring agent to poll until completion:
+  - Poll every 30 seconds: `gh pr view {number} --json state --jq .state`
+  - If state becomes `MERGED`: report success and proceed to Step 4
+  - If checks fail: report the failure with details from `gh pr checks {number}`
+  - Timeout after 15 minutes of polling
+
+**If checks are failing:**
+- Report which checks failed: `gh pr checks {number}`
+- Do NOT proceed with merge
+- Suggest investigating the failures
+
+## Step 4: Post-merge actions
+
+After merge is confirmed:
+
+1. **Switch to main and pull latest:**
+   ```bash
+   git checkout main
+   git pull origin main
+   ```
+
+2. **Report the merge commit:**
+   ```bash
+   git log -1 --format="%H %s"
+   ```
+
+3. **Check for next work:**
+   - If there is a known next issue in the current milestone or the user mentioned follow-up work, suggest starting it
+   - If the branch was a worktree, note that the worktree can be cleaned up
+
+## Error handling
+
+- If `gh` commands fail, check authentication: `gh auth status`
+- If merge conflicts are reported, inform the user -- do not attempt automatic resolution
+- If branch protection rules block the merge, report which rules are not satisfied

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,20 @@ Project-specific conventions belong in `.claude/rules/dev-team-process.md` (work
 
 Stored in `docs/adr/`. Read before making changes to foundational patterns. ADRs are immutable records — if a decision changes, write a new ADR that supersedes the original. Do not edit existing ADRs.
 
+# Project Name
+
+## Development
+<!-- Build, test, and run commands. Tool preferences agents can't discover from code. -->
+<!-- Example: "Use pnpm, not npm. Use oxlint for linting, not ESLint." -->
+
+## Test quirks
+<!-- Non-obvious testing behavior that causes false passes or confusing failures. -->
+<!-- Example: "Run integration tests with --no-cache or flaky tests pass incorrectly." -->
+
+## Legacy traps
+<!-- Code that looks correct but isn't. Patterns to avoid. -->
+<!-- Example: "Don't use the v1 auth middleware — it stores tokens non-compliantly." -->
+
 <!-- dev-team:begin -->
 
 ## Dev Team
@@ -141,6 +155,7 @@ Domain-specific findings, known patterns, active watch lists. Each agent owns it
 When the human gives feedback about process, coding style, or tool behavior: write it to `.claude/rules/dev-team-learnings.md`. Only use machine-local memory for things that are truly personal and would not apply to another developer on the same project.
 
 <!-- dev-team:end -->
+
 
 
 


### PR DESCRIPTION
## Summary
- Remove 7 resolved tech debt entries from learnings (all shipped in v1.8.0)
- Remove baked-in retro learning (#456 — now in skill definition)
- Update Szabo/Knuth memory: stale entries marked [fixed]
- Borges v1.8.0 extraction: 11 new memory entries across 8 agents
- v1.8.0 metrics recorded in metrics.md
- Process gap documented: delivery bypassed `/dev-team:task`
- Includes `dev-team update` artifacts (CLAUDE.md, retro skill, merge skill, config)

## Test plan
- [ ] No code changes — memory/docs only
- [ ] Verify learnings file is cleaner (7 strikethrough entries removed)
- [ ] Verify agent memories have v1.8.0 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)