### PR TITLE
fix: mergeClaudeMd stops re-injecting template scaffolding on update

### DIFF
--- a/src/files.ts
+++ b/src/files.ts
@@ -294,6 +294,15 @@ export function mergeClaudeMd(
     return "created";
   }
 
+  // Extract only the managed section (begin→end markers inclusive) from newContent.
+  // This prevents re-injecting template scaffolding above the markers on every update.
+  const newBegin = newContent.indexOf(BEGIN_MARKER);
+  const newEnd = newContent.indexOf(END_MARKER, newBegin);
+  const managedSection =
+    newBegin !== -1 && newEnd !== -1
+      ? newContent.substring(newBegin, newEnd + END_MARKER.length)
+      : newContent;
+
   if (existing.includes(BEGIN_MARKER)) {
     const firstBegin = existing.indexOf(BEGIN_MARKER);
     const firstEnd = existing.indexOf(END_MARKER, firstBegin);
@@ -303,7 +312,7 @@ export function mergeClaudeMd(
         "Warning: Found dev-team begin marker but no end marker in CLAUDE.md. Replacing from begin marker to end of file.",
       );
       const beforeMarker = existing.substring(0, firstBegin);
-      writeFile(filePath, beforeMarker + newContent + "\n");
+      writeFile(filePath, beforeMarker + managedSection + "\n");
       return "replaced";
     }
 
@@ -316,7 +325,7 @@ export function mergeClaudeMd(
 
     const beforeMarker = existing.substring(0, firstBegin);
     const afterMarker = existing.substring(firstEnd + END_MARKER.length);
-    writeFile(filePath, beforeMarker + newContent + afterMarker);
+    writeFile(filePath, beforeMarker + managedSection + afterMarker);
     return "replaced";
   }
 

--- a/tests/unit/files.test.js
+++ b/tests/unit/files.test.js
@@ -458,6 +458,66 @@ describe("mergeClaudeMd", () => {
     assert.ok(content.includes("User footer"), "should preserve content after last pair");
   });
 
+  it("does not re-inject template scaffolding on update when user has content above markers", () => {
+    const p = path.join(tmpDir, "CLAUDE.md");
+    // Simulate an existing CLAUDE.md where user has their own content above the markers
+    fs.writeFileSync(
+      p,
+      "# My Real Project\n\nCustom dev notes here.\n\n<!-- dev-team:begin -->\nold managed\n<!-- dev-team:end -->\n",
+    );
+
+    // Pass the full template (scaffolding + managed section) as newContent, like init/update do
+    const fullTemplate =
+      "# Project Name\n\n## Development\n\n## Test quirks\n\n<!-- dev-team:begin -->\nupdated managed\n<!-- dev-team:end -->\n";
+    const result = mergeClaudeMd(p, fullTemplate);
+    assert.equal(result, "replaced");
+
+    const content = fs.readFileSync(p, "utf-8");
+    assert.ok(content.includes("# My Real Project"), "should preserve user content above markers");
+    assert.ok(content.includes("Custom dev notes here."), "should preserve user notes");
+    assert.ok(content.includes("updated managed"), "should have updated managed content");
+    assert.ok(!content.includes("# Project Name"), "should NOT re-inject template scaffolding");
+    assert.ok(
+      !content.includes("## Test quirks"),
+      "should NOT re-inject template scaffolding sections",
+    );
+  });
+
+  it("writes full template including scaffolding on fresh install", () => {
+    const p = path.join(tmpDir, "CLAUDE-fresh.md");
+    const fullTemplate =
+      "# Project Name\n\n## Development\n\n<!-- dev-team:begin -->\nmanaged\n<!-- dev-team:end -->\n";
+    const result = mergeClaudeMd(p, fullTemplate);
+    assert.equal(result, "created");
+
+    const content = fs.readFileSync(p, "utf-8");
+    assert.ok(content.includes("# Project Name"), "should include scaffolding on fresh install");
+    assert.ok(content.includes("## Development"), "should include scaffolding sections");
+    assert.ok(content.includes("managed"), "should include managed content");
+  });
+
+  it("preserves scaffolding if user kept it above markers", () => {
+    const p = path.join(tmpDir, "CLAUDE.md");
+    // User kept the original scaffolding as their content
+    fs.writeFileSync(
+      p,
+      "# Project Name\n\n## Development\n\n## Test quirks\n\n<!-- dev-team:begin -->\nold managed\n<!-- dev-team:end -->\n",
+    );
+
+    const fullTemplate =
+      "# Project Name\n\n## Development\n\n## Test quirks\n\n<!-- dev-team:begin -->\nupdated managed\n<!-- dev-team:end -->\n";
+    const result = mergeClaudeMd(p, fullTemplate);
+    assert.equal(result, "replaced");
+
+    const content = fs.readFileSync(p, "utf-8");
+    assert.ok(content.includes("# Project Name"), "should keep user's scaffolding");
+    assert.ok(content.includes("## Test quirks"), "should keep user's scaffolding sections");
+    assert.ok(content.includes("updated managed"), "should have updated managed content");
+    // Crucially: should NOT have duplicate scaffolding
+    const nameCount = (content.match(/# Project Name/g) || []).length;
+    assert.equal(nameCount, 1, "should have exactly one instance of scaffolding");
+  });
+
   it("replaces from begin marker to EOF when end marker is missing", () => {
     const p = path.join(tmpDir, "CLAUDE.md");
     fs.writeFileSync(p, "# Project\n\n<!-- dev-team:begin -->\nold content without end marker");


### PR DESCRIPTION
Closes #563

## Summary
- Fixed `mergeClaudeMd` in `src/files.ts` to extract only the managed section (between `<!-- dev-team:begin -->` and `<!-- dev-team:end -->` markers) from the template when updating an existing CLAUDE.md
- On fresh install (no existing file), the full template including scaffolding is still written
- On update (existing file with markers), only the managed section is replaced — user content above markers is preserved and template scaffolding is not re-injected

## Test plan
- [x] Existing CLAUDE.md with user content above markers: user content preserved, no scaffolding injected
- [x] New CLAUDE.md (no existing file): full template including scaffolding written
- [x] Existing CLAUDE.md with original scaffolding kept by user: scaffolding preserved as-is, no duplicates
- [x] All 475 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)