### PR TITLE
Fix lint-format.js hook reading stdin instead of argv[2]

### DIFF
--- a/.claude/hooks/lint-format.js
+++ b/.claude/hooks/lint-format.js
@@ -15,7 +15,7 @@ const path = require("path");
 
 let input = {};
 try {
-  input = JSON.parse(require("fs").readFileSync(0, "utf-8"));
+  input = JSON.parse(process.argv[2] || "{}");
 } catch {
   process.exit(0);
 }


### PR DESCRIPTION
## Summary
- Fixed input parsing in `.claude/hooks/lint-format.js` to read from `process.argv[2]` instead of stdin
- Aligns with every other hook in the project

Closes #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)