### PR TITLE
feat: create evaluator calibration examples for reviewer agents

### DIFF
--- a/.dev-team/agent-memory/dev-team-brooks/calibration-examples.md
+++ b/.dev-team/agent-memory/dev-team-brooks/calibration-examples.md
@@ -1,0 +1,43 @@
+# Calibration Examples: Brooks (Architect)
+
+Annotated examples of correctly classified findings from this project's review history. Use these to calibrate finding severity and avoid repeat miscalibrations.
+
+### Example 1: DEFERRED — Skill composability ADR suggestion
+
+**Finding:** The skill-calls-skill pattern (/dev-team:extract invoked by /dev-team:task, /dev-team:review invoked with --embedded flag) should be formally documented in an ADR to establish the composability contract.
+**Classification:** [SUGGESTION]
+**Outcome:** deferred to #493, then completed in v1.10.0
+**Why:** The pattern was working correctly at runtime but lacked formal architectural documentation. Deferring was correct — the implementation was sound and shipping it was higher priority than documenting it. But the ADR was genuinely needed: without it, future skill authors would not know the composability contract (disable-model-invocation, --embedded flag semantics, output format expectations).
+**Lesson:** ADR suggestions for working patterns are legitimate deferrals, not dismissals. The test: "would a new contributor be confused without this documentation?" If yes, create the issue and track it. The v1.10.0 completion validated the deferral — the ADR was written with better context after the pattern had been exercised in production.
+
+### Example 2: ACCEPTED — --reviewers removal as breaking change
+
+**Finding:** Task skill now controls reviewer selection internally. The --reviewers flag on /dev-team:review is removed. Anyone invoking /dev-team:review directly with --reviewers will get an error.
+**Classification:** [RISK]
+**Outcome:** accepted (flagged for release notes)
+**Why:** This is a genuine breaking change for direct review skill users. The --embedded pattern subsumes the old interface, but the removal is not backward-compatible. The correct action was to accept and ensure it appears in v1.9.0 release notes, not to maintain backward compatibility indefinitely.
+**Lesson:** When a skill interface changes, always assess whether external consumers exist. Internal-only interfaces (invoked by other skills) can change freely. Public interfaces (invoked by users via slash commands) need release note callouts for removals. Brooks should flag interface removals even when the replacement is architecturally superior — the migration cost falls on users.
+
+### Example 3: ACCEPTED — 4-way learnings merge conflict requiring sequential ordering
+
+**Finding:** Four parallel branches all edited dev-team-learnings.md. Merging created a 4-way conflict that required sequential merge ordering with manual conflict resolution between each merge.
+**Classification:** [DEFECT]
+**Outcome:** accepted (resolved via sequential merge ordering)
+**Why:** Parallel branches touching shared files is an architectural coordination problem, not just a process problem. The learnings file is a shared resource with high write contention. The fix — sequential merge ordering — is correct for the current scale but does not prevent recurrence.
+**Lesson:** Shared mutable files (learnings, metrics, MEMORY.md) are architectural bottlenecks in parallel workflows. When reviewing parallel branch plans, flag shared file writes as merge-ordering constraints upfront. This is the same class as "sequential chains must integrate-as-you-go" but applies to parallel branches, not just sequential ones.
+
+### Example 4: ACCEPTED — HookEntry interface incomplete (missing timeout/blocking fields)
+
+**Finding:** The HookEntry TypeScript interface was missing timeout and blocking fields that exist in the runtime settings.json hook entries. mergeSettings using Object.assign would propagate these fields at runtime but the type system did not reflect them.
+**Classification:** [RISK]
+**Outcome:** accepted (interface extended)
+**Why:** Type-reality drift is a maintainability risk. Code using HookEntry would not get type checking on timeout/blocking access, leading to potential undefined-at-runtime bugs. The fix was straightforward — extend the interface to match the runtime shape.
+**Lesson:** When reviewing interface definitions, compare them against the actual data they model. JSON config files are the most common source of type-reality drift — the config evolves faster than the TypeScript types. Check settings.json schema against HookEntry/ConfigEntry types during reviews.
+
+### Example 5: ACCEPTED — INFRA_HOOKS separation as temporary architectural pattern
+
+**Finding:** init.ts now separates INFRA_HOOKS (always installed) from QUALITY_HOOKS (opt-in). Infrastructure hooks bypass user choice.
+**Classification:** [RISK]
+**Outcome:** accepted (with "remove when upstream fixes land" caveat)
+**Why:** The worktree serialization hooks work around Claude Code bugs (#34645, #39680). They must be installed to prevent race conditions, so user opt-out would be counterproductive. However, the pattern of bypassing user choice is architecturally concerning if it grows beyond the current 2 hooks.
+**Lesson:** Temporary architectural patterns need explicit removal conditions. "Remove when upstream fixes land" is a valid condition but must be tracked. Brooks should flag any growth in INFRA_HOOKS — each addition weakens user control. The current 2-hook scope is acceptable; 5+ would warrant an ADR.

--- a/.dev-team/agent-memory/dev-team-knuth/calibration-examples.md
+++ b/.dev-team/agent-memory/dev-team-knuth/calibration-examples.md
@@ -1,0 +1,43 @@
+# Calibration Examples: Knuth (Quality Auditor)
+
+Annotated examples of correctly classified findings from this project's review history. Use these to calibrate finding severity and avoid repeat miscalibrations.
+
+### Example 1: FIXED — Missing gate in .claude copy of merge skill
+
+**Finding:** Merge skill gate logic was updated in .dev-team/skills/ but the .claude/skills/ copy was not staged. The installed copy lacks the new gate check, so users running /merge from .claude/skills/ would bypass the gate.
+**Classification:** [DEFECT]
+**Outcome:** fixed
+**Why:** This is a functional gap — the installed copy diverged from the source copy. Users would hit the ungated path. The fix was to stage and commit the .claude/skills/ copy alongside the .dev-team/skills/ change.
+**Lesson:** Path correctness is a recurring quality pattern in this project (seen 5 times: doctor.ts, status.ts, review skill, memory dir, merge skill .claude copy). Any change to a skill or hook must audit all copies — .dev-team/ source AND .claude/ installed copy. This is the single most common defect class.
+
+### Example 2: ACCEPTED — Vocabulary alignment across skill boundaries
+
+**Finding:** Task skill used "addressed/deferred/disputed" outcome vocabulary but Borges expects "accepted/overruled/fixed/ignored". Mismatch breaks automated memory extraction.
+**Classification:** [SUGGESTION]
+**Outcome:** accepted (vocabulary standardized)
+**Why:** Cross-boundary vocabulary mismatches cause silent failures — Borges parses outcomes and cannot match non-standard terms. This was the 5th occurrence of vocabulary alignment issues across the project (v1.2.0 task skill, v1.9.0 extract skill, v1.9.0 review skill, v1.10.0 retro skill).
+**Lesson:** When one component produces structured output consumed by another, vocabulary must be explicitly aligned. Check the consumer's expected vocabulary before introducing new terms. Recurring pattern: any skill that outputs Finding Outcome Log entries must use the standardized vocabulary (fixed, accepted, deferred, overruled, ignored).
+
+### Example 3: ACCEPTED — Stray commits from shared working directory
+
+**Finding:** PR #509 bundled commits from #490 and #494; PR #511 bundled commits from #490 and #493. Agent teams sharing a working directory caused cross-branch contamination.
+**Classification:** [RISK]
+**Outcome:** accepted (worktree isolation recommended)
+**Why:** This is the 2nd occurrence of the same pattern (v1.7.0 had 3 stray commits, v1.10.0 had 2 bundled PRs). Agents switching branches under each other is not a code quality issue per se, but it produces PRs with incorrect commit sets — a quality signal that the review process must catch.
+**Lesson:** When reviewing PRs from parallel agent work, always verify the commit list belongs to the stated issue. Stray commits are a symptom of shared-directory contention. This is a process quality finding, not a code quality finding — but Knuth should flag it because it degrades the traceability chain (requirement to test to commit).
+
+### Example 4: IGNORED — Defense-in-depth redundancy in HOOK_FILES
+
+**Finding:** HOOK_FILES array contains entries that would also be caught by the ghost file filter. The redundancy is unnecessary.
+**Classification:** [SUGGESTION]
+**Outcome:** ignored
+**Why:** Defense-in-depth redundancy is intentional. The HOOK_FILES array is a static allow-list; the ghost filter is a dynamic check. If the ghost filter has a bug, the static list still provides protection. Removing the redundancy saves zero runtime cost and removes a safety net.
+**Lesson:** Do not flag defense-in-depth as redundancy unless the duplicate check has a measurable cost (performance, maintenance burden, or confusion risk). Static allow-lists layered with dynamic filters are a standard hardening pattern. This is now in the anti-patterns list for sentinel-throw tests — analogous reasoning applies.
+
+### Example 5: FIXED — Migration drift in doctor.ts and status.ts
+
+**Finding:** When v1.6.0 migrated files from .dev-team/ to .claude/rules/, doctor.ts and status.ts were not updated to check the new paths. Health checks report false negatives for files that exist at the new location.
+**Classification:** [DEFECT]
+**Outcome:** fixed (issues #431, #432 created for v1.6.1)
+**Why:** Migration completeness is a recurring quality gap. Any file move/rename must audit all modules that reference the old path. doctor.ts and status.ts are particularly vulnerable because they enumerate known file paths for health checking.
+**Lesson:** After any migration that moves or renames files, grep the codebase for the old path. doctor.ts, status.ts, and skill definitions are the three most common victims of path drift. This is the same class as Example 1 — path correctness is the project's #1 recurring defect.

--- a/.dev-team/agent-memory/dev-team-szabo/calibration-examples.md
+++ b/.dev-team/agent-memory/dev-team-szabo/calibration-examples.md
@@ -1,0 +1,43 @@
+# Calibration Examples: Szabo (Security Auditor)
+
+Annotated examples of correctly classified findings from this project's review history. Use these to calibrate finding severity and avoid repeat miscalibrations.
+
+### Example 1: IGNORED — $ARGUMENTS trust boundary in extract skill
+
+**Finding:** Szabo raised a trust boundary question about $ARGUMENTS usage in /dev-team:extract skill — could untrusted input flow through skill arguments?
+**Classification:** [QUESTION]
+**Outcome:** ignored (self-answered)
+**Why:** The skill is invoked only by other orchestration skills (task, review, retro), not by untrusted external input. Skill-to-skill invocation is an internal trust boundary with no user-controlled data crossing it.
+**Lesson:** Before flagging argument trust boundaries, trace the invocation chain. If the caller is another internal skill with disable-model-invocation:true, the trust boundary is already constrained. Do not flag internal-only interfaces as external attack surfaces.
+
+### Example 2: ACCEPTED — Symlink-following in file operations (path traversal)
+
+**Finding:** File operations in init.ts and update.ts follow symlinks without validation. An attacker could plant a symlink at a target path, causing the tool to read/write outside the intended directory tree.
+**Classification:** [RISK]
+**Outcome:** accepted — assertNotSymlink() added in v1.7.0, assertNoSymlinkInPath() added in v1.8.0
+**Why:** File system operations are the primary attack surface for a CLI installer tool. Symlink-following enables path traversal, which is a real risk even for tools running with user permissions (malicious repo contents could redirect writes).
+**Lesson:** For CLI tools that copy files into target directories, symlink validation is a legitimate security concern. The two-wave fix (leaf check + ancestor traversal) is the correct depth. The residual TOCTOU gap was correctly accepted as inherent to POSIX.
+
+### Example 3: ACCEPTED — shell:true with hardcoded arguments
+
+**Finding:** Hook scripts use `execFileSync` with `shell: true` option. Shell expansion could enable command injection.
+**Classification:** [RISK]
+**Outcome:** accepted (documented in anti-patterns, no code change needed)
+**Why:** All arguments are hardcoded string literals or arrays — no user-controlled data flows into the command. `shell: true` is needed on Windows for `.cmd`/`.bat` resolution. The risk is theoretical only when all inputs are developer-authored constants.
+**Lesson:** Command injection requires attacker-controlled input reaching an interpreter. When the binary path and all arguments are string literals, `shell: true` is a false positive. This is now in the anti-patterns list to prevent repeated flagging.
+
+### Example 4: ACCEPTED — TOCTOU in assertNotSymlink accepted as POSIX limitation
+
+**Finding:** assertNotSymlink uses lstatSync before the file operation — classic time-of-check-to-time-of-use gap. An attacker could replace a regular file with a symlink between the check and the operation.
+**Classification:** [RISK]
+**Outcome:** accepted (no fix possible within POSIX constraints)
+**Why:** Check-then-act is inherent to POSIX file operations. Exploitability requires a local attacker with write access to the target directory, which already represents a compromised environment. No atomic alternative exists without OS-specific APIs (O_NOFOLLOW on Linux, RESOLVE_NO_SYMLINKS on newer kernels).
+**Lesson:** When the only mitigation would require non-portable OS-specific APIs, accept the residual risk with documentation rather than pursuing an incomplete fix. State the exploitation prerequisites clearly — "requires local write access" makes the residual risk concrete and assessable.
+
+### Example 5: CLEAN APPROVE — Retro-derived changes with no new trust boundaries
+
+**Finding:** No security findings raised across 4 retro-derived PRs (#509/#510/#511/#512).
+**Classification:** N/A (clean approve)
+**Outcome:** clean
+**Why:** Changes were skill definitions, ADR documents, learnings, and merge timing logic. No new file system operations, no new trust boundary crossings, no new input handling. Clean approve was the correct call.
+**Lesson:** Not every PR needs security findings. Skill definition and documentation changes that do not introduce new I/O, trust boundary crossings, or input handling are genuinely security-neutral. A clean approve is a valid and correct outcome — do not manufacture findings to appear thorough.

--- a/.dev-team/agents/dev-team-brooks.md
+++ b/.dev-team/agents/dev-team-brooks.md
@@ -111,6 +111,9 @@ Do NOT flag these patterns — they have been reviewed and accepted:
 
 - **"Module does two things" when responsibilities share a data structure** — Reason: when two operations act on the same data type or file format (e.g., `files.ts` with read and write operations on the same file types), they are cohesive — not coincidentally coupled. Splitting them forces callers to import from two modules for a single logical concern. Flag only when the responsibilities have independent change reasons and no shared data structure.
 - **Cyclomatic complexity on config objects and migration maps** — Reason: configuration objects, feature flag maps, and migration/upgrade tables often have many static entries that inflate cyclomatic complexity metrics. These are data declarations, not control flow — each entry is independent and requires no mental branching to understand. Flag only when the complexity comes from nested conditionals or dynamic logic, not static enumeration.
+## Calibration examples
+
+See `.dev-team/agent-memory/dev-team-brooks/calibration-examples.md` for annotated examples of correctly classified findings from this project.
 
 ## Learnings: what to record in MEMORY.md
 

--- a/.dev-team/agents/dev-team-knuth.md
+++ b/.dev-team/agents/dev-team-knuth.md
@@ -74,6 +74,9 @@ Do NOT flag these patterns — they have been reviewed and accepted:
 - **Missing tests for generated or vendored files** — Reason: generated files (build output, compiled assets, auto-generated types) and vendored dependencies are not project logic. Testing them duplicates upstream validation and creates brittle tests that break on regeneration.
 - **"Insufficient assertion" on sentinel-throw tests** — Reason: the sentinel-throw pattern (`throw new Error('__EXIT__')`) uses the thrown error as the assertion. If `process.exit()` is stubbed with a no-op, execution continues past the exit point causing false passes. The throw IS the assertion — catching it and verifying the message is a complete test.
 - **Missing boundary tests for parameters validated at a higher level** — Reason: when a parameter is validated and constrained at the API boundary or caller level (e.g., CLI argument parsing rejects invalid values before they reach internal functions), requiring boundary tests at every downstream function creates redundant coverage. Flag only when the validation chain has gaps.
+## Calibration examples
+
+See `.dev-team/agent-memory/dev-team-knuth/calibration-examples.md` for annotated examples of correctly classified findings from this project.
 
 ## Learnings: what to record in MEMORY.md
 

--- a/.dev-team/agents/dev-team-szabo.md
+++ b/.dev-team/agents/dev-team-szabo.md
@@ -74,6 +74,9 @@ Do NOT flag these patterns — they have been reviewed and accepted:
 - **`execFileSync` with hardcoded argument arrays** — Reason: command injection requires attacker-controlled input. When the binary path and all arguments are string literals or hardcoded arrays, there is no injection vector.
 - **`Object.assign` on `JSON.parse` output** — Reason: prototype pollution via `Object.assign` requires a crafted `__proto__` key in the source object. Output from `JSON.parse` does not create prototype-bearing objects — parsed `__proto__` keys become plain data properties, not prototype chain mutations.
 - **`shell: true` in `execFile`/`spawn` with all hardcoded arguments** — Reason: shell expansion is only dangerous when arguments contain user-controlled data. Hardcoded arguments with `shell: true` (commonly needed on Windows for `.cmd`/`.bat` resolution) pose no injection risk.
+## Calibration examples
+
+See `.dev-team/agent-memory/dev-team-szabo/calibration-examples.md` for annotated examples of correctly classified findings from this project.
 
 ## Learnings: what to record in MEMORY.md
 

--- a/templates/agents/dev-team-brooks.md
+++ b/templates/agents/dev-team-brooks.md
@@ -111,6 +111,9 @@ Do NOT flag these patterns — they have been reviewed and accepted:
 
 - **"Module does two things" when responsibilities share a data structure** — Reason: when two operations act on the same data type or file format (e.g., `files.ts` with read and write operations on the same file types), they are cohesive — not coincidentally coupled. Splitting them forces callers to import from two modules for a single logical concern. Flag only when the responsibilities have independent change reasons and no shared data structure.
 - **Cyclomatic complexity on config objects and migration maps** — Reason: configuration objects, feature flag maps, and migration/upgrade tables often have many static entries that inflate cyclomatic complexity metrics. These are data declarations, not control flow — each entry is independent and requires no mental branching to understand. Flag only when the complexity comes from nested conditionals or dynamic logic, not static enumeration.
+## Calibration examples
+
+See `.dev-team/agent-memory/dev-team-brooks/calibration-examples.md` for annotated examples of correctly classified findings from this project.
 
 ## Learnings: what to record in MEMORY.md
 

--- a/templates/agents/dev-team-knuth.md
+++ b/templates/agents/dev-team-knuth.md
@@ -74,6 +74,9 @@ Do NOT flag these patterns — they have been reviewed and accepted:
 - **Missing tests for generated or vendored files** — Reason: generated files (build output, compiled assets, auto-generated types) and vendored dependencies are not project logic. Testing them duplicates upstream validation and creates brittle tests that break on regeneration.
 - **"Insufficient assertion" on sentinel-throw tests** — Reason: the sentinel-throw pattern (`throw new Error('__EXIT__')`) uses the thrown error as the assertion. If `process.exit()` is stubbed with a no-op, execution continues past the exit point causing false passes. The throw IS the assertion — catching it and verifying the message is a complete test.
 - **Missing boundary tests for parameters validated at a higher level** — Reason: when a parameter is validated and constrained at the API boundary or caller level (e.g., CLI argument parsing rejects invalid values before they reach internal functions), requiring boundary tests at every downstream function creates redundant coverage. Flag only when the validation chain has gaps.
+## Calibration examples
+
+See `.dev-team/agent-memory/dev-team-knuth/calibration-examples.md` for annotated examples of correctly classified findings from this project.
 
 ## Learnings: what to record in MEMORY.md
 

--- a/templates/agents/dev-team-szabo.md
+++ b/templates/agents/dev-team-szabo.md
@@ -74,6 +74,9 @@ Do NOT flag these patterns — they have been reviewed and accepted:
 - **`execFileSync` with hardcoded argument arrays** — Reason: command injection requires attacker-controlled input. When the binary path and all arguments are string literals or hardcoded arrays, there is no injection vector.
 - **`Object.assign` on `JSON.parse` output** — Reason: prototype pollution via `Object.assign` requires a crafted `__proto__` key in the source object. Output from `JSON.parse` does not create prototype-bearing objects — parsed `__proto__` keys become plain data properties, not prototype chain mutations.
 - **`shell: true` in `execFile`/`spawn` with all hardcoded arguments** — Reason: shell expansion is only dangerous when arguments contain user-controlled data. Hardcoded arguments with `shell: true` (commonly needed on Windows for `.cmd`/`.bat` resolution) pose no injection risk.
+## Calibration examples
+
+See `.dev-team/agent-memory/dev-team-szabo/calibration-examples.md` for annotated examples of correctly classified findings from this project.
 
 ## Learnings: what to record in MEMORY.md
 


### PR DESCRIPTION
## Summary
- Create 3 calibration example files (`.dev-team/agent-memory/dev-team-{szabo,knuth,brooks}/calibration-examples.md`) with 5 annotated examples each, drawn from actual project review history
- Update all 3 reviewer agent templates (`templates/agents/`) to reference their calibration files
- Sync installed agent copies in `.dev-team/agents/`

Closes #522

## Test plan
- [x] All 451 tests pass
- [ ] Verify calibration files contain examples matching the specified format
- [ ] Verify agent templates reference the correct calibration file paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)