### PR TITLE
feat: add test:coverage script using Node 22 built-in coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:unit": "node --test \"tests/unit/*.test.js\"",
     "test:integration": "node --test \"tests/integration/*.test.js\"",
     "test:scenarios": "node --test \"tests/scenarios/*.test.js\"",
+    "test:coverage": "node --test --experimental-test-coverage \"tests/**/*.test.js\"",
     "dev": "tsc --watch",
     "lint": "oxlint --tsconfig tsconfig.json src/ scripts/ templates/hooks/ tests/",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
Closes #755

## Summary
- Adds `test:coverage` npm script using Node 22 `--experimental-test-coverage`
- Zero external dependencies
- Current coverage: 93.53% line, 84.07% branch, 93.85% function

## Test plan
- [x] `npm run test:coverage` produces coverage report
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)