### PR TITLE
feat: validate agent-patterns.json regex with safeRegex

### DIFF
--- a/.dev-team/hooks/lib/agent-patterns.js
+++ b/.dev-team/hooks/lib/agent-patterns.js
@@ -13,16 +13,20 @@
 
 const fs = require("fs");
 const path = require("path");
+const { safeRegex } = require("./safe-regex");
 
 /**
  * Compile a pattern entry from the JSON into a RegExp.
  * Entries are either a string (no flags) or [source, flags].
  */
 function compilePattern(entry) {
-  if (Array.isArray(entry)) {
-    return new RegExp(entry[0], entry[1] || "");
+  const source = Array.isArray(entry) ? entry[0] : entry;
+  const flags = Array.isArray(entry) ? entry[1] || "" : undefined;
+  const check = safeRegex(source);
+  if (check.safe === false) {
+    return null;
   }
-  return new RegExp(entry);
+  return flags !== undefined ? new RegExp(source, flags) : check.regex;
 }
 
 /**
@@ -39,14 +43,42 @@ function loadPatterns() {
   const result = {};
   for (const [key, value] of Object.entries(data)) {
     if (value.patterns) {
+      const compiled = [];
+      for (const p of value.patterns) {
+        const re = compilePattern(p);
+        if (re === null) {
+          const src = Array.isArray(p) ? p[0] : p;
+          const check = safeRegex(src);
+          console.error(
+            '[dev-team] skipping unsafe pattern in "' +
+              key +
+              '": ' +
+              src +
+              " (" +
+              check.reason +
+              ")",
+          );
+          continue;
+        }
+        compiled.push(re);
+      }
       result[key] = {
         agent: value.agent,
         label: value.label,
         matchOn: value.matchOn || ["fullPath"],
-        compiled: value.patterns.map(compilePattern),
+        compiled,
       };
     } else if (value.pattern) {
-      result[key] = { compiled: compilePattern(value.pattern) };
+      const re = compilePattern(value.pattern);
+      if (re === null) {
+        const src = Array.isArray(value.pattern) ? value.pattern[0] : value.pattern;
+        const check = safeRegex(src);
+        console.error(
+          '[dev-team] skipping unsafe pattern in "' + key + '": ' + src + " (" + check.reason + ")",
+        );
+        continue;
+      }
+      result[key] = { compiled: re };
     }
   }
   return result;

--- a/templates/hooks/lib/agent-patterns.js
+++ b/templates/hooks/lib/agent-patterns.js
@@ -13,16 +13,20 @@
 
 const fs = require("fs");
 const path = require("path");
+const { safeRegex } = require("./safe-regex");
 
 /**
  * Compile a pattern entry from the JSON into a RegExp.
  * Entries are either a string (no flags) or [source, flags].
  */
 function compilePattern(entry) {
-  if (Array.isArray(entry)) {
-    return new RegExp(entry[0], entry[1] || "");
+  const source = Array.isArray(entry) ? entry[0] : entry;
+  const flags = Array.isArray(entry) ? entry[1] || "" : undefined;
+  const check = safeRegex(source);
+  if (check.safe === false) {
+    return null;
   }
-  return new RegExp(entry);
+  return flags !== undefined ? new RegExp(source, flags) : check.regex;
 }
 
 /**
@@ -39,14 +43,42 @@ function loadPatterns() {
   const result = {};
   for (const [key, value] of Object.entries(data)) {
     if (value.patterns) {
+      const compiled = [];
+      for (const p of value.patterns) {
+        const re = compilePattern(p);
+        if (re === null) {
+          const src = Array.isArray(p) ? p[0] : p;
+          const check = safeRegex(src);
+          console.error(
+            '[dev-team] skipping unsafe pattern in "' +
+              key +
+              '": ' +
+              src +
+              " (" +
+              check.reason +
+              ")",
+          );
+          continue;
+        }
+        compiled.push(re);
+      }
       result[key] = {
         agent: value.agent,
         label: value.label,
         matchOn: value.matchOn || ["fullPath"],
-        compiled: value.patterns.map(compilePattern),
+        compiled,
       };
     } else if (value.pattern) {
-      result[key] = { compiled: compilePattern(value.pattern) };
+      const re = compilePattern(value.pattern);
+      if (re === null) {
+        const src = Array.isArray(value.pattern) ? value.pattern[0] : value.pattern;
+        const check = safeRegex(src);
+        console.error(
+          '[dev-team] skipping unsafe pattern in "' + key + '": ' + src + " (" + check.reason + ")",
+        );
+        continue;
+      }
+      result[key] = { compiled: re };
     }
   }
   return result;

--- a/tests/unit/agent-patterns.test.js
+++ b/tests/unit/agent-patterns.test.js
@@ -1,0 +1,91 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const libDir = path.join(__dirname, "..", "..", "templates", "hooks", "lib");
+
+describe("agent-patterns safeRegex integration", () => {
+  it("loads all patterns from agent-patterns.json without errors", () => {
+    delete require.cache[require.resolve(path.join(libDir, "agent-patterns"))];
+    const { loadPatterns } = require(path.join(libDir, "agent-patterns"));
+    const patterns = loadPatterns();
+    assert.ok(Object.keys(patterns).length > 0, "should load at least one category");
+  });
+
+  it("all real patterns pass safeRegex validation", () => {
+    const { safeRegex } = require(path.join(libDir, "safe-regex"));
+    const jsonPath = path.join(__dirname, "..", "..", "templates", "hooks", "agent-patterns.json");
+    const data = JSON.parse(fs.readFileSync(jsonPath, "utf-8"));
+    for (const [key, value] of Object.entries(data)) {
+      const entries = value.patterns || (value.pattern ? [value.pattern] : []);
+      for (const entry of entries) {
+        const source = Array.isArray(entry) ? entry[0] : entry;
+        const result = safeRegex(source);
+        assert.ok(
+          result.safe,
+          "pattern " + source + " in " + key + " should be safe: " + result.reason,
+        );
+      }
+    }
+  });
+
+  it("skips unsafe patterns in multi-pattern categories", () => {
+    var tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ap-test-"));
+    var libTmpDir = path.join(tmpDir, "lib");
+    fs.mkdirSync(libTmpDir);
+    fs.copyFileSync(path.join(libDir, "safe-regex.js"), path.join(libTmpDir, "safe-regex.js"));
+    fs.copyFileSync(
+      path.join(libDir, "agent-patterns.js"),
+      path.join(libTmpDir, "agent-patterns.js"),
+    );
+    var fakeData = { testCat: { agent: "test", label: "test", patterns: ["safe", "(.*)+"] } };
+    fs.writeFileSync(path.join(tmpDir, "agent-patterns.json"), JSON.stringify(fakeData));
+    var warnings = [];
+    var origErr = console.error;
+    console.error = function (m) {
+      warnings.push(m);
+    };
+    try {
+      var { loadPatterns } = require(path.join(libTmpDir, "agent-patterns"));
+      var result = loadPatterns();
+      assert.equal(result.testCat.compiled.length, 1, "unsafe pattern should be skipped");
+      assert.ok(result.testCat.compiled[0].test("safe"));
+      assert.ok(warnings.length > 0, "should log warning");
+    } finally {
+      console.error = origErr;
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips unsafe single-pattern entries", () => {
+    var tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ap-test-"));
+    var libTmpDir = path.join(tmpDir, "lib");
+    fs.mkdirSync(libTmpDir);
+    fs.copyFileSync(path.join(libDir, "safe-regex.js"), path.join(libTmpDir, "safe-regex.js"));
+    fs.copyFileSync(
+      path.join(libDir, "agent-patterns.js"),
+      path.join(libTmpDir, "agent-patterns.js"),
+    );
+    var fakeData = { bad: { pattern: "(a+)+" }, good: { pattern: "\\.test\\." } };
+    fs.writeFileSync(path.join(tmpDir, "agent-patterns.json"), JSON.stringify(fakeData));
+    var warnings = [];
+    var origErr = console.error;
+    console.error = function (m) {
+      warnings.push(m);
+    };
+    try {
+      var { loadPatterns } = require(path.join(libTmpDir, "agent-patterns"));
+      var result = loadPatterns();
+      assert.equal(result.bad, undefined, "unsafe single pattern should be skipped");
+      assert.ok(result.good, "safe single pattern should be loaded");
+      assert.ok(warnings.length > 0, "should log warning");
+    } finally {
+      console.error = origErr;
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add safeRegex validation at pattern load time in `agent-patterns.js` to prevent ReDoS attacks
- Unsafe patterns are logged via `console.error` and skipped (graceful degradation, no crash)
- Updates both `templates/hooks/lib/` and `.dev-team/hooks/lib/` copies
- Adds 4 unit tests covering all code paths

Closes #616

## Test plan
- [x] All 4 new unit tests pass (safe patterns load, unsafe patterns skipped with warnings)
- [x] All existing real patterns in agent-patterns.json pass safeRegex validation
- [x] Existing hooks and review-gate tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)