### PR TITLE
chore: parallelize CI lint/typecheck/format, remove duplicate validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run tests
         run: npm test
 
-  lint-and-format:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -51,8 +51,32 @@ jobs:
       - name: Lint
         run: npm run lint
 
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - run: npm ci
+
       - name: Typecheck
         run: npm run typecheck
+
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - run: npm ci
 
       - name: Format check
         run: npm run format:check
@@ -74,9 +98,6 @@ jobs:
 
       - name: Validate README accuracy
         run: node scripts/validate-readme.js
-
-      - name: Validate hook scripts
-        run: node scripts/validate-hooks.js
 
   validate-hooks:
     runs-on: ${{ matrix.os }}
@@ -107,4 +128,3 @@ jobs:
 
       - name: Audit dependencies
         run: npm audit --audit-level=moderate
-


### PR DESCRIPTION
Closes #751

## Summary

- Split `lint-and-format` into three parallel jobs: `lint`, `typecheck`, `format-check` — failures are now reported independently instead of sequentially
- Removed duplicate "Validate hook scripts" step from the `validate` job — `validate-hooks` already runs this across all three OS platforms

## Branch protection update required

The old `lint-and-format` status check name no longer exists after this change. Branch protection rulesets must be updated to reference the new job names:
- `lint-and-format` → replace with `lint`, `typecheck`, `format-check`

This must be done in GitHub repo settings after this PR merges, or CI will not gate on these checks.

## Test plan

- [ ] CI passes — all new parallel jobs run successfully
- [ ] `validate` job no longer runs hook validation (covered by `validate-hooks`)
- [ ] Branch protection ruleset updated with new check names after merge