### PR TITLE
feat: add validate-readme and validate-docs to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,12 @@ jobs:
       - name: Validate hooks
         run: node scripts/validate-hooks.js
 
+      - name: Validate README
+        run: node scripts/validate-readme.js
+
+      - name: Validate docs
+        run: node scripts/validate-docs.js
+
   publish:
     needs: [validate-version, test, lint, format, validate]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `validate-readme.js` and `validate-docs.js` steps to the release pipeline's `validate` job
- Aligns release validation with CI pipeline coverage (which already runs all four validators)

Closes #618

## Test plan
- [ ] Verify release.yml syntax is valid
- [ ] Confirm all four validate scripts exist in `scripts/`
- [ ] CI passes on this branch

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>