### PR TITLE
feat: Codex adapter generates native agents, hooks, rules, memory (fixes #593)

### DIFF
--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -77,7 +77,7 @@ export function buildHooksConfig(): CodexHooksConfig {
           matchers: ["bash", "shell", "terminal"],
           hooks: [
             {
-              command: 'node .dev-team/hooks/dev-team-safety-guard.js "$TOOL_NAME" "$TOOL_INPUT"',
+              command: "node .dev-team/hooks/dev-team-safety-guard.js",
               description: "Safety guard",
             },
           ],
@@ -98,12 +98,11 @@ export function buildHooksConfig(): CodexHooksConfig {
           matchers: ["edit_file", "write_file", "insert_code"],
           hooks: [
             {
-              command: 'node .dev-team/hooks/dev-team-tdd-enforce.js "$TOOL_NAME" "$TOOL_INPUT"',
+              command: "node .dev-team/hooks/dev-team-tdd-enforce.js",
               description: "TDD enforcement",
             },
             {
-              command:
-                'node .dev-team/hooks/dev-team-post-change-review.js "$TOOL_NAME" "$TOOL_INPUT"',
+              command: "node .dev-team/hooks/dev-team-post-change-review.js",
               description: "Post-change review",
             },
           ],
@@ -208,10 +207,12 @@ export class CodexAdapter implements RuntimeAdapter {
   }
 
   private genRules(codexDir: string): void {
+    const rulesPath = path.join(codexDir, "rules", "dev-team-learnings.md");
+    if (fileExists(rulesPath)) return;
     const src = path.join(templateDir(), "rules", "dev-team-learnings.md");
     const content = readFile(src);
     writeFile(
-      path.join(codexDir, "rules", "dev-team-learnings.md"),
+      rulesPath,
       content || "# Shared Team Learnings\n\nAdd project-specific learnings here.\n",
     );
   }

--- a/tests/unit/codex-adapter.test.js
+++ b/tests/unit/codex-adapter.test.js
@@ -146,6 +146,15 @@ describe("CodexAdapter", () => {
     assert.ok(fs.existsSync(path.join(tmpDir, ".codex", "hooks.json")));
     assert.ok(fs.existsSync(path.join(tmpDir, ".codex", "rules", "dev-team-learnings.md")));
   });
+
+  it("generate() does not overwrite existing learnings rules", () => {
+    const rp = path.join(tmpDir, ".codex", "rules", "dev-team-learnings.md");
+    fs.mkdirSync(path.dirname(rp), { recursive: true });
+    fs.writeFileSync(rp, "# Custom learnings\nUser-specific content.\n");
+    new CodexAdapter().generate(SAMPLE_DEFS, tmpDir);
+    const content = fs.readFileSync(rp, "utf-8");
+    assert.ok(content.includes("User-specific content"), "existing learnings should be preserved");
+  });
 });
 
 describe("renderAgentToml", () => {


### PR DESCRIPTION
## Summary
- Full rewrite of the Codex adapter to generate native `.codex/` configuration instead of `.agents/`
- Generates `.codex/agents/*.toml` files with TOML-native agent definitions (name, description, developer_instructions, optional model)
- Generates `.codex/hooks.json` mapping dev-team hooks to Codex PreToolUse/PostToolUse events
- Generates `.codex/rules/dev-team-learnings.md` for shared team learnings
- Generates `.codex/agent-memory/*/MEMORY.md` per-agent calibration memory (user-owned, never overwritten)
- Skills moved from `.agents/skills/` to `.codex/skills/`
- Claude Code-specific references (Agent tool, subagent_type, run_in_background) stripped from agent instruction bodies

## Test plan
- [x] All 558 existing tests pass (0 failures)
- [x] 28 codex-specific tests covering TOML generation, hooks config, rules, memory, update tracking, skills, and openai.yaml
- [x] npm run build compiles cleanly
- [x] npm run format passes

Closes #593

Generated with Claude Code