### PR TITLE
fix: add unit tests for merge-gate hook

### DIFF
--- a/tests/unit/hooks.test.js
+++ b/tests/unit/hooks.test.js
@@ -2635,7 +2635,6 @@ describe("dev-team-merge-gate", () => {
       timeout: 5000,
       cwd: opts.cwd || tmpDir,
       env,
-      windowsVerbatimArguments: true,
     });
     return { code: result.status, stdout: result.stdout || "", stderr: result.stderr || "" };
   }


### PR DESCRIPTION
Closes #749

## Summary
- Adds 19 unit tests covering all code paths in the merge-gate hook (`templates/hooks/dev-team-merge-gate.js`)
- Tests use fake git/gh scripts in temp directories to control branch detection without hitting real repos
- Covers: pass-through for non-merge commands, --skip-review escape hatch, JSON parse failure (fail-open), detached HEAD, missing .reviews/ directory, sidecar branch matching (JSON field + filename fallback), wrong-branch blocking, empty reviews dir, cleanup-manifest exclusion, broken JSON sidecars, command regex variants, and PR number lookup

## Test plan
- [x] All 815+ tests pass (`npm test`)
- [x] Formatting passes (`npx oxfmt --check .`)
- [ ] CI passes on PR