### PR TITLE
fix: add missing validate:docs npm script for local/CI parity

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "format": "oxfmt --write src/ scripts/ templates/hooks/ tests/",
     "format:check": "oxfmt --check src/ scripts/ templates/hooks/ tests/",
     "validate:agents": "node scripts/validate-agents.js",
+    "validate:docs": "node scripts/validate-docs.js",
     "validate:hooks": "node scripts/validate-hooks.js",
     "validate:readme": "node scripts/validate-readme.js",
     "prepublishOnly": "npm run build"


### PR DESCRIPTION
Closes #714

## Summary

- Adds `"validate:docs": "node scripts/validate-docs.js"` to `package.json` scripts, placed alphabetically between `validate:agents` and `validate:hooks`
- Matches the pattern of the other three `validate:*` scripts
- Restores local/CI parity (`ci.yml:70` and `release.yml:105` both call this script directly)

## Test plan

- [x] `npm run validate:docs` runs successfully and reports all docs valid
- [x] `npm test` — 703 tests pass, 0 failures
- [x] Only `package.json` modified

Generated with Claude Code