### PR TITLE
fix: add path containment validation to worktree-remove hook

### DIFF
--- a/templates/hooks/dev-team-worktree-remove.js
+++ b/templates/hooks/dev-team-worktree-remove.js
@@ -13,6 +13,8 @@
 
 "use strict";
 
+const fs = require("fs");
+const path = require("path");
 const { execFileSync } = require("child_process");
 
 let input = {};
@@ -31,8 +33,25 @@ if (!worktreePath) {
 }
 
 // Validate worktree_path is an absolute path (fixes #537)
-if (!require("path").isAbsolute(worktreePath)) {
+if (!path.isAbsolute(worktreePath)) {
   process.stderr.write("[dev-team worktree-remove] worktree_path must be an absolute path\n");
+  process.exit(0);
+}
+
+// Validate worktree_path resolves within the project root (fixes #725)
+const projectRoot = process.cwd();
+const realRoot = fs.realpathSync(projectRoot);
+let resolvedWorktreePath = worktreePath;
+try {
+  resolvedWorktreePath = fs.realpathSync(worktreePath);
+} catch {
+  // Path doesn't exist — use the unresolved path for containment check
+}
+const rel = path.relative(realRoot, resolvedWorktreePath);
+if (rel === ".." || rel.startsWith(".." + path.sep) || path.isAbsolute(rel)) {
+  process.stderr.write(
+    `[dev-team worktree-remove] worktree_path "${worktreePath}" resolves outside project root\n`,
+  );
   process.exit(0);
 }
 


### PR DESCRIPTION
Adds path containment validation to `dev-team-worktree-remove.js`, matching the pattern already used in `dev-team-worktree-create.js`. After verifying the path is absolute, the hook now resolves symlinks and checks that the resolved path falls within the project root — rejecting any path that escapes via traversal.

Closes #725