### PR TITLE
feat: tighten npm audit to moderate level in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,5 +100,5 @@ jobs:
       - run: npm ci
 
       - name: Audit dependencies
-        run: npm audit --audit-level=high
+        run: npm audit --audit-level=moderate
 


### PR DESCRIPTION
## Summary
- Change `--audit-level=high` to `--audit-level=moderate` in CI to catch moderate-severity vulnerabilities

Closes #667