### PR TITLE
chore: release v3.0.0

### DIFF
--- a/.dev-team/config.json
+++ b/.dev-team/config.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.2",
+  "version": "3.0.0",
   "agents": [
     "Voss",
     "Hamilton",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fredericboyer/dev-team",
-      "version": "2.0.2",
+      "version": "3.0.0",
       "license": "MIT",
       "bin": {
         "dev-team": "bin/dev-team.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fredericboyer/dev-team",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "Adversarial AI agent team for any project — installs Claude Code agents, hooks, and skills that enforce quality through productive friction",
   "main": "dist/init.js",
   "types": "dist/init.d.ts",


### PR DESCRIPTION
BREAKING: runtime-native directory layout. Agents in .claude/agents/, memory in .claude/agent-memory/, no more symlinks. ADR-038.