### PR TITLE
fix: remove unnecessary \! escaping in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           PKG_VERSION=$(node -p "require('./package.json').version")
           TAG_VERSION="${TAG_REF#v}"
-          if [ "$PKG_VERSION" \!= "$TAG_VERSION" ]; then
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
             echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
             exit 1
           fi
@@ -139,7 +139,7 @@ jobs:
             echo "::warning::No changelog entry found for version ${VERSION}"
             echo "Release ${VERSION}" > /tmp/release-notes.md
           else
-            echo "$NOTES" | sed '/./,$\!d' > /tmp/release-notes.md
+            echo "$NOTES" | sed '/./,$!d' > /tmp/release-notes.md
           fi
         env:
           TAG_REF: ${{ github.ref_name }}


### PR DESCRIPTION
The \\! escaping broke the v1.11.0 GitHub Release creation (sed command failed). In non-interactive bash, ! has no special meaning.