### PR TITLE
fix: use node_modules/.bin instead of npx in lint-format hook

### DIFF
--- a/.claude/hooks/lint-format.js
+++ b/.claude/hooks/lint-format.js
@@ -11,6 +11,7 @@
 "use strict";
 
 const { execFileSync } = require("child_process");
+const fs = require("fs");
 const path = require("path");
 
 let input = {};
@@ -31,16 +32,27 @@ if (!LINTABLE.includes(ext)) {
   process.exit(0);
 }
 
-try {
-  execFileSync("npx", ["oxlint", filePath], { encoding: "utf-8", timeout: 10000, stdio: "pipe" });
-} catch (err) {
-  if (err.stdout) process.stdout.write(err.stdout);
+const oxlintBin = path.resolve("node_modules/.bin/oxlint");
+const oxfmtBin = path.resolve("node_modules/.bin/oxfmt");
+
+if (fs.existsSync(oxlintBin)) {
+  try {
+    execFileSync(oxlintBin, [filePath], { encoding: "utf-8", timeout: 10000, stdio: "pipe" });
+  } catch (err) {
+    if (err.stdout) process.stdout.write(err.stdout);
+  }
 }
 
-try {
-  execFileSync("npx", ["oxfmt", "--write", filePath], { encoding: "utf-8", timeout: 10000, stdio: "pipe" });
-} catch {
-  // oxfmt failure is non-blocking
+if (fs.existsSync(oxfmtBin)) {
+  try {
+    execFileSync(oxfmtBin, ["--write", filePath], {
+      encoding: "utf-8",
+      timeout: 10000,
+      stdio: "pipe",
+    });
+  } catch {
+    // oxfmt failure is non-blocking
+  }
 }
 
 process.exit(0);


### PR DESCRIPTION
## Summary
- Replace `npx oxlint` and `npx oxfmt` calls with direct `node_modules/.bin/oxlint` and `node_modules/.bin/oxfmt` paths
- Add `fs.existsSync` guard before each invocation — silently skips if `node_modules` is absent, preventing unexpected network fetches from npm

Closes #728