### PR TITLE
feat: Copilot adapter generates native agents, skills, memory, learnings

### DIFF
--- a/src/adapters/copilot.ts
+++ b/src/adapters/copilot.ts
@@ -46,10 +46,6 @@ export function adaptAgentBody(body: string): string {
   adapted = adapted.replace(/\.claude\/agents\//g, ".github/agents/");
   adapted = adapted.replace(/\.claude\/agent-memory\//g, ".github/agent-memory/");
   adapted = adapted.replace(
-    /`\.claude\/agents\/([^`]+)\.agent\.md`/g,
-    "`.github/agents/$1.agent.md`",
-  );
-  adapted = adapted.replace(
     /Write status to `\.dev-team\/agent-status\/[^`]+`[^.]*\./g,
     "Report progress via status messages.",
   );
@@ -118,7 +114,7 @@ export function adaptSkillContent(content: string): string {
   const [, yaml, body] = match;
   const filteredLines = yaml
     .split("\n")
-    .filter((line) => !line.trim().startsWith("disable-model-invocation"));
+    .filter((line) => !line.trimStart().startsWith("disable-model-invocation:"));
   return `---\n${filteredLines.join("\n")}\n---\n${body}`;
 }
 
@@ -308,15 +304,11 @@ export class CopilotAdapter implements RuntimeAdapter {
 
   /**
    * Updates .github/agents/*.agent.md during update().
-   * Always writes latest content — change tracking is handled by
+   * Delegates to generateAgents() — change tracking is handled by
    * instruction file comparison in the caller.
    */
   private updateAgents(definitions: CanonicalAgentDefinition[], targetDir: string): void {
-    const agentsDir = path.join(targetDir, ".github", "agents");
-    for (const def of definitions) {
-      const agentPath = path.join(agentsDir, `${def.name}.agent.md`);
-      writeFile(agentPath, renderCopilotAgent(def));
-    }
+    this.generateAgents(definitions, targetDir);
   }
 
   /**
@@ -328,12 +320,7 @@ export class CopilotAdapter implements RuntimeAdapter {
     const skillsSrcDir = path.join(templateDir(), "skills");
     const skillsDestDir = path.join(targetDir, ".github", "skills");
 
-    let skillDirs: string[];
-    try {
-      skillDirs = listSubdirectories(skillsSrcDir);
-    } catch {
-      return;
-    }
+    const skillDirs = listSubdirectories(skillsSrcDir);
 
     for (const skillDir of skillDirs) {
       const srcPath = path.join(skillsSrcDir, skillDir, "SKILL.md");

--- a/tests/unit/copilot-adapter.test.js
+++ b/tests/unit/copilot-adapter.test.js
@@ -214,14 +214,13 @@ describe("CopilotAdapter", () => {
     assert.ok(skillDirs.length > 0, "should have at least one skill");
 
     const taskSkillPath = path.join(skillsDir, "dev-team-task", "SKILL.md");
-    if (fs.existsSync(taskSkillPath)) {
-      const content = fs.readFileSync(taskSkillPath, "utf-8");
-      assert.ok(content.includes("---"), "skill should have frontmatter");
-      assert.ok(
-        !content.includes("disable-model-invocation"),
-        "should strip disable-model-invocation from skill frontmatter",
-      );
-    }
+    assert.ok(fs.existsSync(taskSkillPath), "task skill SKILL.md should exist");
+    const content = fs.readFileSync(taskSkillPath, "utf-8");
+    assert.ok(content.includes("---"), "skill should have frontmatter");
+    assert.ok(
+      !content.includes("disable-model-invocation"),
+      "should strip disable-model-invocation from skill frontmatter",
+    );
   });
 
   it("update() creates skill files", () => {


### PR DESCRIPTION
## Summary
- Full rewrite of the Copilot adapter to generate all native Copilot artifacts beyond hooks and instructions
- Generates `.github/agents/*.agent.md` with YAML frontmatter, mapped tool names (Claude Code -> Copilot), and adapted body text
- Generates `.github/skills/*/SKILL.md` from templates, stripping `disable-model-invocation` (agent-level in Copilot)
- Creates `.github/agent-memory/*/MEMORY.md` directories (preserved on update, never overwritten)
- Creates `.github/instructions/dev-team-learnings.instructions.md` with `applyTo: "**"` frontmatter
- Adds `mapTools()`, `adaptAgentBody()`, `adaptSkillContent()` exported utilities
- 27 new tests covering all generation methods and utility functions

Closes #592

## Test plan
- [x] All 565 tests pass (538 existing + 27 new)
- [x] npm run build succeeds
- [x] npm run format clean
- [ ] CI passes

Generated with Claude Code