### PR TITLE
chore: release v1.11.1

### DIFF
--- a/.dev-team/agent-memory/dev-team-borges/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-borges/MEMORY.md
@@ -130,3 +130,11 @@
 - **Outcome**: verified
 - **Last-verified**: 2026-03-29
 - **Context**: Largest release to date. 0 DEFECTs across all 8 PRs. ~18 unique findings (all advisory), 1 accepted, 3 deferred, 14 ignored. Low acceptance rate (6%) is not a signal quality issue — reflects hardening scope (CI, tests, docs, symlink guards). Deming memory compressed (191→~165 lines) by consolidating 4 v1.5.0-era entries and 3 v1.7.0-era entries into summaries. New entries written: Deming (1), Szabo (1), Knuth (1), Brooks (2), Beck (2), Tufte (1). Last-verified bumped on Deming CI entry and Beck test-listing entry. Zero-overrule alert continues at n>=112. No new shared learnings needed — release was hardening, not new process/principles.
+
+### [2026-03-30] v1.11.1 extraction — 1 PR, 1 finding, 0% acceptance, hotfix
+- **Type**: MILESTONE [verified]
+- **Source**: v1.11.1 hotfix (#563, PR #565)
+- **Tags**: metrics, calibration, extraction, hotfix
+- **Outcome**: verified
+- **Last-verified**: 2026-03-30
+- **Context**: Small hotfix — mergeClaudeMd duplicate scaffolding fix. 1 advisory finding (Knuth SUGGESTION, ignored). No new memory entries needed — bumped Last-verified on Knuth's related mergeClaudeMd boundary condition entry. Zero-overrule alert continues at n>=113. No new shared learnings. Proportional extraction for hotfix scope.

--- a/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
@@ -16,7 +16,7 @@
 - **Source**: #461, PR #479
 - **Tags**: boundary-condition, merge-logic
 - **Outcome**: fixed
-- **Last-verified**: 2026-03-29
+- **Last-verified**: 2026-03-30
 - **Context**: Missing END marker now triggers replace-from-BEGIN-to-EOF instead of append. Also fixed END-before-BEGIN edge case by searching for END only after BEGIN position. Two distinct boundary conditions fixed in same PR.
 
 ### [2026-03-29] v1.8.0: 18 new tests added — assertNotSymlink, assertNoSymlinkInPath, safeRegex

--- a/.dev-team/config.json
+++ b/.dev-team/config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.11.0",
+  "version": "1.11.1",
   "agents": [
     "Voss",
     "Hamilton",

--- a/.dev-team/metrics.md
+++ b/.dev-team/metrics.md
@@ -185,3 +185,16 @@
 - **Notes**: Largest release to date (27 issues, 8 PRs). All 8 PRs approved with 0 DEFECTs. High ignore rate (78%) reflects the nature of the work — primarily hardening, CI improvements, test coverage, and documentation. Most advisory findings targeted latent risks (compareSemver prerelease, regex edge cases) or minor suggestions (ordering, location) that were reasonable to ignore for the scope. 3 deferred findings tracked: Semgrep full enforcement, calibration example path in user projects. 1 round per PR — clean convergence.
 - **[RISK] Zero-overrule alert**: Rolling overrule rate remains 0% at n>=112 in-team findings (v1.2.0 through v1.11.0). Per research brief #490, healthy adversarial review shows 1-10% overrule rate. Acceptance rate (6%) is below the healthy band (60-85%) but this is attributable to the release scope (hardening/docs) rather than signal quality. When excluding pure-hardening releases, the rolling acceptance rate is within the healthy band.
 
+### [2026-03-30] Task: v1.11.1 hotfix (#563) — PR #565
+- **Agents**: implementing: Deming, reviewers: Knuth
+- **Rounds**: 1 (LIGHT)
+- **Findings**:
+  - Knuth: 0 DEFECT, 0 RISK, 1 SUGGESTION (1 ignored — guard clarity, advisory)
+- **Acceptance rate**: 0% (0 accepted / 1 total)
+- **Overrule rate**: 0% (0/1)
+- **Fix rate (DEFECTs)**: N/A (0 DEFECTs)
+- **Ignore rate (advisory)**: 100% (1/1)
+- **Duration**: single session, 1 PR
+- **Notes**: Small hotfix — mergeClaudeMd duplicate scaffolding fix. 1 advisory finding ignored (guard clarity for newBegin === -1). LIGHT review, 1 round to convergence. Clean fix scope.
+- **[RISK] Zero-overrule alert**: Rolling overrule rate remains 0% at n>=113 in-team findings (v1.2.0 through v1.11.1).
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-03-30
+
+### Fixed
+- `mergeClaudeMd` no longer re-injects template scaffolding on update (#563, #565).
+- `release.yml` unnecessary `\!` escaping removed (#562).
+
+### Dependencies
+- oxfmt 0.41.0 → 0.42.0 (#558).
+- oxlint 1.56.0 → 1.57.0 (#559).
+
 ## [1.11.0] - 2026-03-29
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fredericboyer/dev-team",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "MIT",
       "bin": {
         "dev-team": "bin/dev-team.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Adversarial AI agent team for any project — installs Claude Code agents, hooks, and skills that enforce quality through productive friction",
   "main": "dist/init.js",
   "types": "dist/init.d.ts",


### PR DESCRIPTION
## Summary
- Hotfix release v1.11.1
- **Fixed**: `mergeClaudeMd` no longer re-injects template scaffolding on update (#563, #565)
- **Fixed**: `release.yml` unnecessary `\!` escaping removed (#562)
- **Dependencies**: oxfmt 0.42.0 (#558), oxlint 1.57.0 (#559)

## Checklist
- [x] Version bumped in package.json, package-lock.json, config.json
- [x] CHANGELOG.md updated
- [x] All 475 tests pass
- [x] Milestone v1.11.1 closed
- [x] No tags created (post-merge)