### PR TITLE
fix: address Copilot review findings from PRs #594 and #596

### DIFF
--- a/scripts/validate-docs.js
+++ b/scripts/validate-docs.js
@@ -123,9 +123,8 @@ function shouldSkip(filePath) {
 
 function scanFileForStalePaths(filePath) {
   const content = fs.readFileSync(filePath, "utf-8");
-  const isMemoryFile = /agent-memory\//.test(filePath);
+  const isMemoryFile = /agent-memory[\\/]/.test(filePath.replace(/\\/g, "/"));
   for (const dep of DEPRECATED_PATHS) {
-    dep.pattern.lastIndex = 0;
     const lines = content.split("\n");
     let matchCount = 0;
     for (const line of lines) {

--- a/src/update.ts
+++ b/src/update.ts
@@ -435,6 +435,7 @@ export function migrateToV3Layout(targetDir: string): string[] {
     // Clean up old directory
     try {
       assertNotSymlink(oldAgentsDir);
+      assertNoSymlinkInPath(oldAgentsDir);
       fs.rmSync(oldAgentsDir, { recursive: true });
     } catch {
       // best effort
@@ -464,6 +465,7 @@ export function migrateToV3Layout(targetDir: string): string[] {
     // Clean up old directory
     try {
       assertNotSymlink(oldMemoryDir);
+      assertNoSymlinkInPath(oldMemoryDir);
       fs.rmSync(oldMemoryDir, { recursive: true });
     } catch {
       // best effort
@@ -475,6 +477,7 @@ export function migrateToV3Layout(targetDir: string): string[] {
   if (dirExists(oldSkillsDir)) {
     try {
       assertNotSymlink(oldSkillsDir);
+      assertNoSymlinkInPath(oldSkillsDir);
       fs.rmSync(oldSkillsDir, { recursive: true });
       log.push("Removed .dev-team/skills/ (skills now in .claude/skills/)");
     } catch {

--- a/tests/unit/canonical.test.js
+++ b/tests/unit/canonical.test.js
@@ -249,6 +249,59 @@ describe("adapter registry", () => {
 
     assert.throws(() => registerAdapter(fakeAdapter), /Cannot replace built-in adapter "claude"/);
   });
+
+  it("registerAdapter throws when replacing built-in copilot adapter", () => {
+    // First registration succeeds (reserves the slot)
+    const copilotAdapter = {
+      id: "copilot",
+      name: "Copilot",
+      generate() {},
+      update() {
+        return { updated: [], added: [] };
+      },
+    };
+    registerAdapter(copilotAdapter);
+    assert.equal(getAdapter("copilot").name, "Copilot");
+
+    // Second registration must throw
+    assert.throws(
+      () => registerAdapter(copilotAdapter),
+      /Cannot replace built-in adapter "copilot"/,
+    );
+  });
+
+  it("registerAdapter throws when replacing built-in codex adapter", () => {
+    const codexAdapter = {
+      id: "codex",
+      name: "Codex",
+      generate() {},
+      update() {
+        return { updated: [], added: [] };
+      },
+    };
+    registerAdapter(codexAdapter);
+    assert.equal(getAdapter("codex").name, "Codex");
+
+    assert.throws(() => registerAdapter(codexAdapter), /Cannot replace built-in adapter "codex"/);
+  });
+
+  it("registerAdapter throws when replacing built-in agents-md adapter", () => {
+    const agentsMdAdapter = {
+      id: "agents-md",
+      name: "AGENTS.md",
+      generate() {},
+      update() {
+        return { updated: [], added: [] };
+      },
+    };
+    registerAdapter(agentsMdAdapter);
+    assert.equal(getAdapter("agents-md").name, "AGENTS.md");
+
+    assert.throws(
+      () => registerAdapter(agentsMdAdapter),
+      /Cannot replace built-in adapter "agents-md"/,
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **validate-docs.js**: Normalized paths in `isMemoryFile` check for Windows compatibility (backslash handling)
- **validate-docs.js**: Removed dead `dep.pattern.lastIndex = 0` reset (new RegExp per line makes it pointless)
- **update.ts**: Added `assertNoSymlinkInPath()` to all 3 `rmSync` calls for old agents, memory, and skills directories (ancestor symlink bypass guard)
- **canonical.test.js**: Added tests verifying all 4 BUILTIN_IDS adapters (claude, copilot, codex, agents-md) cannot be replaced

## Test plan
- [x] All 547 tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Format clean (`npm run format`)
- [ ] Verify new BUILTIN_IDS tests cover the register-then-replace pattern for copilot, codex, and agents-md

Closes the 6 Copilot findings from PRs #594 and #596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)