### PR TITLE
fix: update README hooks count (8 → 10) for worktree hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ npx @fredericboyer/dev-team create-agent <name>     # Scaffold a custom agent
 
 **Opus** agents do deep analysis — Szabo, Knuth, Brooks, and Turing are read-only; Drucker uses opus for orchestration with full access. **Sonnet** agents implement (faster, full write access). Borges runs at end-of-workflow for memory consolidation. Rams reviews design system compliance.
 
-### Hooks (8)
+### Hooks (10)
 
 | Hook | Trigger | Behavior |
 |------|---------|----------|
@@ -147,6 +147,8 @@ npx @fredericboyer/dev-team create-agent <name>     # Scaffold a custom agent
 | Pre-commit lint | Before commit | **Blocks** commit if lint or format checks fail. |
 | Agent teams guide | Before Agent spawn | **Advisory** guidance for worktree isolation and team coordination patterns. |
 | Review gate | Before commit | **Blocks** commit without review evidence. Stateless commit gates for adversarial review enforcement. |
+| Worktree create | Before worktree creation | **Serializes** parallel worktree creation to prevent git lock races. |
+| Worktree remove | After worktree removal | **Cleans up** worktree artifacts and stale branch references. |
 
 All hooks are Node.js scripts — work on macOS, Linux, and Windows.
 


### PR DESCRIPTION
## Summary
- Updates README hooks table from 8 to 10 to include `worktree-create` and `worktree-remove` hooks added in v1.8.0
- Fixes `validate-readme` CI check that was failing on PR #487

## Test plan
- [ ] `validate-readme` CI check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>