### PR TITLE
chore: remove duplicate CLAUDE.md template scaffolding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,20 +47,6 @@ Project-specific conventions belong in `.claude/rules/dev-team-process.md` (work
 
 Stored in `docs/adr/`. Read before making changes to foundational patterns. ADRs are immutable records — if a decision changes, write a new ADR that supersedes the original. Do not edit existing ADRs.
 
-# Project Name
-
-## Development
-<!-- Build, test, and run commands. Tool preferences agents can't discover from code. -->
-<!-- Example: "Use pnpm, not npm. Use oxlint for linting, not ESLint." -->
-
-## Test quirks
-<!-- Non-obvious testing behavior that causes false passes or confusing failures. -->
-<!-- Example: "Run integration tests with --no-cache or flaky tests pass incorrectly." -->
-
-## Legacy traps
-<!-- Code that looks correct but isn't. Patterns to avoid. -->
-<!-- Example: "Don't use the v1 auth middleware — it stores tokens non-compliantly." -->
-
 <!-- dev-team:begin -->
 
 ## Dev Team
@@ -156,9 +142,6 @@ Domain-specific findings, known patterns, active watch lists. Each agent owns it
 When the human gives feedback about process, coding style, or tool behavior: write it to `.claude/rules/dev-team-learnings.md`. Only use machine-local memory for things that are truly personal and would not apply to another developer on the same project.
 
 <!-- dev-team:end -->
-
-
-
 
 
 


### PR DESCRIPTION
Manual cleanup — root cause tracked in #563.