### PR TITLE
chore: suppress git init default branch hints in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
+      - name: Configure git defaults
+        run: git config --global init.defaultBranch main
+
       - run: npm ci
 
       - name: Build


### PR DESCRIPTION
Closes #744

## Summary

- Adds `git config --global init.defaultBranch main` step to the `build-and-test` CI job, after `actions/setup-node` and before `npm ci`
- Eliminates ~494 `hint: Using 'master' as the name for the initial branch` messages from `git init` calls in scenario/integration tests
- Only `build-and-test` needs this — the `validate` and `validate-hooks` jobs don't invoke `git init`

## Test plan

- [x] All 785 tests pass locally with no regressions
- [ ] CI passes on this PR