### PR TITLE
chore: release v1.11.0

### DIFF
--- a/.dev-team/agent-memory/dev-team-beck/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-beck/MEMORY.md
@@ -24,7 +24,7 @@
 - **Source**: package.json analysis
 - **Tags**: testing, ci
 - **Outcome**: verified
-- **Last-verified**: 2026-03-29
+- **Last-verified**: 2026-03-29 (confirmed: PR #557 added 5 new test files to scripts.test)
 - **Context**: New test files must be added to the explicit list in package.json scripts.test. CI runs tests cross-platform (ubuntu, macos, windows) with Node 22.
 
 ### [2026-03-25] TDD enforced via hook — dev-team-tdd-enforce.js
@@ -58,6 +58,22 @@
 - **Outcome**: fixed
 - **Last-verified**: 2026-03-29
 - **Context**: assertNotSymlink, assertNoSymlinkInPath, and safeRegex each got dedicated test suites. Tests cover: leaf rejection, ancestor traversal, realpathSync tradeoff behavior, nested quantifier patterns, length bounds. Uses the sentinel-throw pattern for process.exit. Tightened existing test assertions (#474) to reduce false positive risk — narrower assertions catch regressions that broad ones miss.
+
+### [2026-03-29] v1.11.0: Worktree hook tests and input validation (#529, #537)
+- **Type**: DECISION [new]
+- **Source**: #529, #537, PR #556
+- **Tags**: testing, hooks, worktree, input-validation
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-29
+- **Context**: Worktree serialization hooks (WorktreeCreate/WorktreeRemove) gained proper test coverage and input validation. Tests verify lock acquisition, timeout behavior, and cleanup. Input validation guards against missing/invalid worktree paths.
+
+### [2026-03-29] v1.11.0: Test coverage batch — init error paths, update backup, createAgent, CLI help
+- **Type**: DECISION [new]
+- **Source**: #540, #541, #542, #545, #548, PR #557
+- **Tags**: testing, coverage, init, update, cli, createAgent
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-29
+- **Context**: Five coverage gaps closed in single PR: init error paths (missing package.json, config already exists), update backup flow, createAgent validation (empty name, missing fields), CLI --help output verification, hookRemovals integration test. Continues systematic coverage expansion pattern.
 
 ## Framework and Runner Notes
 

--- a/.dev-team/agent-memory/dev-team-borges/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-borges/MEMORY.md
@@ -122,3 +122,11 @@
 - **Outcome**: verified
 - **Last-verified**: 2026-03-29
 - **Context**: Post-hoc extraction — Borges was not spawned during delivery. v1.8.0 bypassed `/dev-team:task` and agent reviews entirely. ~30 Copilot findings, all addressed. No formal DEFECTs. New entries written: Szabo (1 new + 1 updated), Knuth (2), Brooks (2), Deming (2), Beck (1), Conway (1), Voss (1). Process learning added to shared learnings (process gap). Key architectural changes: INFRA_HOOKS separation, task skill 4-step decomposition, assertNoSymlinkInPath ancestor guard. System improvement identified: v1.8.0 process gap confirms that bypassing the adversarial loop should be reserved for hotfixes, not feature releases.
+
+### [2026-03-29] v1.11.0 extraction — 27 issues, 8 PRs, ~18 findings, 6% acceptance, hardening release
+- **Type**: MILESTONE [verified]
+- **Source**: v1.11.0 task loop (27 issues, 8 PRs #550-#557)
+- **Tags**: metrics, calibration, extraction, hardening
+- **Outcome**: verified
+- **Last-verified**: 2026-03-29
+- **Context**: Largest release to date. 0 DEFECTs across all 8 PRs. ~18 unique findings (all advisory), 1 accepted, 3 deferred, 14 ignored. Low acceptance rate (6%) is not a signal quality issue — reflects hardening scope (CI, tests, docs, symlink guards). Deming memory compressed (191→~165 lines) by consolidating 4 v1.5.0-era entries and 3 v1.7.0-era entries into summaries. New entries written: Deming (1), Szabo (1), Knuth (1), Brooks (2), Beck (2), Tufte (1). Last-verified bumped on Deming CI entry and Beck test-listing entry. Zero-overrule alert continues at n>=112. No new shared learnings needed — release was hardening, not new process/principles.

--- a/.dev-team/agent-memory/dev-team-brooks/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-brooks/MEMORY.md
@@ -133,5 +133,21 @@
 - **Last-verified**: 2026-03-29
 - **Context**: Brooks flagged HookEntry interface as incomplete — missing timeout and blocking fields that exist in settings.json hook entries. Extended to match runtime shape. mergeSettings Object.assign now correctly propagates these attributes during update.
 
+### [2026-03-29] v1.11.0: Review tiers and DoD formalized in review/task skills
+- **Type**: DECISION [new]
+- **Source**: #519, #520, PR #551
+- **Tags**: architecture, skills, review, anti-patterns
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-29
+- **Context**: Review skill now defines explicit tiers (LIGHT/STANDARD/DEEP) and Definition of Done criteria. Anti-pattern sections added to reviewer agent definitions. Harness assumption audit added to retro skill (#521, PR #550). Calibration examples shipped for reviewer agents (#522, PR #553). These are template improvements — shipped to all users.
+
+### [2026-03-29] v1.11.0: Calibration examples path missing in user projects
+- **Type**: RISK [deferred]
+- **Source**: PR #553, Brooks finding
+- **Tags**: architecture, calibration, init, path
+- **Outcome**: deferred
+- **Last-verified**: 2026-03-29
+- **Context**: Calibration examples directory exists in templates but init/update may not copy it to user projects. Path correctness pattern continues (Seen: 6th instance). Deferred — not blocking, examples are reference material.
+
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->

--- a/.dev-team/agent-memory/dev-team-deming/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-deming/MEMORY.md
@@ -24,7 +24,7 @@
 - **Source**: .github/workflows/ci.yml analysis
 - **Tags**: ci, validation, agents, hooks
 - **Outcome**: verified
-- **Last-verified**: 2026-03-25
+- **Last-verified**: 2026-03-29
 - **Context**: scripts/validate-agents.js checks agent frontmatter. scripts/validate-hooks.js verifies hook scripts load without errors. Both are separate CI jobs. Hook validation runs cross-platform.
 
 ### [2026-03-25] TypeScript with NodeNext resolution — pretest builds before test
@@ -45,35 +45,11 @@
 
 ## Hook Effectiveness
 
-### [2026-03-26] Review gate pattern duplication with post-change-review
-- **Type**: RISK [resolved]
-- **Tags**: hooks, maintenance
+### [2026-03-26] v1.5.0 era — pattern extraction and template organization (consolidated)
+- **Type**: PATTERN [verified]
+- **Tags**: hooks, templates, shared-protocol, guarded-files, dx
 - **Last-verified**: 2026-03-26
-- **Context**: Pattern duplication was resolved by extracting shared patterns to `.dev-team/hooks/agent-patterns.json` (PR #344). Both hooks now import from a single source. Superseded by the shared pattern extraction approach.
-
-### [2026-03-26] SHARED.md protocol reduces agent definition duplication by ~16%
-- **Type**: DECISION [verified]
-- **Source**: PR #376 (feat/353), ADR-030
-- **Tags**: agents, templates, shared-protocol, dx
-- **Outcome**: accepted
-- **Last-verified**: 2026-03-26
-- **Context**: Common agent sections (progress reporting, memory hygiene, challenge protocol) extracted to SHARED.md. Agent definitions include it via reference. Reduces 1873→1574 total lines. ADR-030 governs the shared protocol pattern.
-
-### [2026-03-26] Process rules extracted from CLAUDE.md to dev-team-process.md
-- **Type**: DECISION [verified]
-- **Source**: PR #373, ADR-031
-- **Tags**: process, dx, claude-md, templates, guarded-files
-- **Outcome**: accepted
-- **Last-verified**: 2026-03-26
-- **Context**: CLAUDE.md was growing unwieldy. Process rules now live in a dedicated file, keeping CLAUDE.md under 100 lines. ADR-031 governs the extraction.
-
-### [2026-03-26] process.md is a guarded file — never overwritten on update
-- **Type**: DECISION [verified]
-- **Source**: PR #398 (fix/397)
-- **Tags**: update, guarded-files, process
-- **Outcome**: accepted
-- **Last-verified**: 2026-03-26
-- **Context**: process.md joins learnings.md and metrics.md as files that are never overwritten by `dev-team update`. update.ts only installs process.md if missing (for pre-v1.5.0 projects). The contradiction between "Never modify .dev-team/" and process.md being user-editable was resolved by clarifying which files are preserved vs overwritten.
+- **Context**: Several foundational DX decisions consolidated: (1) Review gate pattern duplication resolved via agent-patterns.json extraction (PR #344). (2) SHARED.md protocol reduces agent definition duplication ~16% (ADR-030). (3) Process rules extracted from CLAUDE.md to dev-team-process.md (ADR-031). (4) process.md, learnings.md, metrics.md are guarded files — never overwritten on update (PR #398).
 
 ### [2026-03-26] Skill invocation control: orchestration vs advisory skills
 - **Type**: DECISION [verified]
@@ -99,29 +75,11 @@
 - **Last-verified**: 2026-03-27
 - **Context**: cachedGitDiff was copy-pasted across 3 hooks (tdd-enforce, pre-commit-gate, review-gate). Extracted to `templates/hooks/lib/git-cache.js`. All 3 hooks now `require("./lib/git-cache")`. init.ts and update.ts updated to copy lib/ directory. Remaining duplication: fallback pattern arrays (#437, still open).
 
-### [2026-03-26] CI gap: no npm audit step
-- **Type**: SUGGESTION [resolved]
-- **Source**: Codebase audit, Issue #440
-- **Tags**: ci, security, npm, dx
-- **Outcome**: fixed — `audit-dependencies` job added to CI (PR for #440)
+### [2026-03-27] v1.7.0 era — audit-derived fixes (consolidated)
+- **Type**: PATTERN [verified]
+- **Tags**: ci, testing, duplication, dx
 - **Last-verified**: 2026-03-27
-- **Context**: Added `audit-dependencies` job running `npm audit --audit-level=high` as a separate CI job, consistent with one-concern-per-job pattern. Only blocks on high/critical severity.
-
-### [2026-03-27] review-gate.test.js added to test script (Issue #435)
-- **Type**: SUGGESTION [resolved]
-- **Source**: Codebase audit, Issue #435
-- **Tags**: testing, hooks, dx
-- **Outcome**: fixed
-- **Last-verified**: 2026-03-27
-- **Context**: review-gate.test.js was not in the npm test script. Added to package.json. Also fixed the runGate test helper: it used execFileSync which swallows stderr on exit 0 — switched to spawnSync to capture stderr in all cases. The --skip-review test was failing because the hook outputs via console.warn (stderr) but the helper only captured stderr on error paths.
-
-### [2026-03-27] Symlink creation extracted to ensureSymlink() in files.ts
-- **Type**: DECISION [verified]
-- **Source**: Issue #441
-- **Tags**: duplication, files, dx
-- **Outcome**: fixed
-- **Last-verified**: 2026-03-27
-- **Context**: ~30 lines of identical symlink creation with Windows junction fallback existed in both init.ts and update.ts. Extracted to ensureSymlink() in files.ts. Also removed unused fs import from init.ts. Part of the hook/utility dedup series (#436, #437).
+- **Context**: Three audit-derived improvements consolidated: (1) npm audit CI step added (#440). (2) review-gate.test.js added to test script, runGate helper switched from execFileSync to spawnSync (#435). (3) ensureSymlink() extracted from init.ts/update.ts to files.ts (#441).
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->
@@ -189,3 +147,11 @@
 - **Outcome**: fixed
 - **Last-verified**: 2026-03-29
 - **Context**: Three bugs fixed: (1) init now appends INFRA_HOOKS labels to config.json hooks array, (2) init refuses when config.json exists (use --force), (3) mergeSettings updates attributes (timeout, type) on existing hooks via Object.assign. Also added removeHooksFromSettings for hook removal cleanup and hookRemovals migration in update.ts. HookEntry interface extended with timeout/blocking fields per Brooks review.
+
+### [2026-03-29] v1.11.0: CI hardening — npm ci, Semgrep, release parallelization, validate-docs
+- **Type**: DECISION [new]
+- **Source**: #528, #530, #533, #546, #547, PR #552
+- **Tags**: ci, security, dx, semgrep, validation
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-29
+- **Context**: CI improvements: npm ci replaces npm install for reproducible builds, Semgrep SAST added (silent on failure per Brooks — deferred to full enforcement), release workflow parallelized, validate-docs job added. Lint scope extended to tests/ directory (#555). Duplicate hook removed (dev-team-watch-list.js had redundant copy).

--- a/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
@@ -133,3 +133,11 @@
 - **Outcome**: fixed
 - **Last-verified**: 2026-03-26
 - **Context**: Review skill referenced agent-patterns.json at wrong path. Corrected to `.dev-team/hooks/agent-patterns.json`. Path correctness is a recurring theme — verify paths in skill definitions during review. Seen: 4 times (this + doctor.ts K1 + status.ts K3 + memory dir deming/ v1.7.0).
+
+### [2026-03-29] v1.11.0: Test coverage expanded — init error paths, update backup, createAgent, CLI help
+- **Type**: PATTERN [new]
+- **Source**: #540, #541, #542, #545, #548, PR #557
+- **Tags**: testing, coverage, init, update, cli
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-29
+- **Context**: 5 test coverage issues addressed in single PR. New tests for: init error paths (missing package.json, invalid config), update backup flow, createAgent validation (empty name, missing fields), CLI --help output, hookRemovals integration. Continues the coverage expansion pattern from v1.7.0 (#438) and v1.8.0 (#480).

--- a/.dev-team/agent-memory/dev-team-szabo/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-szabo/MEMORY.md
@@ -104,3 +104,11 @@
 - **Outcome**: fixed
 - **Last-verified**: 2026-03-26
 - **Context**: Skills now detect platform from config (default: github). When platform field is absent (pre-v1.5 installs), skills default to github rather than failing. update.ts backfills the platform field on upgrade.
+
+### [2026-03-29] v1.11.0: Semgrep SAST deferred to full enforcement
+- **Type**: SUGGESTION [deferred]
+- **Source**: PR #552, Szabo finding
+- **Tags**: ci, sast, semgrep, security
+- **Outcome**: deferred
+- **Last-verified**: 2026-03-29
+- **Context**: Semgrep SAST added to CI but configured as silent (non-blocking) on failure per Brooks suggestion. Szabo recommended full Semgrep config with custom rules. Deferred — current setup provides visibility without blocking CI. Full enforcement tracked for future hardening pass.

--- a/.dev-team/agent-memory/dev-team-tufte/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-tufte/MEMORY.md
@@ -112,3 +112,11 @@
 - **Outcome**: accepted
 - **Last-verified**: 2026-03-26
 - **Context**: Seven design principles codified: workflow-agnostic, platform-neutral, language-neutral, discoverable-only, process-driven, rules for shared context, skill invocation control. These are the product's template design contract — all future template changes must comply.
+
+### [2026-03-29] v1.11.0: Review tiers, DoD, context docs, and anti-pattern sections added
+- **Type**: DECISION [new]
+- **Source**: #519, #520, #523, #524, PR #551
+- **Tags**: documentation, review, anti-patterns, templates
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-29
+- **Context**: Review skill documentation expanded: explicit tier definitions (LIGHT/STANDARD/DEEP), Definition of Done criteria, context documentation sections. Anti-pattern sections added to reviewer agent definitions (Szabo, Knuth, Brooks) with calibration examples. Safety guard and shell:true documentation updated (#536, #538, PR #554). ADR index and research brief naming aligned with guidelines (#527, PR for docs alignment).

--- a/.dev-team/config.json
+++ b/.dev-team/config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.1",
+  "version": "1.11.0",
   "agents": [
     "Voss",
     "Hamilton",

--- a/.dev-team/metrics.md
+++ b/.dev-team/metrics.md
@@ -168,3 +168,20 @@
 - **Notes**: Small hotfix — 3 init/update bugs fixed (config completeness, init guard, settings merge). High ignore rate reflects advisory findings on trusted internal code (Object.assign on template JSON, defense-in-depth redundancy). One accepted finding: Brooks flagged incomplete HookEntry interface, extended with timeout/blocking fields. One deferred: Knuth flagged missing settings cleanup test. Rolling zero-overrule alert continues at n>=94 in-team findings.
 - **[RISK] Zero-overrule alert**: Rolling overrule rate remains 0% at n>=94 in-team findings (v1.2.0 through v1.10.1). Per research brief #490, healthy adversarial review shows 1-10% overrule rate.
 
+### [2026-03-29] Task: v1.11.0 delivery (#519-#548) — PRs #550-#557
+- **Agents**: implementing: Deming, Beck, Tufte; reviewers: Szabo, Knuth, Brooks
+- **Rounds**: 1 per PR (8 PRs)
+- **Findings**:
+  - Szabo: 0 DEFECT, 1 RISK (1 ignored — compareSemver prerelease, latent), 2 SUGGESTION (2 deferred — Semgrep config), 1 QUESTION (1 ignored — validate-docs setup-node)
+  - Knuth: 0 DEFECT, 3 RISK (3 ignored — validate-docs regex, release.yml escaping, compareSemver), 1 SUGGESTION (1 ignored — double symlink check)
+  - Brooks: 0 DEFECT, 4 RISK (1 accepted — merge ordering, 1 deferred — Semgrep silent, 1 ignored — double build, 1 deferred — calibration path missing), 5 SUGGESTION (5 ignored — review gate LIGHT, DoD ordering, context docs location, calibration seeding, lock contention test), 1 QUESTION (1 ignored — init.js side effects)
+- **Unique findings**: ~18 (after deduplication of ~25 raw)
+- **Acceptance rate**: 6% (1 accepted / ~18 total)
+- **Overrule rate**: 0% (0/~18)
+- **Fix rate (DEFECTs)**: N/A (0 DEFECTs)
+- **Defer rate (advisory)**: 17% (3/~18 — Semgrep config x2, calibration path)
+- **Ignore rate (advisory)**: 78% (14/~18)
+- **Duration**: single session, 8 PRs, 27 issues
+- **Notes**: Largest release to date (27 issues, 8 PRs). All 8 PRs approved with 0 DEFECTs. High ignore rate (78%) reflects the nature of the work — primarily hardening, CI improvements, test coverage, and documentation. Most advisory findings targeted latent risks (compareSemver prerelease, regex edge cases) or minor suggestions (ordering, location) that were reasonable to ignore for the scope. 3 deferred findings tracked: Semgrep full enforcement, calibration example path in user projects. 1 round per PR — clean convergence.
+- **[RISK] Zero-overrule alert**: Rolling overrule rate remains 0% at n>=112 in-team findings (v1.2.0 through v1.11.0). Per research brief #490, healthy adversarial review shows 1-10% overrule rate. Acceptance rate (6%) is below the healthy band (60-85%) but this is attributable to the release scope (hardening/docs) rather than signal quality. When excluding pure-hardening releases, the rolling acceptance rate is within the healthy band.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-03-29
+
+### Added
+- Review intensity tiers (LIGHT/FULL) with explicit selection criteria and reviewer routing (#519, #551).
+- Definition of Done (DoD) negotiation protocol for task skill — agents and humans agree on acceptance criteria upfront (#520, #551).
+- Harness assumption audit in retro skill — retro now validates that hook/skill assumptions still hold (#521, #550).
+- Anti-pattern sections for reviewer agents — calibration examples of what NOT to flag (#523, #551).
+- Calibration examples for Szabo, Knuth, and Brooks reviewers — concrete accept/flag/skip examples (#522, #553).
+- `validate-docs` CI job — catches stale doc references and broken links (#546, #552).
+- Semgrep SAST (non-blocking) added to CI pipeline (#533, #552).
+- `.nvmrc` pinning Node.js version for consistent local development (#535, #554).
+- Context documentation for review skill — explains what context reviewers receive (#524, #551).
+
+### Changed
+- Agent timeouts aligned to 2-minute threshold across all skills (#519, #551).
+- Release workflow parallelized — independent CI jobs run concurrently (#547, #552).
+- `npm ci` replaces `npm install` in CI for deterministic installs (#528, #552).
+- Lint and format checks extended to `tests/` directory (#534, #555).
+- `validate-agents` and `validate-hooks` CI jobs optimized (#530, #552).
+
+### Fixed
+- Symlink guards added to `mergeSettings` and `removeHooksFromSettings` — prevents symlink-following attacks (#531, #555).
+- `compareSemver` prerelease handling — correctly orders prerelease vs release versions (#538, #554).
+- `doctor.ts` `hookFileMap` deduplication — no longer reports false failures for hooks with multiple files (#539, #554).
+- `listFilesRecursive` depth and symlink guard — bounded traversal prevents runaway recursion (#543, #554).
+- Worktree hook input validation hardened — rejects malformed JSON gracefully (#537, #556).
+- Safety guard and `shell:true` documentation clarified (#536, #554).
+- Duplicate pre-commit hook entry removed from settings template (#532, #555).
+- Retro CLAUDE.md template duplication removed (#549).
+- Mori `HookEntry` memory corrected (#549).
+- Docs aligned with guidelines — ADR index, research brief naming (#527).
+
+### Tests
+- 23+ new tests: worktree hook tests (13) (#529, #556), init error paths (#540, #557), update backup (#541, #557), `createAgent` validation (#542, #557), CLI help (#545, #557), `hookRemovals` integration (#548, #557).
+
 ## [1.10.1] - 2026-03-29
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fredericboyer/dev-team",
-      "version": "1.10.1",
+      "version": "1.11.0",
       "license": "MIT",
       "bin": {
         "dev-team": "bin/dev-team.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "Adversarial AI agent team for any project — installs Claude Code agents, hooks, and skills that enforce quality through productive friction",
   "main": "dist/init.js",
   "types": "dist/init.d.ts",


### PR DESCRIPTION
## Summary

- **27 issues** across **9 PRs** — largest release yet
- Bumps version to 1.11.0, updates CHANGELOG.md, config.json, and agent memories
- Milestone v1.11.0 closed

## What's in v1.11.0

### Added
- Review intensity tiers (LIGHT/FULL) with explicit selection criteria
- Definition of Done negotiation protocol for task skill
- Harness assumption audit in retro skill
- Anti-pattern sections and calibration examples for reviewers
- `validate-docs` CI job, Semgrep SAST (non-blocking), `.nvmrc`

### Changed
- Agent timeouts aligned to 2 minutes, release workflow parallelized
- `npm ci` in CI, lint/format extended to `tests/`

### Fixed
- Symlink guards in mergeSettings/removeHooksFromSettings
- compareSemver prerelease handling, doctor hookFileMap dedup
- listFilesRecursive depth/symlink guard, worktree hook input validation
- Duplicate pre-commit hook removed

### Tests
- 23+ new tests (472 total): worktree hooks, init error paths, update backup, createAgent validation, CLI help, hookRemovals integration

## PRs included
- #549, #550, #551, #552, #553, #554, #555, #556, #557

## Post-merge
Push tag `v1.11.0` — CI handles npm publish and GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)