### PR TITLE
fix: migration tests and hardening for migrateToV3Layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-03-30
+
+### BREAKING
+- v3 layout migration -- agents move from `.dev-team/agents/` to `.claude/agents/` with `.agent.md` extension; agent-memory moves from `.dev-team/agent-memory/` to `.claude/agent-memory/`; `.dev-team/skills/` removed (skills install directly to `.claude/skills/`).
+
+### Added
+- `migrateToV3Layout` migration -- automatically migrates pre-v3 directory layouts on `dev-team update`.
+- `assertNotSymlink` guards on all `rmSync` calls in v3 layout migration (Szabo F-01).
+- `BUILTIN_IDS` in adapter registry now includes all shipped adapters: claude, copilot, codex, agents-md (Szabo F-03).
+- Tests for `migrateToV3Layout`: happy path, idempotent, partial state, memory migration, symlink cleanup, SHARED.md preserved.
+
+## [2.0.2] - 2026-03-30
+
+### Fixed
+- `BUILTIN_IDS` adapter registry guard now covers all four shipped adapters -- prevents accidental replacement of copilot, codex, and agents-md adapters.
+- `assertNotSymlink` guards added before `rmSync` calls in `migrateToV3Layout` -- prevents symlink-following directory removal.
+
+### Tests
+- 6 new integration tests for `migrateToV3Layout` migration function.
+
 ## [2.0.1] - 2026-03-30
 
 ### Removed

--- a/src/formats/adapters.ts
+++ b/src/formats/adapters.ts
@@ -106,7 +106,7 @@ export class ClaudeCodeAdapter implements RuntimeAdapter {
 
 const registry = new Map<string, RuntimeAdapter>();
 
-const BUILTIN_IDS = new Set(["claude"]);
+const BUILTIN_IDS = new Set(["claude", "copilot", "codex", "agents-md"]);
 
 /**
  * Register a runtime adapter. Replaces any existing adapter with the same id,

--- a/src/update.ts
+++ b/src/update.ts
@@ -401,7 +401,7 @@ function migrateFromClaude(targetDir: string): string[] {
  * Removes .dev-team/learnings.md if .claude/rules/dev-team-learnings.md exists
  * Idempotent — safe to run multiple times.
  */
-function migrateToV3Layout(targetDir: string): string[] {
+export function migrateToV3Layout(targetDir: string): string[] {
   const log: string[] = [];
   const claudeDir = path.join(targetDir, ".claude");
   const devTeamDir = path.join(targetDir, ".dev-team");
@@ -434,6 +434,7 @@ function migrateToV3Layout(targetDir: string): string[] {
     }
     // Clean up old directory
     try {
+      assertNotSymlink(oldAgentsDir);
       fs.rmSync(oldAgentsDir, { recursive: true });
     } catch {
       // best effort
@@ -462,6 +463,7 @@ function migrateToV3Layout(targetDir: string): string[] {
     }
     // Clean up old directory
     try {
+      assertNotSymlink(oldMemoryDir);
       fs.rmSync(oldMemoryDir, { recursive: true });
     } catch {
       // best effort
@@ -472,6 +474,7 @@ function migrateToV3Layout(targetDir: string): string[] {
   const oldSkillsDir = path.join(devTeamDir, "skills");
   if (dirExists(oldSkillsDir)) {
     try {
+      assertNotSymlink(oldSkillsDir);
       fs.rmSync(oldSkillsDir, { recursive: true });
       log.push("Removed .dev-team/skills/ (skills now in .claude/skills/)");
     } catch {

--- a/tests/integration/update.test.js
+++ b/tests/integration/update.test.js
@@ -7,7 +7,12 @@ const path = require("path");
 const os = require("os");
 
 const { run } = require("../../dist/init");
-const { update, compareSemver, cleanupLegacyMemoryDirs } = require("../../dist/update");
+const {
+  update,
+  compareSemver,
+  cleanupLegacyMemoryDirs,
+  migrateToV3Layout,
+} = require("../../dist/update");
 const { removeHooksFromSettings } = require("../../dist/files");
 
 let tmpDir;
@@ -825,6 +830,142 @@ describe("cleanupLegacyMemoryDirs", () => {
     await update(tmpDir);
 
     assert.ok(!fs.existsSync(legacyDir), "legacy directory should be cleaned up during update");
+  });
+});
+
+describe("migrateToV3Layout", () => {
+  it("migrates agents from .dev-team/agents/ to .claude/agents/ with rename", async () => {
+    await run(tmpDir, ["--all"]);
+    const oldAgentsDir = path.join(tmpDir, ".dev-team", "agents");
+    fs.mkdirSync(oldAgentsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(oldAgentsDir, "dev-team-voss.md"),
+      "---\nname: dev-team-voss\n---\n# Voss agent definition",
+    );
+    const newAgentPath = path.join(tmpDir, ".claude", "agents", "dev-team-voss.agent.md");
+    fs.unlinkSync(newAgentPath);
+    const log = migrateToV3Layout(tmpDir);
+    assert.ok(
+      fs.existsSync(newAgentPath),
+      "agent should be at .claude/agents/dev-team-voss.agent.md",
+    );
+    const content = fs.readFileSync(newAgentPath, "utf-8");
+    assert.ok(content.includes("Voss agent definition"), "content should be preserved");
+    assert.ok(!fs.existsSync(oldAgentsDir), ".dev-team/agents/ should be removed");
+    assert.ok(
+      log.some((l) => l.includes("Migrated") && l.includes("agents")),
+      "should log agent migration",
+    );
+  });
+
+  it("is idempotent -- running twice produces same result", async () => {
+    await run(tmpDir, ["--all"]);
+    const oldAgentsDir = path.join(tmpDir, ".dev-team", "agents");
+    fs.mkdirSync(oldAgentsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(oldAgentsDir, "dev-team-voss.md"),
+      "---\nname: dev-team-voss\n---\n# Voss",
+    );
+    const newAgentPath = path.join(tmpDir, ".claude", "agents", "dev-team-voss.agent.md");
+    fs.unlinkSync(newAgentPath);
+    migrateToV3Layout(tmpDir);
+    const firstContent = fs.readFileSync(newAgentPath, "utf-8");
+    const log2 = migrateToV3Layout(tmpDir);
+    const secondContent = fs.readFileSync(newAgentPath, "utf-8");
+    assert.equal(firstContent, secondContent, "content should be identical after second run");
+    assert.ok(
+      !log2.some((l) => l.includes("Migrated") && l.includes("agents")),
+      "second run should not re-migrate agents",
+    );
+  });
+
+  it("handles partial state -- some agents already in .claude/agents/", async () => {
+    await run(tmpDir, ["--all"]);
+    const oldAgentsDir = path.join(tmpDir, ".dev-team", "agents");
+    fs.mkdirSync(oldAgentsDir, { recursive: true });
+    const newMoriPath = path.join(tmpDir, ".claude", "agents", "dev-team-mori.agent.md");
+    fs.unlinkSync(newMoriPath);
+    fs.writeFileSync(
+      path.join(oldAgentsDir, "dev-team-mori.md"),
+      "---\nname: dev-team-mori\n---\n# Mori old",
+    );
+    fs.writeFileSync(
+      path.join(oldAgentsDir, "dev-team-voss.md"),
+      "---\nname: dev-team-voss\n---\n# Voss OLD -- should not overwrite",
+    );
+    migrateToV3Layout(tmpDir);
+    const vossContent = fs.readFileSync(
+      path.join(tmpDir, ".claude", "agents", "dev-team-voss.agent.md"),
+      "utf-8",
+    );
+    assert.ok(
+      !vossContent.includes("should not overwrite"),
+      "existing agent should not be overwritten",
+    );
+    assert.ok(fs.existsSync(newMoriPath), "mori should be migrated");
+    const moriContent = fs.readFileSync(newMoriPath, "utf-8");
+    assert.ok(moriContent.includes("Mori old"), "migrated mori should have old content");
+  });
+
+  it("migrates agent-memory from .dev-team/agent-memory/ to .claude/agent-memory/", async () => {
+    await run(tmpDir, ["--all"]);
+    const oldMemoryDir = path.join(tmpDir, ".dev-team", "agent-memory", "dev-team-voss");
+    fs.mkdirSync(oldMemoryDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(oldMemoryDir, "MEMORY.md"),
+      "# Voss Memory\nCustom calibration data here.",
+    );
+    const newMemoryDir = path.join(tmpDir, ".claude", "agent-memory", "dev-team-voss");
+    fs.rmSync(newMemoryDir, { recursive: true });
+    const log = migrateToV3Layout(tmpDir);
+    const memoryPath = path.join(newMemoryDir, "MEMORY.md");
+    assert.ok(fs.existsSync(memoryPath), "memory should be at .claude/agent-memory/");
+    const content = fs.readFileSync(memoryPath, "utf-8");
+    assert.ok(content.includes("Custom calibration data"), "memory content should be preserved");
+    assert.ok(
+      !fs.existsSync(path.join(tmpDir, ".dev-team", "agent-memory")),
+      ".dev-team/agent-memory/ should be removed",
+    );
+    assert.ok(
+      log.some((l) => l.includes("memory")),
+      "should log memory migration",
+    );
+  });
+
+  it("removes .claude/skills/ symlinks pointing to .dev-team/skills/", async () => {
+    await run(tmpDir, ["--all"]);
+    const claudeSkillsDir = path.join(tmpDir, ".claude", "skills");
+    const fakeTarget = path.join(tmpDir, ".dev-team", "skills", "dev-team-challenge");
+    fs.mkdirSync(fakeTarget, { recursive: true });
+    fs.writeFileSync(path.join(fakeTarget, "SKILL.md"), "# skill");
+    const symlinkPath = path.join(claudeSkillsDir, "dev-team-fake-symlink");
+    fs.symlinkSync(fakeTarget, symlinkPath);
+    const log = migrateToV3Layout(tmpDir);
+    assert.ok(!fs.existsSync(symlinkPath), "symlink to .dev-team/skills/ should be removed");
+    assert.ok(
+      log.some((l) => l.includes("stale symlink")),
+      "should log symlink removal",
+    );
+  });
+
+  it("preserves non-agent .md files (SHARED.md) without rename", async () => {
+    await run(tmpDir, ["--all"]);
+    const oldAgentsDir = path.join(tmpDir, ".dev-team", "agents");
+    fs.mkdirSync(oldAgentsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(oldAgentsDir, "SHARED.md"),
+      "# Shared Agent Protocol\nShared instructions here.",
+    );
+    const destPath = path.join(tmpDir, ".claude", "agents", "SHARED.md");
+    if (fs.existsSync(destPath)) fs.unlinkSync(destPath);
+    migrateToV3Layout(tmpDir);
+    assert.ok(fs.existsSync(destPath), "SHARED.md should be migrated without rename");
+    assert.ok(
+      !fs.existsSync(path.join(tmpDir, ".claude", "agents", "SHARED.agent.md")),
+      "SHARED.md should NOT be renamed to SHARED.agent.md",
+    );
+    const content = fs.readFileSync(destPath, "utf-8");
+    assert.ok(content.includes("Shared instructions"), "SHARED.md content should be preserved");
   });
 });
 


### PR DESCRIPTION
## Summary
- Add 6 integration tests for `migrateToV3Layout`: happy path agent migration, idempotency, partial state handling, agent-memory migration, symlink cleanup, and SHARED.md preservation
- Add `assertNotSymlink` guards before all `rmSync` calls in `migrateToV3Layout` (Szabo F-01) to prevent symlink-following directory removal
- Update `BUILTIN_IDS` to include all shipped adapters: claude, copilot, codex, agents-md (Szabo F-03)
- Add missing v2.0.2 and v3.0.0 CHANGELOG entries

## Test plan
- [x] All 6 new `migrateToV3Layout` tests pass
- [x] Full test suite passes (544 tests, 0 failures)
- [x] `npm run build` succeeds
- [x] `npm run format` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)