### PR TITLE
chore: release v2.0.0

### DIFF
--- a/.claude/rules/dev-team-learnings.md
+++ b/.claude/rules/dev-team-learnings.md
@@ -1,6 +1,6 @@
 # Shared Team Learnings
-<!-- Read by all agents at session start. Keep under 200 lines. -->
-<!-- For formal decisions, use ADRs instead. This file captures organic learnings. -->
+<\!-- Read by all agents at session start. Keep under 200 lines. -->
+<\!-- For formal decisions, use ADRs instead. This file captures organic learnings. -->
 
 ## Coding Conventions
 
@@ -12,7 +12,7 @@
 - Spawn review agents as `general-purpose` subagents with the actual agent definition loaded from `.dev-team/agents/dev-team-*.md`. Do NOT use `pr-review-toolkit:*` as proxies — they have different behavior.
 - Hooks over CLAUDE.md for enforcement (ADR-001). If agents keep flagging the same pattern, it should be a hook.
 - **Review gate enforces the adversarial loop at commit time** (ADR-029). Two stateless gates: review evidence + findings resolution. Sidecar files in `.dev-team/.reviews/` keyed by agent + content hash. LIGHT reviews are advisory only. `--skip-review` is the escape hatch.
-- **Research-first for architectural releases.** When a release involves architectural changes, run Turing research briefs before implementation. Findings shape ADRs and design decisions, reducing rework. Validated in v1.6.0 (2 briefs → 2 ADRs + 7 design principles).
+- **Research-first for architectural releases.** When a release involves architectural changes, run Turing research briefs before implementation. Findings shape ADRs and design decisions, reducing rework. Validated in v1.6.0 (2 briefs → 2 ADRs + 7 design principles) and v2.0 (2 briefs → 2 ADRs + adapter architecture).
 - **Verify platform behavior against official docs, not third-party sources.** Turing research #406 initially got rules inheritance wrong by relying on inferred behavior. Always check official Claude Code documentation for behavioral claims about rules, subagents, and agent teams.
 - **Agent teams sharing a working directory cause cross-branch contamination.** v1.7.0 delivery had repeated issues: agents switched branches under each other, stray commits landed on wrong branches (#447→#438, #436→#446, #440→#434), stashes went stale. Worktree isolation (one worktree per agent) prevents all of these. Prefer worktree-isolated agents for multi-branch parallel work.
 - **"Require up-to-date branches" protection creates merge cascades.** Each merge makes other PRs stale, requiring sequential rebase+push. GitHub merge queues would automate this. For now, factor this into time estimates for multi-PR batches.
@@ -24,10 +24,13 @@
 
 - **Skill composability: orchestration skills can invoke other skills.** /dev-team:extract and /dev-team:review are invoked by /dev-team:task as sub-skills. Use `disable-model-invocation: true` on sub-skills to prevent autonomous firing. The `--embedded` flag signals compact output mode for skill-to-skill invocation. See ADR-035 for the formal pattern.
 - **Don't encode what agents already know.** AI agents have built-in knowledge of languages, frameworks, conventions, and standards. Hardcoding language-specific patterns (test file regex, linter commands, complexity keywords) into hooks or config creates static encyclopedias that are always incomplete. Instead, hooks should detect the ecosystem (read manifest files) and delegate language-specific reasoning to the agent. Include only what agents can't discover: tool preferences, legacy traps, test quirks, custom middleware warnings. (See: "AGENTS.md Verdict" — if the agent can discover it from code, delete it.)
+- **Adapter registry for multi-runtime portability (ADR-036).** Canonical format = current dev-team format. Adapters translate to runtime-native formats. Adding a runtime = implementing RuntimeAdapter + registering it. No changes to init.ts or update.ts. MCP is the cross-runtime enforcement layer (ADR-037).
 
 ## Known Tech Debt
 
 - **INFRA_HOOKS worktree serialization is temporary** — workaround for Claude Code bugs anthropics/claude-code#34645 and #39680. Remove when upstream fixes land.
+- **Dual code paths: hook vs MCP review gate.** review_gate logic exists in both `dev-team-review-gate.js` (hook) and `src/mcp/tools/review-gate.ts` (MCP tool). K10 finding in v2.0 showed they diverged during initial implementation. Must be tested and reviewed together until extracted to shared module. See ADR-037.
+- **Duplicate import in init.ts.** `import "./adapters/index.js"` appears twice (lines 23-24). Harmless but should be cleaned up.
 
 ## Quality Benchmarks
 
@@ -36,7 +39,8 @@
 - Pre-commit gate: blocks commits without memory updates (override via `.dev-team/.memory-reviewed`).
 - **Migration completeness**: Any change that moves/renames files must audit all modules that reference those paths. doctor.ts, status.ts, and skill definitions are recurring victims of path drift (3 instances across v1.5.0–v1.6.0).
 - **process.exit stubs must throw a sentinel error.** When testing functions that call `process.exit()`, a no-op stub lets execution continue past the exit point, causing false passes. Use a throw-sentinel pattern (e.g., `throw new Error('__EXIT__')`). Independently confirmed by Szabo, Knuth, and Brooks in v1.7.0 review.
+- **Input boundary validation for string-to-path conversions.** v2.0 had two path traversal findings (F-01 adapter name, R-02 MCP filePath). All user-facing strings that become file paths must be validated at the parsing/input boundary — not deeper in the call stack.
 
 ## Overruled Challenges
-<!-- When the human overrules an agent, record why — prevents re-flagging -->
+<\!-- When the human overrules an agent, record why — prevents re-flagging -->
 

--- a/.dev-team/agent-memory/dev-team-borges/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-borges/MEMORY.md
@@ -138,3 +138,11 @@
 - **Outcome**: verified
 - **Last-verified**: 2026-03-30
 - **Context**: Small hotfix — mergeClaudeMd duplicate scaffolding fix. 1 advisory finding (Knuth SUGGESTION, ignored). No new memory entries needed — bumped Last-verified on Knuth's related mergeClaudeMd boundary condition entry. Zero-overrule alert continues at n>=113. No new shared learnings. Proportional extraction for hotfix scope.
+
+### [2026-03-30] v2.0 extraction — 4 PRs, ~35 findings, 4 DEFECTs, major release
+- **Type**: MILESTONE [verified]
+- **Source**: v2.0 multi-runtime portability (#501-#506, #508, #525, PRs #569-#572)
+- **Tags**: metrics, calibration, extraction, major-release, multi-runtime
+- **Outcome**: verified
+- **Last-verified**: 2026-03-30
+- **Context**: First major version release extraction. 4 branches, 4 PRs, ~35 findings across 3 review rounds. 4 DEFECTs (all fixed): path traversal via name (F-01), registerAdapter replacement (F-02), side-effect imports (S2), MCP deriveRequiredAgents divergence (K10). Research-first pattern validated again (2 briefs → 2 ADRs). New entries written: Deming (3), Szabo (3), Knuth (2), Brooks (4), Turing (1), Conway (1). Last-verified bumped on 3 existing entries. 3 new shared learnings: adapter registry design principle, dual code path tech debt, input boundary validation benchmark. Brooks at 185 lines — monitor for next release. All agents remain under 200-line cap.

--- a/.dev-team/agent-memory/dev-team-brooks/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-brooks/MEMORY.md
@@ -24,7 +24,7 @@
 - **Source**: CLAUDE.md + package.json files array
 - **Tags**: architecture, boundaries
 - **Outcome**: verified
-- **Last-verified**: 2026-03-26
+- **Last-verified**: 2026-03-30
 - **Context**: templates/ contains what gets installed in target projects. .dev-team/ contains dev-team's own agents/hooks/skills for dogfooding. Improvements must target templates/ to ship in releases — never modify .dev-team/ for improvements (overwritten by update).
 
 ### [2026-03-25] Agent proliferation governed by ADR-022 — soft cap of 15
@@ -148,6 +148,38 @@
 - **Outcome**: deferred
 - **Last-verified**: 2026-03-29
 - **Context**: Calibration examples directory exists in templates but init/update may not copy it to user projects. Path correctness pattern continues (Seen: 6th instance). Deferred — not blocking, examples are reference material.
+
+### [2026-03-30] v2.0: Adapter registry architecture (ADR-036) — modular multi-runtime support
+- **Type**: DECISION [new]
+- **Source**: #501, PR #569
+- **Tags**: architecture, adapters, multi-runtime, registry-pattern
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-30
+- **Context**: RuntimeAdapter interface (generate + update) with central registry. ClaudeCodeAdapter is identity transform. init.ts and update.ts iterate adapters instead of inline copy logic. Config field `runtimes` (default: `["claude"]`) controls which adapters fire. This is the multi-runtime foundation — adding a new runtime requires only implementing RuntimeAdapter and registering it. No changes to init.ts or update.ts.
+
+### [2026-03-30] v2.0: Side-effect imports fixed with barrel file (S2)
+- **Type**: DEFECT [fixed]
+- **Source**: PR #569, Brooks finding S2
+- **Tags**: architecture, imports, side-effects, barrel-file
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-30
+- **Context**: Initial adapter registration used side-effect imports (import for registration side effect only). Brooks flagged this as violating ADR-036 principle of explicit registration. Fixed: barrel file `src/adapters/index.ts` consolidates all adapter imports. Importing the barrel registers all adapters. Note: init.ts has a duplicate `import "./adapters/index.js"` line that should be cleaned up.
+
+### [2026-03-30] v2.0: MCP server as enforcement portability layer (ADR-037)
+- **Type**: DECISION [new]
+- **Source**: #503, PR #572
+- **Tags**: architecture, mcp, enforcement, portability
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-30
+- **Context**: Hooks are Claude Code-proprietary. MCP is the only cross-runtime enforcement mechanism. Server exposes read-only tools (review_gate first). Zero dependencies per ADR-002. Stdio transport (one server per session). Architectural risk: two code paths for same logic (hook + MCP tool) — must keep in sync. Tool registry pattern allows adding more enforcement tools without modifying server core.
+
+### [2026-03-30] v2.0: Dual code path sync risk — hook vs MCP enforcement
+- **Type**: RISK [accepted]
+- **Source**: PRs #569, #572, ADR-037
+- **Tags**: architecture, code-sync, hooks, mcp, risk
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-30
+- **Context**: review_gate logic now exists in two places: dev-team-review-gate.js (hook) and src/mcp/tools/review-gate.ts (MCP tool). K10 finding showed they had already diverged during initial implementation. Extraction to shared module is the long-term fix but adds complexity. For now, accepted as architectural debt — the two implementations must be tested and reviewed together.
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->

--- a/.dev-team/agent-memory/dev-team-conway/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-conway/MEMORY.md
@@ -115,5 +115,13 @@
 - **Last-verified**: 2026-03-29
 - **Context**: v1.8.0 introduced INFRA_HOOKS (always-installed, non-optional). Release testing must now verify: (1) fresh install includes infra hooks, (2) update adds infra hooks to existing projects, (3) infra hooks don't appear in user-selectable lists. This is a new install surface to validate.
 
+### [2026-03-30] v2.0: Major version — multi-runtime adapter registry + MCP enforcement
+- **Type**: DECISION [new]
+- **Source**: #501-#506, #508, #525, PRs #569-#572
+- **Tags**: release, major, multi-runtime, breaking-change
+- **Outcome**: accepted
+- **Last-verified**: 2026-03-30
+- **Context**: Major version justified by: new `runtimes` config field changes config schema, `--runtime` CLI flag adds new CLI surface, MCP server adds new subcommand (`dev-team mcp`). Not backward-breaking for existing Claude-only installs (default runtime is "claude", adapter is identity transform). 2 ADRs (036, 037), 2 research briefs (#508, #525), 5 adapters, 8 new test files, ~3,300 new lines. 4 DEFECTs fixed during review.
+
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->

--- a/.dev-team/agent-memory/dev-team-deming/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-deming/MEMORY.md
@@ -155,3 +155,27 @@
 - **Outcome**: fixed
 - **Last-verified**: 2026-03-29
 - **Context**: CI improvements: npm ci replaces npm install for reproducible builds, Semgrep SAST added (silent on failure per Brooks — deferred to full enforcement), release workflow parallelized, validate-docs job added. Lint scope extended to tests/ directory (#555). Duplicate hook removed (dev-team-watch-list.js had redundant copy).
+
+### [2026-03-30] v2.0: Canonical format + adapter registry (ADR-036)
+- **Type**: DECISION [new]
+- **Source**: #501, PR #569
+- **Tags**: architecture, adapters, multi-runtime, canonical-format, dx
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-30
+- **Context**: Agent definitions formalized via CanonicalAgentDefinition interface (portable + runtime-specific fields). Adapter registry pattern extracts agent copy logic from init.ts/update.ts. ClaudeCodeAdapter is identity transform — backward compatible. init.ts and update.ts now iterate registered adapters via getAdaptersForRuntimes(). `runtimes` config field + `--runtime` CLI flag control which adapters run. Duplicate `import "./adapters/index.js"` in init.ts noted but not blocking.
+
+### [2026-03-30] v2.0: 5 runtime adapters — agents-md, copilot, codex, cursor, windsurf
+- **Type**: DECISION [new]
+- **Source**: #502, #504, #505, #506, PRs #570, #571
+- **Tags**: adapters, multi-runtime, copilot, codex, cursor, windsurf, agents-md, dx
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-30
+- **Context**: Five adapters registered via barrel file (src/adapters/index.ts). AgentsMd generates single AGENTS.md at root. Copilot generates .github/copilot-instructions.md + per-agent .github/instructions/. Codex generates .agents/AGENTS.md + skills + .codex/config.toml. Cursor generates .cursor/rules/. Windsurf generates .windsurf/rules/. Cursor and Windsurf share identical format (YAML frontmatter with description field). All adapters implement generate() + update() interface.
+
+### [2026-03-30] v2.0: MCP enforcement server (ADR-037)
+- **Type**: DECISION [new]
+- **Source**: #503, PR #572
+- **Tags**: mcp, enforcement, review-gate, multi-runtime, dx
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-30
+- **Context**: JSON-RPC 2.0 over stdio, zero dependencies. Tool registry pattern with review_gate as first tool. Uses agent-patterns.json for file routing (same source as hook). Launched via `npx dev-team mcp`. Read-only: checks state but never mutates. Path traversal guard on filePath input (R-02 fix). Two code paths now exist for review gate: hook (Claude Code) and MCP tool (all runtimes) — sync risk noted in ADR-037.

--- a/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-knuth/MEMORY.md
@@ -141,3 +141,19 @@
 - **Outcome**: fixed
 - **Last-verified**: 2026-03-29
 - **Context**: 5 test coverage issues addressed in single PR. New tests for: init error paths (missing package.json, invalid config), update backup flow, createAgent validation (empty name, missing fields), CLI --help output, hookRemovals integration. Continues the coverage expansion pattern from v1.7.0 (#438) and v1.8.0 (#480).
+
+### [2026-03-30] v2.0: MCP deriveRequiredAgents diverged from hook — FIXED (K10)
+- **Type**: DEFECT [fixed]
+- **Source**: PR #572, Knuth finding K10
+- **Tags**: mcp, review-gate, agent-patterns, code-sync, quality
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-30
+- **Context**: Initial MCP review_gate implementation used hardcoded agent routing instead of loading from agent-patterns.json. This diverged from the hook's approach and would drift as patterns evolve. Fixed: MCP tool now loads and parses agent-patterns.json with proper fallback. This is the dual-code-path sync risk noted in ADR-037 — first instance of the pattern drifting.
+
+### [2026-03-30] v2.0: Comprehensive test suites for canonical format and all adapters
+- **Type**: PATTERN [new]
+- **Source**: PRs #569, #570, #571, #572
+- **Tags**: testing, adapters, canonical, mcp, coverage
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-30
+- **Context**: 8 new test files added: canonical.test.js (264 lines), agents-md-adapter.test.js, copilot-adapter.test.js, codex-adapter.test.js, cursor-adapter.test.js, windsurf-adapter.test.js, mcp-server.test.js, mcp-review-gate.test.js. Total test count now 554 (up from ~430). Each adapter has generate+update tests. MCP tests cover protocol handling, tool dispatch, and review gate logic.

--- a/.dev-team/agent-memory/dev-team-szabo/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-szabo/MEMORY.md
@@ -112,3 +112,27 @@
 - **Outcome**: deferred
 - **Last-verified**: 2026-03-29
 - **Context**: Semgrep SAST added to CI but configured as silent (non-blocking) on failure per Brooks suggestion. Szabo recommended full Semgrep config with custom rules. Deferred — current setup provides visibility without blocking CI. Full enforcement tracked for future hardening pass.
+
+### [2026-03-30] v2.0: Path traversal via adapter name field — FIXED (F-01)
+- **Type**: DEFECT [fixed]
+- **Source**: PR #569, Szabo finding F-01
+- **Tags**: path-traversal, adapters, input-validation, security
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-30
+- **Context**: parseAgentDefinition name field is used to construct file paths in adapters. Unrestricted names like `../../etc/passwd` could write outside target directories. Fixed: regex validation `/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/` added to parseAgentDefinition. Reinforces pattern: all user-facing string-to-path conversions need validation at the parsing boundary.
+
+### [2026-03-30] v2.0: registerAdapter replacement guard — FIXED (F-02)
+- **Type**: DEFECT [fixed]
+- **Source**: PR #569, Szabo finding F-02
+- **Tags**: adapters, registry, security, defense-in-depth
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-30
+- **Context**: registerAdapter allowed replacing built-in adapters with user-registered ones, potentially masking the Claude Code identity transform with a malicious adapter. Fixed: BUILTIN_IDS set prevents replacement of built-in adapters.
+
+### [2026-03-30] v2.0: MCP filePath traversal validation — FIXED (R-02)
+- **Type**: RISK [fixed]
+- **Source**: PR #572, Szabo finding R-02
+- **Tags**: mcp, path-traversal, input-validation, security
+- **Outcome**: fixed
+- **Last-verified**: 2026-03-30
+- **Context**: MCP review_gate tool accepts filePath from MCP client. Without validation, absolute paths or `..` traversals could check files outside the project. Fixed: path.normalize + reject if starts with `..` or is absolute. Same pattern as the adapter name validation (F-01) — validate at the input boundary.

--- a/.dev-team/agent-memory/dev-team-turing/MEMORY.md
+++ b/.dev-team/agent-memory/dev-team-turing/MEMORY.md
@@ -72,15 +72,15 @@
 - **Source**: Issue #264
 - **Tags**: portability, multi-runtime, AGENTS.md, MCP, adapters, standards
 - **Outcome**: brief written to `docs/research/264-agent-runtime-portability-2026-03-29.md`
-- **Last-verified**: 2026-03-29
+- **Last-verified**: 2026-03-30
 - **Calibration**: The agent runtime landscape has two settled standards (AGENTS.md for instructions, MCP for tools) and everything else is fragmented. Hooks, skills, memory, and multi-agent are not standardized — only Claude Code and Codex CLI have hooks, and their formats differ. The hybrid architecture (AGENTS.md core + MCP enforcement + runtime adapters) is the only approach that preserves dev-team's value. Key discovery: AAIF under Linux Foundation (Dec 2025) is the strongest convergence signal — AGENTS.md, MCP, and goose under one roof. Claude Code's non-adoption of AGENTS.md is the largest single portability risk. Runtime-specific formats churn fast (Cursor and Windsurf both deprecated original formats within months).
 
-### [2026-03-29] Standards landscape for coding agent interoperability
+### [2026-03-30] Standards landscape for coding agent interoperability
 - **Type**: CALIBRATION [verified]
 - **Source**: Issue #264 research
 - **Tags**: standards, AAIF, W3C, IETF, A2A, ACP, ANP
 - **Outcome**: completed
-- **Last-verified**: 2026-03-29
+- **Last-verified**: 2026-03-30
 - **Context**: Four agent communication protocols exist (MCP, A2A, ACP, ANP) but only MCP is relevant for coding agents — the others target enterprise orchestration or decentralized networks. W3C and IETF have early-stage work (AI Agent Protocol CG, AIDIP) but nothing targeting coding agent configuration. The AAIF is the only governance body that matters for this space. When researching agent standards, focus on AAIF projects (AGENTS.md, MCP) and skip the enterprise/network protocols unless the question specifically involves agent-to-agent delegation.
 
 ### [2026-03-30] Runtime verification for review step (#525)
@@ -98,6 +98,14 @@
 - **Outcome**: completed
 - **Last-verified**: 2026-03-30
 - **Context**: `skill-recommendations.json` is an underappreciated integration point. Rather than building tool-specific subsystems, dev-team can influence which tools agents have available by recommending skills for detected ecosystems. This is lighter than hooks, cheaper than custom integration code, and respects Claude Code's native skill discovery. For future tool integration questions (linters, formatters, browser tools), consider "add a skill recommendation" before "build a wrapper."
+
+### [2026-03-30] Codex CLI evaluation (#508) — skills transfer well, hooks do not
+- **Type**: RESEARCH [completed]
+- **Source**: Issue #508
+- **Tags**: codex, multi-runtime, adapters, portability, evaluation
+- **Outcome**: brief written to `docs/research/508-codex-cli-evaluation-2026-03-30.md`
+- **Last-verified**: 2026-03-30
+- **Calibration**: Codex CLI has near-identical skill format (~95% transfer rate) but experimental hook system with limited Bash scope (~30% coverage). The recommendation is: adapt skills and instructions fully, skip hooks. Hooks are Claude Code's differentiator — MCP enforcement is the cross-runtime replacement. This research directly shaped the Codex adapter implementation (skills + AGENTS.md, no hooks).
 
 ### [2026-03-26] Research-first approach validated in v1.6.0
 - **Type**: PATTERN [verified]

--- a/.dev-team/config.json
+++ b/.dev-team/config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.11.1",
+  "version": "2.0.0",
   "agents": [
     "Voss",
     "Hamilton",

--- a/.dev-team/metrics.md
+++ b/.dev-team/metrics.md
@@ -198,3 +198,20 @@
 - **Notes**: Small hotfix — mergeClaudeMd duplicate scaffolding fix. 1 advisory finding ignored (guard clarity for newBegin === -1). LIGHT review, 1 round to convergence. Clean fix scope.
 - **[RISK] Zero-overrule alert**: Rolling overrule rate remains 0% at n>=113 in-team findings (v1.2.0 through v1.11.1).
 
+### [2026-03-30] Task: v2.0 multi-runtime portability (#501, #502, #503, #504, #505, #506, #508, #525) — PRs #569, #570, #571, #572
+- **Agents**: implementing: Deming; reviewers: Szabo, Knuth, Brooks; research: Turing; extract: Borges
+- **Rounds**: 1 per branch (4 branches)
+- **Findings**:
+  - Szabo: 2 DEFECT (2 fixed — F-01 path traversal, F-02 registerAdapter), 1 RISK (1 fixed — R-02 MCP filePath), ~5 advisory (accepted/noted)
+  - Knuth: 1 DEFECT (1 fixed — K10 MCP deriveRequiredAgents), ~8 advisory (accepted/noted)
+  - Brooks: 1 DEFECT (1 fixed — S2 side-effect imports), ~12 advisory (accepted/deferred/noted)
+  - Cross-branch: ~5 duplicates merged
+- **Unique findings**: ~35 (after deduplication)
+- **Acceptance rate**: ~75% (estimated — 4 DEFECTs fixed, majority of advisory accepted or noted)
+- **Overrule rate**: 0% (0/~35)
+- **Fix rate (DEFECTs)**: 100% (4/4)
+- **Defer rate (advisory)**: ~15% (YAML quoting, test gap details)
+- **Duration**: single session, 4 branches
+- **Notes**: First MAJOR release. Research-first (Turing #508, #525) → 2 ADRs (036, 037). 5 runtime adapters (claude, agents-md, copilot, codex, cursor, windsurf) + MCP enforcement server. ~3,300 new lines, 8 new test files, 554 total tests. Key architectural patterns: adapter registry (ADR-036), MCP enforcement (ADR-037), canonical format as identity of current format. Dual code path (hook vs MCP) flagged as tech debt. Duplicate import in init.ts noted for cleanup.
+- **[RISK] Zero-overrule alert**: Rolling overrule rate remains 0% at n>=148 in-team findings (v1.2.0 through v2.0). Per research brief #490, healthy adversarial review shows 1-10% overrule rate. Acceptance rate (~75%) is within the healthy band (60-85%).
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-03-30
+
+### BREAKING
+- New `--runtime` flag changes `init` behavior — selects target runtime (claude-code, copilot, codex, cursor, windsurf) during initialization.
+- `runtimes` field added to `config.json` — tracks which runtime adapters are active.
+- Adapter registry replaces inline agent copy logic — agent installation now routes through runtime-specific adapters.
+
+### Added
+- Canonical agent definition format with YAML frontmatter and Markdown body (ADR-036, #501, #569).
+- Adapter registry pattern — pluggable runtime adapters with shared interface (#501, #569).
+- AGENTS.md export adapter — generates consolidated `AGENTS.md` from canonical definitions (#502, #570).
+- GitHub Copilot adapter — translates agent definitions for Copilot CLI consumption (#504, #570).
+- Codex CLI adapter — skills-focused translation for OpenAI Codex CLI (#505, #571).
+- Cursor adapter — agent definitions adapted for Cursor AI runtime (#506, #571).
+- Windsurf adapter — agent definitions adapted for Windsurf runtime (#506, #571).
+- MCP enforcement server with review-gate tool (ADR-037, #503, #572).
+- `npx dev-team mcp` CLI command to start the MCP enforcement server (#503, #572).
+- Barrel file for adapter imports (`src/adapters/index.ts`) (#569).
+- Path traversal validation on adapter file operations (#569).
+- Input boundary validation for adapter registry (#569).
+
+### Research
+- Codex CLI evaluation — capabilities, limitations, and integration strategy (#508, #568).
+- Runtime verification — adapter correctness and cross-runtime consistency (#525, #568).
+- Agent portability across runtimes — design principles for multi-runtime support (#264, #568).
+
+### Internal
+- Closes umbrella issue #264 (Support GitHub Copilot CLI as an agent runtime).
+
 ## [1.11.1] - 2026-03-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "1.11.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fredericboyer/dev-team",
-      "version": "1.11.1",
+      "version": "2.0.0",
       "license": "MIT",
       "bin": {
         "dev-team": "bin/dev-team.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "1.11.1",
+  "version": "2.0.0",
   "description": "Adversarial AI agent team for any project — installs Claude Code agents, hooks, and skills that enforce quality through productive friction",
   "main": "dist/init.js",
   "types": "dist/init.d.ts",


### PR DESCRIPTION
## Summary

- **MAJOR release**: Multi-runtime portability. Introduces canonical agent definition format (ADR-036), adapter registry, and runtime-specific adapters for GitHub Copilot, Codex CLI, Cursor, and Windsurf.
- **MCP enforcement server** with review-gate tool (ADR-037) and `npx dev-team mcp` CLI command.
- **Research**: Codex CLI evaluation, runtime verification, agent portability design principles.

### Breaking changes
- `--runtime` flag changes `init` behavior
- `runtimes` field added to `config.json`
- Adapter registry replaces inline agent copy logic

### PRs included
- #568: Research briefs (Codex CLI + runtime verification)
- #569: Canonical agent format + adapter registry (#501)
- #570: AGENTS.md export + Copilot adapter (#502, #504)
- #571: Codex, Cursor, Windsurf adapters (#505, #506)
- #572: MCP enforcement server prototype (#503)

Closes #264

### Checklist
- [x] Version bumped to 2.0.0 (package.json, package-lock.json, config.json)
- [x] CHANGELOG.md updated with BREAKING/Added/Research/Internal sections
- [x] v2.0 milestone closed
- [x] All 554 tests pass
- [x] Agent memories, learnings, and metrics staged
- [ ] CI green
- [ ] Do NOT tag or publish — handled post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)