### PR TITLE
fix: scorecard skill references /dev-team:extract for Borges invocation

### DIFF
--- a/.claude/rules/dev-team-learnings.md
+++ b/.claude/rules/dev-team-learnings.md
@@ -26,7 +26,7 @@
 
 ## Known Tech Debt
 
-- **Scorecard unaware of /dev-team:extract** (#494) — scorecard gates could drift now that extract is a separate skill. Deferred from v1.9.0 PR #492.
+- **INFRA_HOOKS worktree serialization is temporary** — workaround for Claude Code bugs anthropics/claude-code#34645 and #39680. Remove when upstream fixes land.
 
 ## Quality Benchmarks
 

--- a/.dev-team/skills/dev-team-scorecard/SKILL.md
+++ b/.dev-team/skills/dev-team-scorecard/SKILL.md
@@ -36,12 +36,12 @@ Before issuing any `gh issue`, `gh pr`, or other platform-specific CLI commands,
 
 Run each check and record pass/fail with evidence.
 
-### 1. Borges ran
+### 1. Borges ran (via `/dev-team:extract`)
 
-**Check**: Read `.dev-team/metrics.md` and search for an entry matching the workflow's issue number, PR number, or branch name.
+**Check**: Borges memory extraction is invoked via `/dev-team:extract` at the end of orchestration workflows (`/dev-team:task`, `/dev-team:review`, `/dev-team:audit`, `/dev-team:retro`). The verification artifact is a `.dev-team/metrics.md` entry. Read `.dev-team/metrics.md` and search for an entry matching the workflow's issue number, PR number, or branch name.
 
 - **Pass**: Entry exists with the workflow reference
-- **Fail**: No matching entry found
+- **Fail**: No matching entry found (Borges was not invoked, or `/dev-team:extract` was skipped)
 
 ### 2. All findings acknowledged
 

--- a/templates/skills/dev-team-scorecard/SKILL.md
+++ b/templates/skills/dev-team-scorecard/SKILL.md
@@ -36,12 +36,12 @@ Before issuing any `gh issue`, `gh pr`, or other platform-specific CLI commands,
 
 Run each check and record pass/fail with evidence.
 
-### 1. Borges ran
+### 1. Borges ran (via `/dev-team:extract`)
 
-**Check**: Read `.dev-team/metrics.md` and search for an entry matching the workflow's issue number, PR number, or branch name.
+**Check**: Borges memory extraction is invoked via `/dev-team:extract` at the end of orchestration workflows (`/dev-team:task`, `/dev-team:review`, `/dev-team:audit`, `/dev-team:retro`). The verification artifact is a `.dev-team/metrics.md` entry. Read `.dev-team/metrics.md` and search for an entry matching the workflow's issue number, PR number, or branch name.
 
 - **Pass**: Entry exists with the workflow reference
-- **Fail**: No matching entry found
+- **Fail**: No matching entry found (Borges was not invoked, or `/dev-team:extract` was skipped)
 
 ### 2. All findings acknowledged
 


### PR DESCRIPTION
## Summary
- Updated the scorecard "Borges ran" check to explain that Borges is invoked via `/dev-team:extract` and that the `metrics.md` entry is the verification artifact
- Synced installed copy at `.dev-team/skills/dev-team-scorecard/SKILL.md`
- Removed the #494 Known Tech Debt entry from `.claude/rules/dev-team-learnings.md`

Closes #494

## Test plan
- [x] `npm test` passes (18 tests, 0 failures)
- [ ] Verify scorecard check 1 heading and description reference `/dev-team:extract`
- [ ] Verify #494 tech debt entry removed from learnings, #493 entry untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)