### PR TITLE
chore: add .oxlintrc.json config baseline and fix unused-var warnings

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": [
+    "typescript",
+    "unicorn",
+    "oxc"
+  ],
+  "categories": {
+    "correctness": "error"
+  },
+  "rules": {},
+  "env": {
+    "builtin": true
+  }
+}


### PR DESCRIPTION
Closes #727

## Summary
- Adds `.oxlintrc.json` with explicit config baseline so rule selection is stable across oxlint upgrades
- Removes 5 unused imports from `tests/unit/init.test.js` (`beforeEach`, `afterEach`, `fs`, `path`, `os`)
- Removes unused `isGitPush` function from `.claude/hooks/issue-pr-enforce.js`
- Fixes unused `catch (err)` parameter in `.claude/hooks/copilot-merge-gate.js`

## Test plan
- [ ] `./node_modules/.bin/oxlint` reports 0 warnings and 0 errors
- [ ] `npm test` passes (785 tests, 0 failures)