### PR TITLE
fix: add path traversal validation to worktree hook base_path

### DIFF
--- a/templates/hooks/dev-team-worktree-create.js
+++ b/templates/hooks/dev-team-worktree-create.js
@@ -34,7 +34,18 @@ try {
   process.exit(1);
 }
 
-const basePath = input.base_path || process.cwd();
+const projectRoot = process.cwd();
+let basePath = input.base_path || projectRoot;
+
+// Validate base_path: resolve to absolute, reject path traversal (fixes #617)
+basePath = path.resolve(basePath);
+if (!basePath.startsWith(projectRoot + path.sep) && basePath !== projectRoot) {
+  process.stderr.write(
+    `[dev-team worktree-create] base_path "${input.base_path}" resolves outside project root, falling back to cwd\n`,
+  );
+  basePath = projectRoot;
+}
+
 const worktreeName = input.worktree_name;
 const branchName = input.branch_name;
 

--- a/tests/unit/hooks.test.js
+++ b/tests/unit/hooks.test.js
@@ -1864,11 +1864,15 @@ describe("dev-team-worktree-create", () => {
   it("creates worktree on first try (no lock contention)", () => {
     initGitRepo(tmpDir);
     const worktreeName = "test-wt-" + Date.now();
-    const result = runWorktreeHook(hook, {
-      base_path: tmpDir,
-      worktree_name: worktreeName,
-      branch_name: "test-branch-" + Date.now(),
-    });
+    const result = runWorktreeHook(
+      hook,
+      {
+        base_path: tmpDir,
+        worktree_name: worktreeName,
+        branch_name: "test-branch-" + Date.now(),
+      },
+      { cwd: tmpDir },
+    );
     assert.equal(result.code, 0, `Expected exit 0, stderr: ${result.stderr}`);
     const expectedPath = path.join(tmpDir, ".claude", "worktrees", worktreeName);
     assert.equal(result.stdout.trim(), expectedPath);
@@ -1884,11 +1888,15 @@ describe("dev-team-worktree-create", () => {
     fs.utimesSync(lockDir, staleTime, staleTime);
 
     const worktreeName = "test-wt-retry-" + Date.now();
-    const result = runWorktreeHook(hook, {
-      base_path: tmpDir,
-      worktree_name: worktreeName,
-      branch_name: "test-branch-retry-" + Date.now(),
-    });
+    const result = runWorktreeHook(
+      hook,
+      {
+        base_path: tmpDir,
+        worktree_name: worktreeName,
+        branch_name: "test-branch-retry-" + Date.now(),
+      },
+      { cwd: tmpDir },
+    );
     assert.equal(
       result.code,
       0,
@@ -1906,11 +1914,15 @@ describe("dev-team-worktree-create", () => {
     fs.utimesSync(lockDir, staleTime, staleTime);
 
     const worktreeName = "test-wt-stale-" + Date.now();
-    const result = runWorktreeHook(hook, {
-      base_path: tmpDir,
-      worktree_name: worktreeName,
-      branch_name: "test-branch-stale-" + Date.now(),
-    });
+    const result = runWorktreeHook(
+      hook,
+      {
+        base_path: tmpDir,
+        worktree_name: worktreeName,
+        branch_name: "test-branch-stale-" + Date.now(),
+      },
+      { cwd: tmpDir },
+    );
     assert.equal(result.code, 0, `Stale lock should be cleaned up, stderr: ${result.stderr}`);
     // Lock should be released after hook completes
     assert.ok(!fs.existsSync(lockDir), "Lock should be released after hook completes");
@@ -1933,7 +1945,7 @@ describe("dev-team-worktree-create", () => {
         worktree_name: "test-wt-timeout",
         branch_name: "test-branch-timeout",
       },
-      { timeout: 5000 },
+      { timeout: 5000, cwd: tmpDir },
     );
     assert.notEqual(result.code, 0, "Should not succeed when lock is held");
     // Clean up the lock
@@ -1945,18 +1957,37 @@ describe("dev-team-worktree-create", () => {
   });
 
   it("exits 1 when worktree_name is missing", () => {
-    const result = runWorktreeHook(hook, { base_path: tmpDir });
+    const result = runWorktreeHook(hook, { base_path: tmpDir }, { cwd: tmpDir });
     assert.equal(result.code, 1);
     assert.ok(result.stderr.includes("Missing worktree_name"));
   });
 
   it("exits 1 when basePath has no .git directory (#537)", () => {
-    const result = runWorktreeHook(hook, {
-      base_path: tmpDir,
-      worktree_name: "test-wt",
-    });
+    const result = runWorktreeHook(
+      hook,
+      {
+        base_path: tmpDir,
+        worktree_name: "test-wt",
+      },
+      { cwd: tmpDir },
+    );
     assert.equal(result.code, 1);
     assert.ok(result.stderr.includes(".git directory"));
+  });
+
+  it("falls back to cwd when base_path traverses outside project root (#617)", () => {
+    const result = runWorktreeHook(
+      hook,
+      {
+        base_path: "/tmp/../etc",
+        worktree_name: "test-wt",
+      },
+      { cwd: tmpDir },
+    );
+    assert.ok(
+      result.stderr.includes("resolves outside project root"),
+      "Should warn about path traversal",
+    );
   });
 
   it("exits 1 on malformed JSON input", () => {


### PR DESCRIPTION
## Summary

- Add `path.resolve()` + project root boundary check to `base_path` in `dev-team-worktree-create.js` — falls back to `process.cwd()` with a warning if the resolved path escapes the project root
- Update all existing worktree-create tests to set `cwd: tmpDir` so `process.cwd()` matches the test's `base_path`
- Add new test: path traversal detection (`/tmp/../etc` triggers fallback warning)

Closes #617

## Test plan

- [x] All 155 hook tests pass (including 7 worktree-create tests)
- [x] New traversal test verifies warning message on `../` escape
- [x] Existing worktree creation, lock, and validation tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)