### PR TITLE
feat: complete agent routing table in task skill

### DIFF
--- a/.claude/skills/dev-team-task/SKILL.md
+++ b/.claude/skills/dev-team-task/SKILL.md
@@ -19,6 +19,9 @@ Start a task loop for: $ARGUMENTS
    - Tooling/config -> @dev-team-deming
    - Documentation -> @dev-team-tufte
    - Release/versioning -> @dev-team-conway
+   - Infrastructure/CI/Docker/deployment -> @dev-team-hamilton
+
+   For tasks that require **research/investigation** before implementation, optionally spawn @dev-team-turing as a pre-implementation research agent before selecting the implementing agent above. Turing is read-only — it produces research briefs, not code changes.
 
 3. **Architect pre-assessment** (skip for bug fixes, typo fixes, config tweaks):
    Spawn @dev-team-brooks to assess:

--- a/templates/skills/dev-team-task/SKILL.md
+++ b/templates/skills/dev-team-task/SKILL.md
@@ -20,7 +20,8 @@ Start a task loop for: $ARGUMENTS
    - Documentation -> @dev-team-tufte
    - Release/versioning -> @dev-team-conway
    - Infrastructure/CI/Docker/deployment -> @dev-team-hamilton
-   - Research/investigation -> @dev-team-turing
+
+   For tasks that require **research/investigation** before implementation, optionally spawn @dev-team-turing as a pre-implementation research agent before selecting the implementing agent above. Turing is read-only — it produces research briefs, not code changes.
 
 3. **Architect pre-assessment** (skip for bug fixes, typo fixes, config tweaks):
    Spawn @dev-team-brooks to assess:


### PR DESCRIPTION
## Summary

- Add Hamilton (infrastructure/CI/Docker/deployment) and Turing (research/investigation) to the implementing agent routing table in the task skill
- Excludes Szabo, Knuth, Brooks, Borges, Rams, and Drucker as they are reviewers/auditors/orchestrators, not implementers

Closes #597

## Test plan

- [x] Verified pre-existing test failures are unrelated (hooks.test.js, prompts.test.js fail on main too)
- [ ] Confirm routing table entries match agent definitions in `.claude/agents/`