### PR TITLE
feat: simplify lint-format hook — delegate file filtering to tool config

### DIFF
--- a/.claude/hooks/lint-format.js
+++ b/.claude/hooks/lint-format.js
@@ -26,12 +26,6 @@ if (!filePath) {
   process.exit(0);
 }
 
-const ext = path.extname(filePath);
-const LINTABLE = [".js", ".ts", ".jsx", ".tsx"];
-if (!LINTABLE.includes(ext)) {
-  process.exit(0);
-}
-
 const oxlintBin = path.resolve("node_modules/.bin/oxlint");
 const oxfmtBin = path.resolve("node_modules/.bin/oxfmt");
 


### PR DESCRIPTION
Closes #711

Removes the hardcoded `LINTABLE = [".js", ".ts", ".jsx", ".tsx"]` array and the extension check that uses it. File filtering is now delegated to the tool config (`.oxfmtrc.json`) — the hook simply passes the edited file path to oxlint and oxfmt and lets the tools decide whether to process it.