### PR TITLE
feat: GitHub-first platform, reviewer-agnostic merge skill

### DIFF
--- a/.claude/skills/dev-team-merge/SKILL.md
+++ b/.claude/skills/dev-team-merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-team:merge
-description: Merge a PR with monitoring -- checks Copilot comments, sets auto-merge, monitors until complete, triggers next steps.
+description: Merge a PR with monitoring -- waits for review workflows, addresses unresolved threads, resolves them via GraphQL, sets auto-merge, and monitors until complete.
 user_invocable: true
 ---
 
@@ -8,7 +8,7 @@ Merge a pull request with full monitoring: $ARGUMENTS
 
 ## Release PRs
 
-**Release PRs MUST use this merge skill.** Release PRs (version bumps, changelog updates, release branches) require the same Copilot review handling and CI verification as any other PR — do not bypass this process for releases. When merging a release PR, pay extra attention to:
+**Release PRs MUST use this merge skill.** Release PRs (version bumps, changelog updates, release branches) require the same review handling and CI verification as any other PR. Pay extra attention to:
 - Changelog completeness (all PRs since last release are documented)
 - Version bump correctness (semver compliance)
 - No draft or WIP markers left in release notes
@@ -23,183 +23,119 @@ Merge a pull request with full monitoring: $ARGUMENTS
 2. Capture repo context:
    - `gh repo view --json nameWithOwner --jq .nameWithOwner` to get {owner}/{repo}
 
-## Step 1: Wait for and address Copilot review
+## Step 1: Wait for automated reviews and address threads
 
-Before proceeding with merge, **wait for Copilot review to complete** using multi-signal detection (check run, requested reviewers, and submitted reviews).
+This step only **polls** for automated reviewers (Copilot). Human reviewers work on their own schedule — the skill does not block waiting for them. If no reviews exist yet and no automated reviewer is configured, proceed to Step 2 (set auto-merge) and let platform gates (Mergify, rulesets) enforce review requirements at merge time.
 
-### 1a. Wait for Copilot review via multi-signal detection
+### 1a. Wait for Copilot code review workflow (if configured)
 
-Copilot can appear as a check run, a requested reviewer, or both. Detect all signals before deciding how to wait.
+After a push, the Copilot code review workflow may take time to start and complete. Use two-phase polling:
 
-Get the HEAD commit SHA for the PR, then probe all three signals sequentially:
+**Phase 1 — Wait to appear** (every 15s, timeout 2 minutes):
+```bash
+gh pr checks {number} | grep -i "copilot"
+```
+If `Copilot code review` never appears after 2 minutes, Copilot is not configured — skip to Step 1b.
+
+**Phase 2 — Wait to complete** (every 15s, timeout 3 minutes):
+Once the check appears, poll until its status is no longer `pending`:
+```bash
+gh pr checks {number} | grep -i "copilot"
+```
+When completed, proceed to Step 1b.
+
+### 1b. Query all unresolved review threads
+
+Use GraphQL to get ALL unresolved threads — from any reviewer (Copilot, human, bot):
 
 ```bash
-# Get the PR's HEAD commit SHA
-PR_SHA=$(gh pr view {number} --json headRefOid --jq .headRefOid)
-
-# Signal 1: Check runs API
-gh api repos/{owner}/{repo}/commits/${PR_SHA}/check-runs \
-  --jq '.check_runs[] | select(.app.slug == "copilot-pull-request-reviewer" or .name == "Copilot") | {name, status, conclusion}'
-
-# Signal 2: Requested reviewers API (Copilot pending as reviewer)
-gh api repos/{owner}/{repo}/pulls/{number}/requested_reviewers \
-  --jq '[.users[] | select(.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$"))] | length'
-
-# Signal 3: Reviews API (Copilot already submitted a review — terminal states only)
-gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews \
-  --jq '[.[] | select((.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$")) and (.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "COMMENTED"))] | length'
+gh api graphql -f query='
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 5) {
+            nodes {
+              author { login }
+              body
+            }
+          }
+        }
+      }
+    }
+  }
+}' -f owner="{owner}" -f repo="{repo}" -F pr={number} \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | {id, body: .comments.nodes[0].body}'
 ```
 
-**Decision logic (evaluate in order):**
+If zero unresolved threads, proceed to Step 2.
 
-1. **If a Copilot check run exists AND status is `queued` or `in_progress`:** poll the check-runs API every 15 seconds until `completed` (max 12 polls, ~3 minutes). If after the final (12th) poll the status is still `queued` or `in_progress`, **treat this as a timeout**: surface a clear error, do **not** proceed to comment reading or merge, and stop the workflow without setting auto-merge.
-   - Once status is `completed` within the polling limit: proceed to 1a-read below.
+### 1c. Address each unresolved thread
 
-2. **If Copilot is in requested_reviewers (Signal 2 count > 0):** Copilot has been requested but hasn't submitted a review yet. Poll the reviews API every 15 seconds until a review from Copilot appears with state `APPROVED`, `CHANGES_REQUESTED`, or `COMMENTED` (max 12 polls, ~3 minutes):
-   ```bash
-   gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews \
-     --jq '[.[] | select((.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$")) and (.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "COMMENTED"))] | length'
-   ```
-   - If a completed review appears within the polling limit: proceed to 1a-read below.
-   - If after the final (12th) poll no completed review exists, **treat this as a timeout**: surface a clear error, do **not** proceed to comment reading or merge, and stop the workflow without setting auto-merge.
-
-3. **If Copilot already submitted a review (Signal 3 count > 0, but not in requested_reviewers and no check run):** review is already done. Proceed directly to 1a-read below.
-
-4. **If none of the three signals detect Copilot:** fall back to a single 30-second wait, then check comments once. This maintains backward compatibility for repos without Copilot configured.
-
-- Do NOT set auto-merge before this step completes.
-
-### 1a-read. Read Copilot comments
-
-Once the check run is completed (or after the fallback wait), read comments once:
-
-```bash
-# Inline review comments (check both Copilot logins)
-gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments --jq '[.[] | select(.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$"))] | length'
-
-# Summary reviews (check both Copilot logins)
-gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews --jq '[.[] | select(.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$"))] | length'
-```
-
-- If either count > 0: Copilot review has findings, proceed to 1b
-- If both counts == 0: no Copilot comments were detected. If a Copilot check run was observed and completed, treat this as a clean review; if no Copilot check run exists, this likely means Copilot review is not configured or did not run. Then proceed to Step 2.
-- Use `--paginate` on all API calls to avoid missing results on PRs with many comments
-
-### 1b. Address Copilot findings
-
-```bash
-# Inline comments (include node_id for thread resolution, check both Copilot logins)
-gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | select(.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$")) | {id: .id, node_id: .node_id, path: .path, line: .line, body: .body}'
-
-# Summary reviews (check both Copilot logins)
-gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews --jq '.[] | select(.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$")) | {id: .id, state: .state, body: .body}'
-```
-
-For each Copilot comment:
+For each unresolved thread:
 1. Read the finding and assess: is it actionable?
 2. **Actionable** (bug, ambiguity, missing logic): fix in code, commit, push
-3. **Style/minor**: acknowledge but skip if not substantive
-4. **Reply to the Copilot thread** explaining what was fixed (or why it was skipped). Use the inline comment reply API:
+3. **Style/minor**: acknowledge with reason
+4. **Reply to the thread** using the inline comment reply API:
    ```bash
-   gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies -f body="Fixed: <brief explanation of the change>"
+   gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies \
+     -f body="Fixed: <brief explanation>"
    ```
-   Note: GitHub's API does not support programmatically resolving review threads. The `minimizeComment` mutation only hides comments (collapses them), it does not mark threads as resolved. Threads must be resolved manually in the GitHub UI, or will be resolved when the PR is merged. Replying with the fix explanation is sufficient.
-   To get the `node_id` for a comment, include it in the initial fetch (already updated above).
-5. **Deferred findings must be tracked.** For findings acknowledged but NOT fixed (style/minor skips, intentional deferrals, or "won't fix" decisions):
-   - Create a GitHub issue to track the deferred finding:
-     ```bash
-     gh issue create \
-       --title "Deferred Copilot finding: <short description>" \
-       --body "$(cat <<'EOF'
-     ## Copilot Finding
-
-     **PR:** #{number}
-     **File:** {path}
-     **Line:** {line}
-
-     ### Finding
-     {copilot_comment_body}
-
-     ### Reason for deferral
-     {explanation of why it was not fixed in this PR}
-
-     ---
-     *Auto-created by merge skill from Copilot review on PR #{number}.*
-     EOF
-     )"
-     ```
-   - Reply to the Copilot thread with the tracking issue number:
-     ```bash
-     gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies \
-       -f body="Tracked in #NNN — deferred: <brief reason>"
-     ```
-6. **Validation gate before merge.** Before proceeding to Step 2 (auto-merge), verify that every Copilot inline comment has been addressed with one of:
-   - A code fix (reply mentioning "Fixed:")
-   - A tracking issue (reply mentioning "Tracked in #NNN")
-
-   Empty acknowledgments, bare "acknowledged" replies, or comments without either a fix or an issue number are **not valid**. If any comment lacks proper resolution, go back and either fix it or create a tracking issue.
-
-   To verify, re-fetch all Copilot inline comments and check that each has at least one reply from the PR author or bot containing "Fixed:" or "Tracked in #":
+5. **Deferred findings** — create a GitHub issue and reply with tracking number:
    ```bash
-   # Get all Copilot comment IDs
-   COPILOT_COMMENTS=$(gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments \
-     --jq '[.[] | select(.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$")) | .id]')
-
-   # For each comment, verify it has a valid reply
-   for COMMENT_ID in $(echo "$COPILOT_COMMENTS" | jq -r '.[]'); do
-     REPLIES=$(gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments \
-       --jq "[.[] | select(.in_reply_to_id == ${COMMENT_ID}) | .body]")
-     HAS_FIX=$(echo "$REPLIES" | jq 'any(test("Fixed:"))')
-     HAS_ISSUE=$(echo "$REPLIES" | jq 'any(test("Tracked in #"))')
-     if [ "$HAS_FIX" != "true" ] && [ "$HAS_ISSUE" != "true" ]; then
-       echo "UNRESOLVED: Comment $COMMENT_ID has no fix or tracking issue"
-     fi
-   done
+   gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies \
+     -f body="Tracked in #NNN — deferred: <brief reason>"
    ```
-   If any comments are unresolved, **do not proceed** — address them before continuing.
-7. After addressing all actionable findings, re-push and wait for CI to restart
 
-### 1c. Verify no new Copilot comments after push
+### 1d. Resolve threads via GraphQL
 
-If you pushed fixes, Copilot may re-review. Re-run the check run monitoring from 1a (get the new HEAD SHA, wait for the Copilot check run to complete, then read comments once).
+After replying to each thread, resolve it programmatically:
 
-If new comments appeared, repeat 1b. Otherwise proceed to Step 2.
+```bash
+gh api graphql -f query='
+mutation($threadId: ID!) {
+  resolveReviewThread(input: { threadId: $threadId }) {
+    thread { id isResolved }
+  }
+}' -f threadId="{thread_id}"
+```
+
+This is required — Mergify (and GitHub rulesets) can enforce `#review-threads-unresolved = 0` as a merge condition. Unresolved threads block merging.
+
+### 1e. Verify and loop
+
+After addressing and resolving all threads:
+1. If code was pushed, return to Step 1a (Copilot may re-review)
+2. If only replies/resolves (no code push), verify zero unresolved threads remain and proceed to Step 2
 
 ## Step 2: Set auto-merge
 
-**GATE: Do NOT proceed to this step until Step 1 (Copilot review) is fully complete with all findings addressed. Setting auto-merge before addressing Copilot findings causes PRs to merge with unresolved comments.**
+**GATE: Do NOT proceed until all review threads are resolved.**
 
 ```bash
 gh pr merge {number} --squash --auto --delete-branch
 ```
 
-This tells GitHub to merge automatically once all required checks pass.
+If Mergify is configured, it handles the merge queue automatically. If not, this sets GitHub's auto-merge to trigger when all required checks pass.
 
-## Step 3: Check CI status and monitor
-
-Check current CI status:
+## Step 3: Monitor CI and merge
 
 ```bash
 gh pr checks {number}
 ```
 
-**If all checks are passing:**
-- The PR will merge immediately (or within seconds)
-- Verify by checking: `gh pr view {number} --json state --jq .state`
-- If state is `MERGED`, proceed to Step 4
+**If all checks pass:** PR will merge automatically (via auto-merge or Mergify queue).
 
-**If checks are pending:**
-- Inform the user that auto-merge is set and CI is running
-- Spawn a background monitoring agent to poll until completion:
-  - Poll every 30 seconds: `gh pr view {number} --json state --jq .state`
-  - If state becomes `MERGED`: report success and proceed to Step 4
-  - If checks fail: report the failure with details from `gh pr checks {number}`
-  - Timeout after 15 minutes of polling
+**If checks are pending:** Report that auto-merge is set and CI is running. Poll every 30 seconds:
+```bash
+gh pr view {number} --json state --jq .state
+```
+Timeout after 15 minutes.
 
-**If checks are failing:**
-- Report which checks failed: `gh pr checks {number}`
-- Do NOT proceed with merge
-- Suggest investigating the failures
+**If checks are failing:** Report which checks failed. Do NOT proceed.
 
 ## Step 4: Post-merge actions
 
@@ -207,8 +143,7 @@ After merge is confirmed:
 
 1. **Switch to main and pull latest:**
    ```bash
-   git checkout main
-   git pull origin main
+   git checkout main && git pull origin main
    ```
 
 2. **Report the merge commit:**
@@ -216,12 +151,10 @@ After merge is confirmed:
    git log -1 --format="%H %s"
    ```
 
-3. **Check for next work:**
-   - If there is a known next issue in the current milestone or the user mentioned follow-up work, suggest starting it
-   - If the branch was a worktree, note that the worktree can be cleaned up
+3. **Check for next work:** suggest starting next issue if one is queued.
 
 ## Error handling
 
 - If `gh` commands fail, check authentication: `gh auth status`
-- If merge conflicts are reported, inform the user -- do not attempt automatic resolution
+- If merge conflicts are reported, inform the user — do not attempt automatic resolution
 - If branch protection rules block the merge, report which rules are not satisfied

--- a/.dev-team/config.json
+++ b/.dev-team/config.json
@@ -30,6 +30,5 @@
   "issueTracker": "GitHub Issues",
   "branchConvention": "feat/123-description",
   "taskBranchPattern": "(feat|fix)\\/",
-  "platform": "github",
   "agentTeams": true
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Adversarial AI agent team for any project. Installs Claude Code agents, hooks, a
 
 Templates, agent definitions, skills, and hooks ship to all projects. They must remain:
 - **Workflow-agnostic** — don't assume PRs, specific branch naming, or any particular development workflow
-- **Platform-neutral** — don't hardcode `gh`, GitHub Actions, Copilot, or any specific tool. Use the `platform` config field for detection
+- **GitHub-first** — `gh` CLI, GitHub Actions, and GitHub GraphQL API are first-class (ADR-040). Review handling is reviewer-agnostic (works for Copilot, human reviewers, bots) via GraphQL `reviewThreads`
 - **Language-neutral** — don't encode language conventions (test patterns, linter commands, file extensions) that the agent already knows. Hooks detect the ecosystem; agents apply their built-in knowledge
 - **Discoverable-only** — if the agent can learn it by reading the codebase, don't put it in a template. Include only what agents can't discover: tool preferences, legacy traps, process decisions
 - **Process-driven** — agent definitions describe *capabilities* (what the agent can do), not *steps* (how a specific project uses them). Workflow steps (release process, review requirements, integration rules) belong in `.claude/rules/dev-team-process.md`, which each project customizes. Agents receive it automatically via rules — no explicit "read this file" needed.

--- a/docs/adr/040-github-first-reviewer-agnostic-merge.md
+++ b/docs/adr/040-github-first-reviewer-agnostic-merge.md
@@ -1,0 +1,40 @@
+# ADR-040: GitHub-first platform, reviewer-agnostic merge skill
+
+Date: 2026-04-01
+Status: accepted
+
+## Context
+
+The template design principles stated "Platform-neutral — don't hardcode `gh`, GitHub Actions, Copilot, or any specific tool." In practice:
+
+- Every user is on GitHub. No GitLab or Bitbucket users exist.
+- The `platform` config field and multi-platform abstractions added complexity with no users.
+- The merge skill hardcoded Copilot-specific login regex patterns (`copilot-pull-request-reviewer[bot]`), missing human review threads entirely.
+- Copilot code review is a paid add-on — not universally available.
+- v3.2.0 exposed the problem: 6 PRs merged with 36 unresolved Copilot comments because the merge process was Copilot-specific rather than thread-aware.
+
+GitHub's GraphQL API provides `reviewThreads` which returns all threads regardless of author, and `resolveReviewThread` which programmatically resolves them. This was previously believed to be unavailable via API.
+
+## Decision
+
+1. **GitHub is the target platform.** `gh` CLI, GitHub Actions, and GitHub GraphQL API are first-class. Drop the `platform` config field from `.dev-team/config.json`.
+
+2. **Review handling is reviewer-agnostic.** The merge skill addresses ALL unresolved review threads via GraphQL `reviewThreads`, not Copilot-specific login filtering. Works for Copilot, human reviewers, and any bot.
+
+3. **Two-phase Copilot workflow polling.** When Copilot code review is configured, poll for the workflow to appear (phase 1, 2 min timeout), then poll for completion (phase 2, 3 min timeout). When not configured, skip — the thread query still catches any manually-submitted reviews.
+
+4. **Resolve threads via GraphQL.** After replying to each thread, resolve it with `resolveReviewThread`. This enables Mergify's `#review-threads-unresolved = 0` condition and GitHub ruleset enforcement.
+
+## Consequences
+
+**Positive:**
+- Merge skill is simpler (~100 lines vs ~230 lines)
+- Catches ALL review comments, not just Copilot's
+- GraphQL thread resolution enables platform-level enforcement (Mergify, rulesets)
+- No more multi-signal Copilot detection complexity
+
+**Negative:**
+- GitLab/Bitbucket users cannot use dev-team without adaptation (accepted — no such users exist)
+- Removing `platform` config is a breaking change for anyone who set it (mitigated — the field was only used in this repo's own config)
+
+**Supersedes:** The "Platform-neutral" template design principle in CLAUDE.md. Updated to "GitHub-first."

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -64,3 +64,4 @@ What becomes easier or more difficult?
 | [037](037-mcp-enforcement-server.md) | MCP enforcement server | superseded |
 | [038](038-runtime-native-directory-layout.md) | Runtime-native directory layout | accepted |
 | [039](039-decompose-task-into-composable-skills.md) | Decompose task skill into composable sub-skills | accepted |
+| [040](040-github-first-reviewer-agnostic-merge.md) | GitHub-first platform, reviewer-agnostic merge skill | accepted |

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -63,8 +63,6 @@ Do NOT skip this. Do NOT treat hook output as optional. If you believe a review 
 - `/dev-team:extract` — Borges memory extraction, metrics verification, and memory formation gates
 - `/dev-team:scorecard` — audit process conformance for a completed task
 
-> **Non-GitHub platforms:** Skills and hooks reference `gh` CLI commands for GitHub. If your project uses GitLab, Bitbucket, or another platform, adapt these commands accordingly. Set the `platform` field in `.dev-team/config.json` to `"gitlab"`, `"bitbucket"`, or `"other"`.
-
 > **Non-JS/TS projects:** Hooks detect the ecosystem and delegate language-specific reasoning to agents. File patterns in `agent-patterns.json` cover common conventions; agents apply their built-in knowledge for language-specific test naming, build tools, and framework structures beyond these patterns (see ADR-034).
 
 > **Multi-runtime support:** Use `--runtime` flag during `dev-team init` to target additional runtimes (e.g., `--runtime claude,copilot` or `--runtime codex`). Each runtime adapter generates native configuration files. Run `dev-team update` after changing runtimes to regenerate all adapter output.

--- a/templates/skills/dev-team-merge/SKILL.md
+++ b/templates/skills/dev-team-merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-team:merge
-description: Merge a PR with monitoring -- checks Copilot comments, sets auto-merge, monitors until complete, triggers next steps.
+description: Merge a PR with monitoring -- waits for review workflows, addresses unresolved threads, resolves them via GraphQL, sets auto-merge, and monitors until complete.
 user_invocable: true
 ---
 
@@ -8,7 +8,7 @@ Merge a pull request with full monitoring: $ARGUMENTS
 
 ## Release PRs
 
-**Release PRs MUST use this merge skill.** Release PRs (version bumps, changelog updates, release branches) require the same Copilot review handling and CI verification as any other PR — do not bypass this process for releases. When merging a release PR, pay extra attention to:
+**Release PRs MUST use this merge skill.** Release PRs (version bumps, changelog updates, release branches) require the same review handling and CI verification as any other PR. Pay extra attention to:
 - Changelog completeness (all PRs since last release are documented)
 - Version bump correctness (semver compliance)
 - No draft or WIP markers left in release notes
@@ -23,183 +23,119 @@ Merge a pull request with full monitoring: $ARGUMENTS
 2. Capture repo context:
    - `gh repo view --json nameWithOwner --jq .nameWithOwner` to get {owner}/{repo}
 
-## Step 1: Wait for and address Copilot review
+## Step 1: Wait for automated reviews and address threads
 
-Before proceeding with merge, **wait for Copilot review to complete** using multi-signal detection (check run, requested reviewers, and submitted reviews).
+This step only **polls** for automated reviewers (Copilot). Human reviewers work on their own schedule — the skill does not block waiting for them. If no reviews exist yet and no automated reviewer is configured, proceed to Step 2 (set auto-merge) and let platform gates (Mergify, rulesets) enforce review requirements at merge time.
 
-### 1a. Wait for Copilot review via multi-signal detection
+### 1a. Wait for Copilot code review workflow (if configured)
 
-Copilot can appear as a check run, a requested reviewer, or both. Detect all signals before deciding how to wait.
+After a push, the Copilot code review workflow may take time to start and complete. Use two-phase polling:
 
-Get the HEAD commit SHA for the PR, then probe all three signals sequentially:
+**Phase 1 — Wait to appear** (every 15s, timeout 2 minutes):
+```bash
+gh pr checks {number} | grep -i "copilot"
+```
+If `Copilot code review` never appears after 2 minutes, Copilot is not configured — skip to Step 1b.
+
+**Phase 2 — Wait to complete** (every 15s, timeout 3 minutes):
+Once the check appears, poll until its status is no longer `pending`:
+```bash
+gh pr checks {number} | grep -i "copilot"
+```
+When completed, proceed to Step 1b.
+
+### 1b. Query all unresolved review threads
+
+Use GraphQL to get ALL unresolved threads — from any reviewer (Copilot, human, bot):
 
 ```bash
-# Get the PR's HEAD commit SHA
-PR_SHA=$(gh pr view {number} --json headRefOid --jq .headRefOid)
-
-# Signal 1: Check runs API
-gh api repos/{owner}/{repo}/commits/${PR_SHA}/check-runs \
-  --jq '.check_runs[] | select(.app.slug == "copilot-pull-request-reviewer" or .name == "Copilot") | {name, status, conclusion}'
-
-# Signal 2: Requested reviewers API (Copilot pending as reviewer)
-gh api repos/{owner}/{repo}/pulls/{number}/requested_reviewers \
-  --jq '[.users[] | select(.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$"))] | length'
-
-# Signal 3: Reviews API (Copilot already submitted a review — terminal states only)
-gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews \
-  --jq '[.[] | select((.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$")) and (.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "COMMENTED"))] | length'
+gh api graphql -f query='
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 5) {
+            nodes {
+              author { login }
+              body
+            }
+          }
+        }
+      }
+    }
+  }
+}' -f owner="{owner}" -f repo="{repo}" -F pr={number} \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | {id, body: .comments.nodes[0].body}'
 ```
 
-**Decision logic (evaluate in order):**
+If zero unresolved threads, proceed to Step 2.
 
-1. **If a Copilot check run exists AND status is `queued` or `in_progress`:** poll the check-runs API every 15 seconds until `completed` (max 12 polls, ~3 minutes). If after the final (12th) poll the status is still `queued` or `in_progress`, **treat this as a timeout**: surface a clear error, do **not** proceed to comment reading or merge, and stop the workflow without setting auto-merge.
-   - Once status is `completed` within the polling limit: proceed to 1a-read below.
+### 1c. Address each unresolved thread
 
-2. **If Copilot is in requested_reviewers (Signal 2 count > 0):** Copilot has been requested but hasn't submitted a review yet. Poll the reviews API every 15 seconds until a review from Copilot appears with state `APPROVED`, `CHANGES_REQUESTED`, or `COMMENTED` (max 12 polls, ~3 minutes):
-   ```bash
-   gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews \
-     --jq '[.[] | select((.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$")) and (.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "COMMENTED"))] | length'
-   ```
-   - If a completed review appears within the polling limit: proceed to 1a-read below.
-   - If after the final (12th) poll no completed review exists, **treat this as a timeout**: surface a clear error, do **not** proceed to comment reading or merge, and stop the workflow without setting auto-merge.
-
-3. **If Copilot already submitted a review (Signal 3 count > 0, but not in requested_reviewers and no check run):** review is already done. Proceed directly to 1a-read below.
-
-4. **If none of the three signals detect Copilot:** fall back to a single 30-second wait, then check comments once. This maintains backward compatibility for repos without Copilot configured.
-
-- Do NOT set auto-merge before this step completes.
-
-### 1a-read. Read Copilot comments
-
-Once the check run is completed (or after the fallback wait), read comments once:
-
-```bash
-# Inline review comments (check both Copilot logins)
-gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments --jq '[.[] | select(.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$"))] | length'
-
-# Summary reviews (check both Copilot logins)
-gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews --jq '[.[] | select(.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$"))] | length'
-```
-
-- If either count > 0: Copilot review has findings, proceed to 1b
-- If both counts == 0: no Copilot comments were detected. If a Copilot check run was observed and completed, treat this as a clean review; if no Copilot check run exists, this likely means Copilot review is not configured or did not run. Then proceed to Step 2.
-- Use `--paginate` on all API calls to avoid missing results on PRs with many comments
-
-### 1b. Address Copilot findings
-
-```bash
-# Inline comments (include node_id for thread resolution, check both Copilot logins)
-gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | select(.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$")) | {id: .id, node_id: .node_id, path: .path, line: .line, body: .body}'
-
-# Summary reviews (check both Copilot logins)
-gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews --jq '.[] | select(.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$")) | {id: .id, state: .state, body: .body}'
-```
-
-For each Copilot comment:
+For each unresolved thread:
 1. Read the finding and assess: is it actionable?
 2. **Actionable** (bug, ambiguity, missing logic): fix in code, commit, push
-3. **Style/minor**: acknowledge but skip if not substantive
-4. **Reply to the Copilot thread** explaining what was fixed (or why it was skipped). Use the inline comment reply API:
+3. **Style/minor**: acknowledge with reason
+4. **Reply to the thread** using the inline comment reply API:
    ```bash
-   gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies -f body="Fixed: <brief explanation of the change>"
+   gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies \
+     -f body="Fixed: <brief explanation>"
    ```
-   Note: GitHub's API does not support programmatically resolving review threads. The `minimizeComment` mutation only hides comments (collapses them), it does not mark threads as resolved. Threads must be resolved manually in the GitHub UI, or will be resolved when the PR is merged. Replying with the fix explanation is sufficient.
-   To get the `node_id` for a comment, include it in the initial fetch (already updated above).
-5. **Deferred findings must be tracked.** For findings acknowledged but NOT fixed (style/minor skips, intentional deferrals, or "won't fix" decisions):
-   - Create a GitHub issue to track the deferred finding:
-     ```bash
-     gh issue create \
-       --title "Deferred Copilot finding: <short description>" \
-       --body "$(cat <<'EOF'
-     ## Copilot Finding
-
-     **PR:** #{number}
-     **File:** {path}
-     **Line:** {line}
-
-     ### Finding
-     {copilot_comment_body}
-
-     ### Reason for deferral
-     {explanation of why it was not fixed in this PR}
-
-     ---
-     *Auto-created by merge skill from Copilot review on PR #{number}.*
-     EOF
-     )"
-     ```
-   - Reply to the Copilot thread with the tracking issue number:
-     ```bash
-     gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies \
-       -f body="Tracked in #NNN — deferred: <brief reason>"
-     ```
-6. **Validation gate before merge.** Before proceeding to Step 2 (auto-merge), verify that every Copilot inline comment has been addressed with one of:
-   - A code fix (reply mentioning "Fixed:")
-   - A tracking issue (reply mentioning "Tracked in #NNN")
-
-   Empty acknowledgments, bare "acknowledged" replies, or comments without either a fix or an issue number are **not valid**. If any comment lacks proper resolution, go back and either fix it or create a tracking issue.
-
-   To verify, re-fetch all Copilot inline comments and check that each has at least one reply from the PR author or bot containing "Fixed:" or "Tracked in #":
+5. **Deferred findings** — create a GitHub issue and reply with tracking number:
    ```bash
-   # Get all Copilot comment IDs
-   COPILOT_COMMENTS=$(gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments \
-     --jq '[.[] | select(.user.login | test("^(Copilot|copilot-pull-request-reviewer)(\\[bot\\])?$")) | .id]')
-
-   # For each comment, verify it has a valid reply
-   for COMMENT_ID in $(echo "$COPILOT_COMMENTS" | jq -r '.[]'); do
-     REPLIES=$(gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments \
-       --jq "[.[] | select(.in_reply_to_id == ${COMMENT_ID}) | .body]")
-     HAS_FIX=$(echo "$REPLIES" | jq 'any(test("Fixed:"))')
-     HAS_ISSUE=$(echo "$REPLIES" | jq 'any(test("Tracked in #"))')
-     if [ "$HAS_FIX" != "true" ] && [ "$HAS_ISSUE" != "true" ]; then
-       echo "UNRESOLVED: Comment $COMMENT_ID has no fix or tracking issue"
-     fi
-   done
+   gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies \
+     -f body="Tracked in #NNN — deferred: <brief reason>"
    ```
-   If any comments are unresolved, **do not proceed** — address them before continuing.
-7. After addressing all actionable findings, re-push and wait for CI to restart
 
-### 1c. Verify no new Copilot comments after push
+### 1d. Resolve threads via GraphQL
 
-If you pushed fixes, Copilot may re-review. Re-run the check run monitoring from 1a (get the new HEAD SHA, wait for the Copilot check run to complete, then read comments once).
+After replying to each thread, resolve it programmatically:
 
-If new comments appeared, repeat 1b. Otherwise proceed to Step 2.
+```bash
+gh api graphql -f query='
+mutation($threadId: ID!) {
+  resolveReviewThread(input: { threadId: $threadId }) {
+    thread { id isResolved }
+  }
+}' -f threadId="{thread_id}"
+```
+
+This is required — Mergify (and GitHub rulesets) can enforce `#review-threads-unresolved = 0` as a merge condition. Unresolved threads block merging.
+
+### 1e. Verify and loop
+
+After addressing and resolving all threads:
+1. If code was pushed, return to Step 1a (Copilot may re-review)
+2. If only replies/resolves (no code push), verify zero unresolved threads remain and proceed to Step 2
 
 ## Step 2: Set auto-merge
 
-**GATE: Do NOT proceed to this step until Step 1 (Copilot review) is fully complete with all findings addressed. Setting auto-merge before addressing Copilot findings causes PRs to merge with unresolved comments.**
+**GATE: Do NOT proceed until all review threads are resolved.**
 
 ```bash
 gh pr merge {number} --squash --auto --delete-branch
 ```
 
-This tells GitHub to merge automatically once all required checks pass.
+If Mergify is configured, it handles the merge queue automatically. If not, this sets GitHub's auto-merge to trigger when all required checks pass.
 
-## Step 3: Check CI status and monitor
-
-Check current CI status:
+## Step 3: Monitor CI and merge
 
 ```bash
 gh pr checks {number}
 ```
 
-**If all checks are passing:**
-- The PR will merge immediately (or within seconds)
-- Verify by checking: `gh pr view {number} --json state --jq .state`
-- If state is `MERGED`, proceed to Step 4
+**If all checks pass:** PR will merge automatically (via auto-merge or Mergify queue).
 
-**If checks are pending:**
-- Inform the user that auto-merge is set and CI is running
-- Spawn a background monitoring agent to poll until completion:
-  - Poll every 30 seconds: `gh pr view {number} --json state --jq .state`
-  - If state becomes `MERGED`: report success and proceed to Step 4
-  - If checks fail: report the failure with details from `gh pr checks {number}`
-  - Timeout after 15 minutes of polling
+**If checks are pending:** Report that auto-merge is set and CI is running. Poll every 30 seconds:
+```bash
+gh pr view {number} --json state --jq .state
+```
+Timeout after 15 minutes.
 
-**If checks are failing:**
-- Report which checks failed: `gh pr checks {number}`
-- Do NOT proceed with merge
-- Suggest investigating the failures
+**If checks are failing:** Report which checks failed. Do NOT proceed.
 
 ## Step 4: Post-merge actions
 
@@ -207,8 +143,7 @@ After merge is confirmed:
 
 1. **Switch to main and pull latest:**
    ```bash
-   git checkout main
-   git pull origin main
+   git checkout main && git pull origin main
    ```
 
 2. **Report the merge commit:**
@@ -216,12 +151,10 @@ After merge is confirmed:
    git log -1 --format="%H %s"
    ```
 
-3. **Check for next work:**
-   - If there is a known next issue in the current milestone or the user mentioned follow-up work, suggest starting it
-   - If the branch was a worktree, note that the worktree can be cleaned up
+3. **Check for next work:** suggest starting next issue if one is queued.
 
 ## Error handling
 
 - If `gh` commands fail, check authentication: `gh auth status`
-- If merge conflicts are reported, inform the user -- do not attempt automatic resolution
+- If merge conflicts are reported, inform the user — do not attempt automatic resolution
 - If branch protection rules block the merge, report which rules are not satisfied


### PR DESCRIPTION
## Summary
- Rewrite merge skill: use GraphQL `reviewThreads` + `resolveReviewThread` instead of Copilot-specific login regex
- Two-phase Copilot workflow polling (wait to appear, wait to complete)
- Don't block on human reviewers — set auto-merge and let platform gates enforce
- ADR-040: GitHub-first platform, reviewer-agnostic merge
- Remove `platform` config field
- Update CLAUDE.md: "Platform-neutral" → "GitHub-first"

Closes #647

🤖 Generated with [Claude Code](https://claude.com/claude-code)