### PR TITLE
test: add symlink guard coverage for update.ts migration functions

### DIFF
--- a/tests/unit/update.test.js
+++ b/tests/unit/update.test.js
@@ -409,7 +409,10 @@ describe("migrateToV3Layout", () => {
     );
 
     // The symlink and the external directory must be untouched
-    assert.ok(fs.lstatSync(symlinkAgentsDir).isSymbolicLink(), "symlink should remain as a symlink");
+    assert.ok(
+      fs.lstatSync(symlinkAgentsDir).isSymbolicLink(),
+      "symlink should remain as a symlink",
+    );
     assert.ok(
       fs.existsSync(path.join(externalAgentsDir, "dev-team-voss.md")),
       "external dir contents should be untouched",


### PR DESCRIPTION
## Summary
- Adds 3 symlink test cases to `tests/unit/update.test.js` covering the symlink guards in `cleanupLegacyMemoryDirs` and `migrateToV3Layout`
- Test 1: `cleanupLegacyMemoryDirs` throws when legacy `MEMORY.md` is a symlink (prevents rename of symlink to new location)
- Test 2: `migrateToV3Layout` skips `.dev-team/agents/` removal when the directory is itself a symlink (symlink guard on `assertNotSymlink(oldAgentsDir)`)
- Test 3: `migrateToV3Layout` step 5 removes stale `.dev-team/skills/` symlinks from `.claude/skills/` while preserving real directories

## Test plan
- [ ] All 769 existing tests still pass
- [ ] 3 new symlink guard tests pass
- [ ] Test-only change — no source code modified

Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)