### PR TITLE
feat: add harness assumption audit to retro skill

### DIFF
--- a/.dev-team/skills/dev-team-retro/SKILL.md
+++ b/.dev-team/skills/dev-team-retro/SKILL.md
@@ -205,6 +205,33 @@ If `.dev-team/metrics.md` exists and contains entries, analyze:
 - Which implementing agents are used most frequently?
 - Are reviewers consistently finding issues in specific domains? This may indicate an implementing agent needs calibration
 
+## Phase 5: Harness assumption audit (`docs/design/harness-assumptions.md`)
+
+Each retro should include a lightweight check: "Which dev-team components compensate for model limitations that may no longer exist?"
+
+1. Read `docs/design/harness-assumptions.md`. If the file does not exist, skip this phase and flag as:
+   ```
+   **[RISK]** Harness — Missing assumptions registry: `docs/design/harness-assumptions.md` not found.
+   Why this matters: without a documented list of harness assumptions, the team cannot systematically evaluate whether components are still necessary as model capabilities evolve.
+   ```
+
+2. For each listed assumption, evaluate whether it is still valid given current model capabilities. Consider:
+   - Has the underlying model limitation been resolved or significantly improved?
+   - Does the component provide value beyond compensating for the limitation (e.g., defense-in-depth)?
+   - Would removing the component introduce regression risk?
+
+3. Flag assumptions that may be outdated as:
+   ```
+   **[SUGGESTION]** Harness — Assumption may be outdated: "<assumption summary>"
+   Current status: <why it may no longer hold>
+   Simplification path: <specific component changes or removals to consider>
+   Risk if simplified: <what could go wrong>
+   ```
+
+4. Update the `Last-validated` date on each reviewed assumption to today's date.
+
+5. Include a summary in the health report under a **Harness assumptions** row in the health score table.
+
 ## Report
 
 Produce a structured health report:
@@ -261,6 +288,7 @@ Provide a simple health score:
 | Agent Memory | healthy / needs attention / unhealthy | count by severity |
 | CLAUDE.md | healthy / needs attention / unhealthy | count by severity |
 | Metrics | healthy / needs attention / unhealthy | count by severity |
+| Harness assumptions | healthy / needs attention / unhealthy | count by severity |
 | **Overall** | **status** | **total** |
 
 Thresholds:

--- a/docs/design/harness-assumptions.md
+++ b/docs/design/harness-assumptions.md
@@ -1,0 +1,40 @@
+# Harness Assumptions
+
+Components in dev-team that compensate for model limitations. Each retro evaluates whether these assumptions still hold, flagging outdated ones for simplification.
+
+## Assumptions
+
+### Safety guard hook
+
+- **Assumption:** Models will execute dangerous commands (rm -rf, force push, credential exposure) without prompting the user first.
+- **Current status:** Claude Code's built-in sandbox provides filesystem and network restrictions. The safety guard hook is a secondary speed bump that catches patterns the sandbox does not cover (e.g., `git push --force` to main).
+- **Component:** `templates/hooks/dev-team-safety-guard.js`
+- **Last-validated:** 2026-03-29
+
+### TDD enforcement hook
+
+- **Assumption:** Models will not write tests without explicit prompting, leading to untested code.
+- **Current status:** Models are significantly better at TDD now and often generate tests unprompted. However, enforcement prevents regression in sessions where the model optimizes for speed over coverage.
+- **Component:** `templates/hooks/dev-team-pre-commit-lint.js` (test coverage check)
+- **Last-validated:** 2026-03-29
+
+### Review gate
+
+- **Assumption:** Models will skip peer reviews without enforcement, optimizing for speed of delivery over quality.
+- **Current status:** Still valid. Models consistently optimize for task completion speed. Without the review gate, adversarial review loops are bypassed, reducing defect detection.
+- **Component:** `templates/hooks/dev-team-review-gate.js`
+- **Last-validated:** 2026-03-29
+
+### Agent memory (two-tier)
+
+- **Assumption:** Models cannot maintain context across sessions, requiring explicit persistence of learnings and calibration data.
+- **Current status:** Still valid. Claude Code sessions are stateless between invocations. Without persisted memory, agents repeat mistakes and lose calibration across sessions.
+- **Component:** `.dev-team/agent-memory/`, `.claude/rules/dev-team-learnings.md`
+- **Last-validated:** 2026-03-29
+
+### Structured finding classifications
+
+- **Assumption:** Models need a rigid taxonomy ([DEFECT], [RISK], [SUGGESTION], [QUESTION]) to produce consistent, actionable review output.
+- **Current status:** Could potentially be relaxed for more nuanced feedback. However, the taxonomy enables automated processing (metrics, gate decisions) and consistent cross-agent communication. Removing it would require replacing the automation layer.
+- **Component:** Agent definitions, review gate, metrics system
+- **Last-validated:** 2026-03-29

--- a/templates/skills/dev-team-retro/SKILL.md
+++ b/templates/skills/dev-team-retro/SKILL.md
@@ -205,6 +205,33 @@ If `.dev-team/metrics.md` exists and contains entries, analyze:
 - Which implementing agents are used most frequently?
 - Are reviewers consistently finding issues in specific domains? This may indicate an implementing agent needs calibration
 
+## Phase 5: Harness assumption audit (`docs/design/harness-assumptions.md`)
+
+Each retro should include a lightweight check: "Which dev-team components compensate for model limitations that may no longer exist?"
+
+1. Read `docs/design/harness-assumptions.md`. If the file does not exist, skip this phase and flag as:
+   ```
+   **[RISK]** Harness — Missing assumptions registry: `docs/design/harness-assumptions.md` not found.
+   Why this matters: without a documented list of harness assumptions, the team cannot systematically evaluate whether components are still necessary as model capabilities evolve.
+   ```
+
+2. For each listed assumption, evaluate whether it is still valid given current model capabilities. Consider:
+   - Has the underlying model limitation been resolved or significantly improved?
+   - Does the component provide value beyond compensating for the limitation (e.g., defense-in-depth)?
+   - Would removing the component introduce regression risk?
+
+3. Flag assumptions that may be outdated as:
+   ```
+   **[SUGGESTION]** Harness — Assumption may be outdated: "<assumption summary>"
+   Current status: <why it may no longer hold>
+   Simplification path: <specific component changes or removals to consider>
+   Risk if simplified: <what could go wrong>
+   ```
+
+4. Update the `Last-validated` date on each reviewed assumption to today's date.
+
+5. Include a summary in the health report under a **Harness assumptions** row in the health score table.
+
 ## Report
 
 Produce a structured health report:
@@ -261,6 +288,7 @@ Provide a simple health score:
 | Agent Memory | healthy / needs attention / unhealthy | count by severity |
 | CLAUDE.md | healthy / needs attention / unhealthy | count by severity |
 | Metrics | healthy / needs attention / unhealthy | count by severity |
+| Harness assumptions | healthy / needs attention / unhealthy | count by severity |
 | **Overall** | **status** | **total** |
 
 Thresholds:


### PR DESCRIPTION
## Summary
- Add Phase 5 to `/dev-team:retro` skill: harness assumption audit that evaluates whether dev-team components still compensate for real model limitations
- Create `docs/design/harness-assumptions.md` with five initial entries (safety guard, TDD enforcement, review gate, agent memory, structured classifications), each with `Last-validated` dates
- Sync installed copy at `.dev-team/skills/dev-team-retro/SKILL.md`
- Add "Harness assumptions" row to the retro health score table

Closes #521

## Test plan
- [ ] Verify `npm test` passes (471/472 -- the 1 failure is a pre-existing flaky worktree removal test)
- [ ] Run `/dev-team:retro` and confirm Phase 5 executes against the new assumptions file
- [ ] Verify the installed copy matches the template copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)