### PR TITLE
fix: clean up stale path references, extend validate-docs

### DIFF
--- a/.claude/agent-memory/dev-team-borges/MEMORY.md
+++ b/.claude/agent-memory/dev-team-borges/MEMORY.md
@@ -17,7 +17,7 @@
 - **Tags**: memory, architecture, tiers
 - **Outcome**: verified
 - **Last-verified**: 2026-03-25
-- **Context**: Tier 1 is .claude/rules/dev-team-learnings.md (shared facts, conventions). Tier 2 is .dev-team/agent-memory/*/MEMORY.md (agent-specific calibration). First 200 lines loaded into context. Formal decisions go to docs/adr/. Avoid copying volatile counts into agent memories — derive from source.
+- **Context**: Tier 1 is .claude/rules/dev-team-learnings.md (shared facts, conventions). Tier 2 is .claude/agent-memory/*/MEMORY.md (agent-specific calibration). First 200 lines loaded into context. Formal decisions go to docs/adr/. Avoid copying volatile counts into agent memories — derive from source.
 
 ## System Improvement Log
 

--- a/.claude/agent-memory/dev-team-brooks/MEMORY.md
+++ b/.claude/agent-memory/dev-team-brooks/MEMORY.md
@@ -174,12 +174,12 @@
 - **Context**: Hooks are Claude Code-proprietary. MCP is the only cross-runtime enforcement mechanism. Server exposes read-only tools (review_gate first). Zero dependencies per ADR-002. Stdio transport (one server per session). Architectural risk: two code paths for same logic (hook + MCP tool) — must keep in sync. Tool registry pattern allows adding more enforcement tools without modifying server core.
 
 ### [2026-03-30] v2.0: Dual code path sync risk — hook vs MCP enforcement
-- **Type**: RISK [accepted]
+- **Type**: RISK [removed in v2.0.1]
 - **Source**: PRs #569, #572, ADR-037
 - **Tags**: architecture, code-sync, hooks, mcp, risk
 - **Outcome**: accepted
 - **Last-verified**: 2026-03-30
-- **Context**: review_gate logic now exists in two places: dev-team-review-gate.js (hook) and src/mcp/tools/review-gate.ts (MCP tool). K10 finding showed they had already diverged during initial implementation. Extraction to shared module is the long-term fix but adds complexity. For now, accepted as architectural debt — the two implementations must be tested and reviewed together.
+- **Context**: MCP enforcement server removed in v2.0.1, eliminating the dual code path sync risk. review_gate logic now exists only in dev-team-review-gate.js (hook). The K10 divergence finding validated the risk — removal was the simplest resolution.
 
 ## Calibration Log
 <!-- Challenges accepted/overruled — tunes adversarial intensity over time -->

--- a/.claude/agent-memory/dev-team-deming/MEMORY.md
+++ b/.claude/agent-memory/dev-team-deming/MEMORY.md
@@ -165,17 +165,17 @@
 - **Context**: Agent definitions formalized via CanonicalAgentDefinition interface (portable + runtime-specific fields). Adapter registry pattern extracts agent copy logic from init.ts/update.ts. ClaudeCodeAdapter is identity transform — backward compatible. init.ts and update.ts now iterate registered adapters via getAdaptersForRuntimes(). `runtimes` config field + `--runtime` CLI flag control which adapters run. Duplicate `import "./adapters/index.js"` in init.ts noted but not blocking.
 
 ### [2026-03-30] v2.0: 5 runtime adapters — agents-md, copilot, codex, cursor, windsurf
-- **Type**: DECISION [new]
+- **Type**: DECISION [removed in v2.0.1]
 - **Source**: #502, #504, #505, #506, PRs #570, #571
 - **Tags**: adapters, multi-runtime, copilot, codex, cursor, windsurf, agents-md, dx
 - **Outcome**: fixed
 - **Last-verified**: 2026-03-30
-- **Context**: Five adapters registered via barrel file (src/adapters/index.ts). AgentsMd generates single AGENTS.md at root. Copilot generates .github/copilot-instructions.md + per-agent .github/instructions/. Codex generates .agents/AGENTS.md + skills + .codex/config.toml. Cursor generates .cursor/rules/. Windsurf generates .windsurf/rules/. Cursor and Windsurf share identical format (YAML frontmatter with description field). All adapters implement generate() + update() interface.
+- **Context**: Five adapters registered via barrel file (src/adapters/index.ts). AgentsMd generates single AGENTS.md at root. Copilot generates .github/copilot-instructions.md + per-agent .github/instructions/. Codex generates .agents/AGENTS.md + skills + .codex/config.toml. Cursor and Windsurf adapters removed in v2.0.1. Current adapters: claude, agents-md, copilot, codex. All adapters implement generate() + update() interface.
 
 ### [2026-03-30] v2.0: MCP enforcement server (ADR-037)
-- **Type**: DECISION [new]
+- **Type**: DECISION [removed in v2.0.1]
 - **Source**: #503, PR #572
 - **Tags**: mcp, enforcement, review-gate, multi-runtime, dx
 - **Outcome**: fixed
 - **Last-verified**: 2026-03-30
-- **Context**: JSON-RPC 2.0 over stdio, zero dependencies. Tool registry pattern with review_gate as first tool. Uses agent-patterns.json for file routing (same source as hook). Launched via `npx dev-team mcp`. Read-only: checks state but never mutates. Path traversal guard on filePath input (R-02 fix). Two code paths now exist for review gate: hook (Claude Code) and MCP tool (all runtimes) — sync risk noted in ADR-037.
+- **Context**: MCP enforcement server removed in v2.0.1. Original design: JSON-RPC 2.0 over stdio, zero dependencies. Tool registry pattern with review_gate as first tool. Removed due to scope reduction — hooks remain the primary enforcement mechanism.

--- a/.claude/agent-memory/dev-team-drucker/MEMORY.md
+++ b/.claude/agent-memory/dev-team-drucker/MEMORY.md
@@ -33,7 +33,7 @@
 - **Tags**: orchestration, subagents, spawning
 - **Outcome**: verified
 - **Last-verified**: 2026-03-25
-- **Context**: Must load actual agent definition from .dev-team/agents/dev-team-*.md when spawning. Do NOT use pr-review-toolkit proxies — different behavior. Use subagent_type: "general-purpose".
+- **Context**: Must load actual agent definition from .claude/agents/dev-team-*.agent.md when spawning. Do NOT use pr-review-toolkit proxies — different behavior. Use subagent_type: "general-purpose".
 
 ### [2026-03-26] Sequential chains require merge-as-you-go orchestration
 - **Type**: PATTERN [verified]

--- a/.claude/agent-memory/dev-team-knuth/MEMORY.md
+++ b/.claude/agent-memory/dev-team-knuth/MEMORY.md
@@ -108,7 +108,7 @@
 - **Tags**: path-correctness, skill-definition, merge
 - **Outcome**: fixed
 - **Last-verified**: 2026-03-29
-- **Context**: Merge skill gate logic was updated in .dev-team/skills/ but the .claude/skills/ copy was not staged. Path correctness pattern continues — Seen: 5 times (doctor.ts K1, status.ts K3, review skill path, memory dir deming/, merge skill .claude copy).
+- **Context**: Merge skill gate logic was updated in .claude/skills/ source but the installed copy was not staged. Path correctness pattern continues — Seen: 5 times (doctor.ts K1, status.ts K3, review skill path, memory dir deming/, merge skill .claude copy).
 
 ### [2026-03-29] v1.10.0: Stray commits from shared working directory — bundled wrong commits into PRs
 - **Type**: RISK [accepted]
@@ -156,4 +156,4 @@
 - **Tags**: testing, adapters, canonical, mcp, coverage
 - **Outcome**: fixed
 - **Last-verified**: 2026-03-30
-- **Context**: 8 new test files added: canonical.test.js (264 lines), agents-md-adapter.test.js, copilot-adapter.test.js, codex-adapter.test.js, cursor-adapter.test.js, windsurf-adapter.test.js, mcp-server.test.js, mcp-review-gate.test.js. Total test count now 554 (up from ~430). Each adapter has generate+update tests. MCP tests cover protocol handling, tool dispatch, and review gate logic.
+- **Context**: Test suites added for canonical format and adapters. cursor-adapter.test.js, windsurf-adapter.test.js, mcp-server.test.js, and mcp-review-gate.test.js removed in v2.0.1. Current adapter test files: canonical.test.js, agents-md-adapter.test.js, copilot-adapter.test.js, codex-adapter.test.js. Each adapter has generate+update tests.

--- a/.claude/agent-memory/dev-team-knuth/calibration-examples.md
+++ b/.claude/agent-memory/dev-team-knuth/calibration-examples.md
@@ -4,11 +4,11 @@ Annotated examples of correctly classified findings from this project's review h
 
 ### Example 1: FIXED — Missing gate in .claude copy of merge skill
 
-**Finding:** Merge skill gate logic was updated in .dev-team/skills/ but the .claude/skills/ copy was not staged. The installed copy lacks the new gate check, so users running /merge from .claude/skills/ would bypass the gate.
+**Finding:** Merge skill gate logic was updated in .claude/skills/ source but the installed copy was not staged. The installed copy lacks the new gate check, so users running /merge would bypass the gate.
 **Classification:** [DEFECT]
 **Outcome:** fixed
-**Why:** This is a functional gap — the installed copy diverged from the source copy. Users would hit the ungated path. The fix was to stage and commit the .claude/skills/ copy alongside the .dev-team/skills/ change.
-**Lesson:** Path correctness is a recurring quality pattern in this project (seen 5 times: doctor.ts, status.ts, review skill, memory dir, merge skill .claude copy). Any change to a skill or hook must audit all copies — .dev-team/ source AND .claude/ installed copy. This is the single most common defect class.
+**Why:** This is a functional gap — the installed copy diverged from the source copy. Users would hit the ungated path. The fix was to stage and commit both copies together.
+**Lesson:** Path correctness is a recurring quality pattern in this project (seen 5 times: doctor.ts, status.ts, review skill, memory dir, merge skill .claude copy). Any change to a skill or hook must audit all copies. This is the single most common defect class.
 
 ### Example 2: ACCEPTED — Vocabulary alignment across skill boundaries
 

--- a/.claude/agent-memory/dev-team-turing/MEMORY.md
+++ b/.claude/agent-memory/dev-team-turing/MEMORY.md
@@ -73,7 +73,7 @@
 - **Tags**: portability, multi-runtime, AGENTS.md, MCP, adapters, standards
 - **Outcome**: brief written to `docs/research/264-agent-runtime-portability-2026-03-29.md`
 - **Last-verified**: 2026-03-30
-- **Calibration**: The agent runtime landscape has two settled standards (AGENTS.md for instructions, MCP for tools) and everything else is fragmented. Hooks, skills, memory, and multi-agent are not standardized — only Claude Code and Codex CLI have hooks, and their formats differ. The hybrid architecture (AGENTS.md core + MCP enforcement + runtime adapters) is the only approach that preserves dev-team's value. Key discovery: AAIF under Linux Foundation (Dec 2025) is the strongest convergence signal — AGENTS.md, MCP, and goose under one roof. Claude Code's non-adoption of AGENTS.md is the largest single portability risk. Runtime-specific formats churn fast (Cursor and Windsurf both deprecated original formats within months).
+- **Calibration**: The agent runtime landscape has two settled standards (AGENTS.md for instructions, MCP for tools) and everything else is fragmented. Hooks, skills, memory, and multi-agent are not standardized — only Claude Code and Codex CLI have hooks, and their formats differ. The hybrid architecture (AGENTS.md core + runtime adapters) preserves dev-team's value. MCP enforcement server was removed in v2.0.1 — hooks remain primary. Key discovery: AAIF under Linux Foundation (Dec 2025) is the strongest convergence signal — AGENTS.md, MCP, and goose under one roof. Claude Code's non-adoption of AGENTS.md is the largest single portability risk. Cursor and Windsurf adapters removed in v2.0.1 — format churn validated the risk.
 
 ### [2026-03-30] Standards landscape for coding agent interoperability
 - **Type**: CALIBRATION [verified]
@@ -105,7 +105,7 @@
 - **Tags**: codex, multi-runtime, adapters, portability, evaluation
 - **Outcome**: brief written to `docs/research/508-codex-cli-evaluation-2026-03-30.md`
 - **Last-verified**: 2026-03-30
-- **Calibration**: Codex CLI has near-identical skill format (~95% transfer rate) but experimental hook system with limited Bash scope (~30% coverage). The recommendation is: adapt skills and instructions fully, skip hooks. Hooks are Claude Code's differentiator — MCP enforcement is the cross-runtime replacement. This research directly shaped the Codex adapter implementation (skills + AGENTS.md, no hooks).
+- **Calibration**: Codex CLI has near-identical skill format (~95% transfer rate) but experimental hook system with limited Bash scope (~30% coverage). The recommendation is: adapt skills and instructions fully, skip hooks. Hooks are Claude Code's differentiator. MCP enforcement was removed in v2.0.1 — hooks remain primary enforcement mechanism. This research directly shaped the Codex adapter implementation (skills + AGENTS.md, no hooks).
 
 ### [2026-03-26] Research-first approach validated in v1.6.0
 - **Type**: PATTERN [verified]

--- a/.claude/rules/dev-team-learnings.md
+++ b/.claude/rules/dev-team-learnings.md
@@ -24,7 +24,7 @@
 
 - **Skill composability: orchestration skills can invoke other skills.** /dev-team:extract and /dev-team:review are invoked by /dev-team:task as sub-skills. Use `disable-model-invocation: true` on sub-skills to prevent autonomous firing. The `--embedded` flag signals compact output mode for skill-to-skill invocation. See ADR-035 for the formal pattern.
 - **Don't encode what agents already know.** AI agents have built-in knowledge of languages, frameworks, conventions, and standards. Hardcoding language-specific patterns (test file regex, linter commands, complexity keywords) into hooks or config creates static encyclopedias that are always incomplete. Instead, hooks should detect the ecosystem (read manifest files) and delegate language-specific reasoning to the agent. Include only what agents can't discover: tool preferences, legacy traps, test quirks, custom middleware warnings. (See: "AGENTS.md Verdict" — if the agent can discover it from code, delete it.)
-- **Adapter registry for multi-runtime portability (ADR-036).** Canonical format = current dev-team format. Adapters translate to runtime-native formats. Adding a runtime = implementing RuntimeAdapter + registering it. No changes to init.ts or update.ts. Native runtime hooks (Copilot, Codex) handle enforcement per-runtime.
+- **Adapter registry for multi-runtime portability (ADR-036).** Canonical format = current dev-team format. Adapters translate to runtime-native formats (current adapters: claude, agents-md, copilot, codex). Adding a runtime = implementing RuntimeAdapter + registering it. No changes to init.ts or update.ts.
 
 ## Known Tech Debt
 
@@ -37,7 +37,7 @@
 - Pre-commit gate: blocks commits without memory updates (override via `.dev-team/.memory-reviewed`).
 - **Migration completeness**: Any change that moves/renames files must audit all modules that reference those paths. doctor.ts, status.ts, and skill definitions are recurring victims of path drift (3 instances across v1.5.0–v1.6.0).
 - **process.exit stubs must throw a sentinel error.** When testing functions that call `process.exit()`, a no-op stub lets execution continue past the exit point, causing false passes. Use a throw-sentinel pattern (e.g., `throw new Error('__EXIT__')`). Independently confirmed by Szabo, Knuth, and Brooks in v1.7.0 review.
-- **Input boundary validation for string-to-path conversions.** v2.0 had two path traversal findings (F-01 adapter name, R-02 Copilot hook filePath). All user-facing strings that become file paths must be validated at the parsing/input boundary — not deeper in the call stack.
+- **Input boundary validation for string-to-path conversions.** v2.0 had a path traversal finding (F-01 adapter name). All user-facing strings that become file paths must be validated at the parsing/input boundary — not deeper in the call stack.
 
 ## Overruled Challenges
 <\!-- When the human overrules an agent, record why — prevents re-flagging -->

--- a/.claude/rules/dev-team-process.md
+++ b/.claude/rules/dev-team-process.md
@@ -70,7 +70,7 @@ Background agents can get stuck without producing output. Apply this escalation 
 - Always use `/dev-team:task` for implementation work — dogfood the agents.
 - Don't ask for approval to continue between tasks. Just do the work. Only pause for critical decisions.
 - Follow through to completion without prompting. When auto-merge is set or CI is pending, monitor and complete the next step (tag, release, cleanup) without waiting for the user.
-- Improvements must be project-agnostic and target `templates/`. Most `.dev-team/` files get overwritten by `dev-team update` — exceptions are `process.md`, `learnings.md`, `metrics.md`, and agent memory files (these are preserved). Project-specific conventions stay in local learnings or this process file.
+- Improvements must be project-agnostic and target `templates/`. Most `.dev-team/` files get overwritten by `dev-team update` — exceptions are `metrics.md` (preserved). Agent memory lives in `.claude/agent-memory/`, learnings and process in `.claude/rules/` — these are not overwritten. Project-specific conventions stay in local learnings or this process file.
 - Dogfooding is the product loop: use dev-team on dev-team → surface friction → `/dev-team:retro` captures patterns → issues target `templates/` → next release improves the tool for everyone.
 
 ## Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Adversarial AI agent team for any project. Installs Claude Code agents, hooks, a
 - `tests/` — Unit, integration, and scenario tests
 - `.claude/agents/` — Our own agent definitions (`.agent.md` files, not shipped to users)
 - `.claude/agent-memory/` — Agent calibration memory (not shipped to users)
-- `.dev-team/` — Hooks, skills, config, and metrics (not shipped to users)
+- `.dev-team/` — Hooks, config, metrics, and research (not shipped to users)
 
 ## Workflow
 

--- a/docs/design/harness-assumptions.md
+++ b/docs/design/harness-assumptions.md
@@ -15,7 +15,7 @@ Components in dev-team that compensate for model limitations. Each retro evaluat
 
 - **Assumption:** Models will not write tests without explicit prompting, leading to untested code.
 - **Current status:** Models are significantly better at TDD now and often generate tests unprompted. However, enforcement prevents regression in sessions where the model optimizes for speed over coverage.
-- **Component:** `templates/hooks/dev-team-pre-commit-lint.js` (test coverage check)
+- **Component:** `templates/hooks/dev-team-tdd-enforce.js` (test coverage check)
 - **Last-validated:** 2026-03-29
 
 ### Review gate

--- a/scripts/validate-docs.js
+++ b/scripts/validate-docs.js
@@ -96,7 +96,14 @@ const DEPRECATED_PATHS = [
 ];
 
 // Directories to scan for stale references
-const SCAN_DIRS = ["docs", "templates", ".claude/rules", ".claude/skills"];
+const SCAN_DIRS = [
+  "docs",
+  "templates",
+  ".claude/rules",
+  ".claude/skills",
+  ".claude/agents",
+  ".claude/agent-memory",
+];
 const SCAN_ROOT_FILES = ["CLAUDE.md", "README.md"];
 
 // Files to skip (historical records that legitimately reference old paths)
@@ -105,8 +112,10 @@ const SKIP_PATTERNS = [
   /docs\/adr\//, // ADRs are immutable records
   /CHANGELOG\.md$/, // Changelog is historical
   /metrics\.md$/, // Metrics are historical
-  /agent-memory\//, // Memory files may reference old paths in historical entries
 ];
+
+// Lines matching these patterns are skipped inside agent-memory files
+const MEMORY_LINE_SKIP = /Last-verified|## Archive/;
 
 function shouldSkip(filePath) {
   return SKIP_PATTERNS.some((p) => p.test(filePath));
@@ -114,11 +123,19 @@ function shouldSkip(filePath) {
 
 function scanFileForStalePaths(filePath) {
   const content = fs.readFileSync(filePath, "utf-8");
+  const isMemoryFile = /agent-memory\//.test(filePath);
   for (const dep of DEPRECATED_PATHS) {
-    const matches = content.match(dep.pattern);
-    if (matches) {
+    dep.pattern.lastIndex = 0;
+    const lines = content.split("\n");
+    let matchCount = 0;
+    for (const line of lines) {
+      if (isMemoryFile && MEMORY_LINE_SKIP.test(line)) continue;
+      const lineMatches = line.match(new RegExp(dep.pattern.source, "g"));
+      if (lineMatches) matchCount += lineMatches.length;
+    }
+    if (matchCount > 0) {
       console.error(
-        `FAIL: "${filePath}" has ${matches.length} stale reference(s) to "${dep.pattern.source}" (deprecated since ${dep.since}, use "${dep.replacement}")`,
+        `FAIL: "${filePath}" has ${matchCount} stale reference(s) to "${dep.pattern.source}" (deprecated since ${dep.since}, use "${dep.replacement}")`,
       );
       errors++;
     }


### PR DESCRIPTION
## Summary
- Fix all remaining `.dev-team/agents/`, `.dev-team/agent-memory/`, and `.dev-team/skills/` stale path references across 10 files (agent memory, learnings, process, CLAUDE.md, harness-assumptions)
- Mark v2.0 Cursor/Windsurf/MCP entries as `[removed in v2.0.1]` in Deming, Brooks, Knuth, and Turing agent memory
- Extend `validate-docs.js`: add `.claude/agents` and `.claude/agent-memory` to scan dirs, replace blanket `agent-memory/` skip with narrower line-level skip (only `Last-verified` and `## Archive` lines)
- Fix TDD enforcement component reference in `harness-assumptions.md` (was `pre-commit-lint.js`, should be `tdd-enforce.js`)
- Fix adapter registry entry in learnings (remove MCP reference, list current adapters)
- Fix input validation entry in learnings (remove MCP R-02 reference)
- Fix dogfooding section in process.md (reflect current file locations)

## Test plan
- [x] `npm run build` passes
- [x] `npm run format` clean
- [x] `npm test` — 538 tests, 0 failures
- [x] `node scripts/validate-docs.js` — all docs valid, 6 directories scanned

Generated with Claude Code