### PR TITLE
chore: review oxlintrc.json — configure unicorn/oxc rule defaults

### DIFF
--- a/.claude/hooks/issue-pr-enforce.js
+++ b/.claude/hooks/issue-pr-enforce.js
@@ -28,10 +28,6 @@ function isGitCommit(cmd) {
   return /\bgit\s+commit\b/.test(cmd);
 }
 
-function isGitPush(cmd) {
-  return /\bgit\s+push\b/.test(cmd);
-}
-
 function isPushToMain(cmd) {
   return /\bgit\s+push\b.*\b(main|master)\b/.test(cmd);
 }

--- a/.claude/hooks/merge-skill-gate.js
+++ b/.claude/hooks/merge-skill-gate.js
@@ -16,7 +16,7 @@
 let input = {};
 try {
   input = JSON.parse(process.argv[2] || "{}");
-} catch (err) {
+} catch {
   process.exit(0); // don't block on parse failure — other hooks handle that
 }
 


### PR DESCRIPTION
Closes #756

## Summary

- Reviewed all unicorn/oxc rules enabled by the current `oxlintrc.json` config
- The `categories: { correctness: "error" }` setting already restricts to correctness-only rules — opinionated style/pedantic unicorn rules are off by default. No rule disables needed.
- Fixed two pre-existing `no-unused-vars` errors caught by oxlint:
  - `merge-skill-gate.js`: removed unused `err` catch parameter (bare `catch`)
  - `issue-pr-enforce.js`: removed dead `isGitPush()` function (`isPushToMain` covers it)
- `npx oxlint` now exits clean: 0 warnings, 0 errors

## Test plan

- [x] `npx oxlint` — zero findings
- [x] `npm test` — 785 pass, 0 fail
- [x] `npx oxfmt --check` on changed files — clean