### PR TITLE
chore: release v1.10.1

### DIFF
--- a/.dev-team/agent-memory/dev-team-borges/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-borges/MEMORY.md
@@ -107,6 +107,14 @@
 - **Last-verified**: 2026-03-29
 - **Context**: 4 retro-derived issues resolved. 12 raw findings (10 unique after dedup), 2 DEFECTs fixed, 4 accepted, 4 ignored, 0 overruled. 60% acceptance rate — within healthy band. Stray commits recurred (2nd time after v1.7.0). Zero-overrule alert triggered at n>=87 in-team findings. New entries: Szabo (1), Knuth (2), Brooks (1), Deming (2), Tufte (1). 1 new shared learning (parallel branch shared-file conflicts). Deming at 191 lines — approaching 200-cap, compressed 2 entries. No stale entries (all within 4 days).
 
+### [2026-03-29] v1.10.1 extraction — 1 PR, 7 findings, 14% acceptance, hotfix
+- **Type**: MILESTONE [verified]
+- **Source**: v1.10.1 hotfix (#515, PR #516)
+- **Tags**: metrics, calibration, extraction, hotfix
+- **Outcome**: verified
+- **Last-verified**: 2026-03-29
+- **Context**: Small hotfix — 3 init/update bugs fixed. 7 advisory findings (0 DEFECT), 1 accepted (Brooks HookEntry interface), 1 deferred (Knuth test gap), 5 ignored (trust boundary, defense-in-depth). 1 round to convergence. Low acceptance rate (14%) reflects advisory findings on trusted internal code — not a signal quality issue.
+
 ### [2026-03-29] v1.8.0 post-hoc extraction — 12 issues, 12 PRs, Copilot-only review
 - **Type**: MILESTONE [verified]
 - **Source**: v1.8.0 task loop (12 issues, 12 PRs #470-#483)

--- a/.dev-team/agent-memory/dev-team-brooks/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-brooks/MEMORY.md
@@ -125,5 +125,13 @@
 - **Last-verified**: 2026-03-29
 - **Context**: Four parallel branches all edited dev-team-learnings.md, creating a 4-way merge conflict. Resolved via sequential merge ordering with conflict resolution between each merge. Same class as "sequential chains must integrate-as-you-go" — parallel branches touching shared files require merge coordination, not just sequential chains.
 
+### [2026-03-29] v1.10.1: HookEntry interface extended with timeout/blocking fields
+- **Type**: RISK [accepted]
+- **Source**: #515, PR #516, finding #6
+- **Tags**: architecture, hooks, interface, typing
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-29
+- **Context**: Brooks flagged HookEntry interface as incomplete — missing timeout and blocking fields that exist in settings.json hook entries. Extended to match runtime shape. mergeSettings Object.assign now correctly propagates these attributes during update.
+
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->

--- a/.dev-team/agent-memory/dev-team-deming/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-deming/MEMORY.md
@@ -182,10 +182,10 @@
 - **Last-verified**: 2026-03-29
 - **Context**: Scorecard now checks for /dev-team:extract invocation (the new Borges entry point) in addition to direct Borges agent spawning. Without this, scorecard would always report "Borges not spawned" for v1.9.0+ workflows that use the extract skill.
 
-### [2026-03-26] Audit baseline: 14 findings, 0 DEFECT, all accepted
-- **Type**: CALIBRATION
-- **Source**: Full codebase audit 2026-03-26
-- **Tags**: audit, calibration, baseline
-- **Outcome**: all accepted
-- **Last-verified**: 2026-03-26
-- **Context**: First full tooling audit. Zero DEFECTs. Themes: hook consolidation, CI hardening, test coverage, migration completeness. Details in metrics.md.
+### [2026-03-29] v1.10.1: init/update bug trio — config completeness, init guard, settings merge
+- **Type**: DECISION [new]
+- **Source**: #515, PR #516
+- **Tags**: init, update, settings, hooks, dx
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-29
+- **Context**: Three bugs fixed: (1) init now appends INFRA_HOOKS labels to config.json hooks array, (2) init refuses when config.json exists (use --force), (3) mergeSettings updates attributes (timeout, type) on existing hooks via Object.assign. Also added removeHooksFromSettings for hook removal cleanup and hookRemovals migration in update.ts. HookEntry interface extended with timeout/blocking fields per Brooks review.

--- a/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
@@ -118,6 +118,14 @@
 - **Last-verified**: 2026-03-29
 - **Context**: PR #509 bundled commits from #490 + #494; PR #511 bundled #490 + #493. Both caused by agents sharing a working directory. Reinforces v1.7.0 finding — worktree isolation prevents cross-branch contamination. Seen: 2nd occurrence (v1.7.0 had 3 stray commits, v1.10.0 had 2 bundled PRs).
 
+### [2026-03-29] v1.10.1: 3 findings ignored — defense-in-depth, test scope, error handling
+- **Type**: CALIBRATION
+- **Source**: #515, PR #516
+- **Tags**: calibration, hotfix
+- **Outcome**: 0 accepted, 1 deferred, 2 ignored
+- **Last-verified**: 2026-03-29
+- **Context**: HOOK_FILES redundancy with ghost filter (ignored — defense in depth), hookRemovals test gap (deferred — unit tests cover it), removeHooksFromSettings swallowing invalid JSON (ignored — mergeSettings runs first). All advisory, no quality signal.
+
 ### [2026-03-26] Review skill had wrong path for agent-patterns.json
 - **Type**: DEFECT [fixed]
 - **Source**: PR #365 (fix/355), Copilot finding

--- a/.dev-team/agent-memory/dev-team-szabo/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-szabo/MEMORY.md
@@ -8,7 +8,7 @@
 - **Source**: package.json + src/ analysis
 - **Tags**: trust-boundary, attack-surface
 - **Outcome**: verified
-- **Last-verified**: 2026-03-26
+- **Last-verified**: 2026-03-29
 - **Context**: dev-team is a CLI installer that copies template files into target projects. No authentication system, no user data handling, no database, no HTTP server. Primary security concern is file system operations and template injection.
 
 ### [2026-03-29] assertNoSymlinkInPath() — ancestor directory traversal guard

--- a/.dev-team/config.json
+++ b/.dev-team/config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.10.1",
   "agents": [
     "Voss",
     "Hamilton",

--- a/.dev-team/metrics.md
+++ b/.dev-team/metrics.md
@@ -152,3 +152,19 @@
 - **Duration**: single session, 12 PRs (#470-#483)
 - **Notes**: v1.8.0 delivered without `/dev-team:task` or dev-team agent reviews. All implementation by orchestrator directly. Copilot was sole reviewer. ~30 Copilot findings across 12 PRs, all addressed. Key PRs with substantive findings: #475 (8 findings on symlink guards — 5 fixed, 3 acknowledged), #479 (mergeClaudeMd edge case), #478 (readFile docstring). Process gap: no adversarial review loop, no Borges extraction during delivery. This post-hoc extraction fills the memory gap. Key deliverables: worktree serialization hooks (INFRA_HOOKS), task skill 4-step decomposition, assertNoSymlinkInPath, readFile error hardening, mergeClaudeMd boundary fix, 18 new tests.
 
+### [2026-03-29] Task: v1.10.1 hotfix (#515) — PR #516
+- **Agents**: implementing: Deming, reviewers: Szabo, Knuth, Brooks
+- **Rounds**: 1
+- **Findings**:
+  - Szabo: 0 DEFECT, 0 RISK, 1 SUGGESTION (1 ignored)
+  - Knuth: 0 DEFECT, 0 RISK, 3 SUGGESTION (1 deferred / 2 ignored), 1 QUESTION (1 ignored)
+  - Brooks: 0 DEFECT, 1 RISK (1 accepted), 1 SUGGESTION (1 ignored)
+- **Acceptance rate**: 14% (1 accepted / 7 total)
+- **Overrule rate**: 0% (0/7)
+- **Fix rate (DEFECTs)**: N/A (0 DEFECTs)
+- **Defer rate (advisory)**: 14% (1/7)
+- **Ignore rate (advisory)**: 71% (5/7)
+- **Duration**: single session, 1 PR
+- **Notes**: Small hotfix — 3 init/update bugs fixed (config completeness, init guard, settings merge). High ignore rate reflects advisory findings on trusted internal code (Object.assign on template JSON, defense-in-depth redundancy). One accepted finding: Brooks flagged incomplete HookEntry interface, extended with timeout/blocking fields. One deferred: Knuth flagged missing settings cleanup test. Rolling zero-overrule alert continues at n>=94 in-team findings.
+- **[RISK] Zero-overrule alert**: Rolling overrule rate remains 0% at n>=94 in-team findings (v1.2.0 through v1.10.1). Per research brief #490, healthy adversarial review shows 1-10% overrule rate.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.1] - 2026-03-29
+
+### Fixed
+- `INFRA_HOOKS` missing from `config.json` after `init` — config completeness now validated (#515, #516).
+- `init --all` silently overwrites existing config — now requires `--force` for re-initialization (#515, #516).
+- `mergeSettings` drops new hook attributes (`timeout`, `blocking`) — HookEntry interface extended to preserve all attributes (#515, #516).
+
+### Added
+- `hookRemovals` migration support for clean hook lifecycle management (#516).
+- `removeHooksFromSettings` cleanup utility (#516).
+- Init guard requiring `--force` for re-init over existing installation (#516).
+
 ## [1.10.0] - 2026-03-29
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fredericboyer/dev-team",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "bin": {
         "dev-team": "bin/dev-team.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Adversarial AI agent team for any project — installs Claude Code agents, hooks, and skills that enforce quality through productive friction",
   "main": "dist/init.js",
   "types": "dist/init.d.ts",


### PR DESCRIPTION
## Summary
- Hotfix release for init/update bugs fixed in #516 (closes #515)
- Config completeness validation, init guard (`--force` for re-init), `mergeSettings` preserving hook attributes
- `hookRemovals` migration support, `removeHooksFromSettings` cleanup utility
- Milestone v1.10.1 closed

## Release checklist
- [x] Version bumped to 1.10.1 (`package.json`, `package-lock.json`, `config.json`)
- [x] CHANGELOG.md updated
- [x] All 451 tests passing
- [x] Milestone closed
- [ ] After merge: push tag `v1.10.1` — CI handles npm publish + GitHub release

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>