### PR TITLE
feat: complexity-aware merge gate — enforce review tier before merge

### DIFF
--- a/templates/hooks/dev-team-merge-gate.js
+++ b/templates/hooks/dev-team-merge-gate.js
@@ -171,5 +171,63 @@ if (branchMatchingSidecars.length === 0) {
   process.exit(2);
 }
 
-// Review evidence found for the correct branch — allow the merge
+// ─── Complexity-aware enforcement ──────────────────────────────────────────
+// If a Brooks assessment exists for this branch and classifies it as COMPLEX,
+// require sidecar evidence from each agent in requiredReviewers.
+// If no assessment exists or it's SIMPLE, the any-sidecar check above suffices.
+
+const assessmentsDir = path.join(process.cwd(), ".dev-team", ".assessments");
+const assessmentPath = path.join(assessmentsDir, sanitizedBranch + ".json");
+
+let assessment = null;
+try {
+  if (fs.existsSync(assessmentPath)) {
+    assessment = JSON.parse(fs.readFileSync(assessmentPath, "utf-8"));
+  }
+} catch {
+  // Malformed assessment JSON — fall back to any-sidecar behavior
+  assessment = null;
+}
+
+if (
+  assessment &&
+  assessment.complexity === "COMPLEX" &&
+  Array.isArray(assessment.requiredReviewers) &&
+  assessment.requiredReviewers.length > 0
+) {
+  // Extract the agent name from each matching sidecar
+  const reviewedAgents = new Set();
+  for (const f of branchMatchingSidecars) {
+    const sidecarPath = path.join(reviewsDir, f);
+    try {
+      const data = JSON.parse(fs.readFileSync(sidecarPath, "utf-8"));
+      if (data.agent) {
+        reviewedAgents.add(data.agent.toLowerCase());
+      }
+    } catch {
+      // skip unparseable sidecars
+    }
+  }
+
+  const missing = assessment.requiredReviewers.filter((r) => !reviewedAgents.has(r.toLowerCase()));
+
+  if (missing.length > 0) {
+    console.error(
+      "[dev-team merge-gate] BLOCKED — COMPLEX task missing required reviewers: " +
+        missing.join(", "),
+    );
+    console.error("\nBranch: " + mergeBranch);
+    console.error("Assessment requires reviews from: " + assessment.requiredReviewers.join(", "));
+    console.error(
+      "Reviews found from: " +
+        (reviewedAgents.size > 0 ? [...reviewedAgents].join(", ") : "(none)"),
+    );
+    console.error(
+      "\nRun the missing review agents, or use --skip-review to bypass (logged as deviation).",
+    );
+    process.exit(2);
+  }
+}
+
+// Review evidence found (and complexity requirements satisfied) — allow the merge
 process.exit(0);

--- a/templates/skills/dev-team-implement/SKILL.md
+++ b/templates/skills/dev-team-implement/SKILL.md
@@ -37,6 +37,20 @@ Implement: $ARGUMENTS
 
    If an ADR is needed, include "Write ADR-NNN: <title>" in the implementation task. The implementing agent writes the ADR file.
 
+   **Write assessment sidecar** — after the pre-assessment completes, write the complexity classification to `.dev-team/.assessments/<sanitized-branch>.json` so the merge gate can enforce the correct review tier:
+
+   ```json
+   {
+     "branch": "<branch-name>",
+     "complexity": "SIMPLE | COMPLEX",
+     "reviewTier": "LIGHT | FULL",
+     "requiredReviewers": ["szabo", "knuth"],
+     "assessedAt": "<ISO-8601 timestamp>"
+   }
+   ```
+
+   For SIMPLE tasks, `requiredReviewers` should be an empty array (Copilot-only is sufficient). For COMPLEX tasks, include the agents that must review before merge. Sanitize the branch name for the filename by replacing non-alphanumeric characters (except hyphens) with hyphens.
+
    **Timeout**: If the pre-assessment agent has not reported progress within 2 minutes, send a status ping. If no response within 1 additional minute, terminate and either perform the pre-assessment yourself or skip it.
 
 ## Definition of Done (COMPLEX tasks only)
@@ -60,6 +74,7 @@ The implementing agent works on the task on a feature branch.
 **Timeout**: If the implementing agent has not reported progress (status file, message, or commit) within 2 minutes, send a status ping. If no response within 1 additional minute, terminate the agent, assess what was completed, and either resume the work yourself or re-spawn a fresh agent with the remaining tasks.
 
 **Validation** — before completion, verify:
+
 - Non-empty diff: `git diff` shows actual changes
 - Tests pass: test command executed with exit code 0
 - Relevance: changed files relate to the stated issue
@@ -73,6 +88,7 @@ The implementing agent works on the task on a feature branch.
 ## Output
 
 When invoked with `--embedded` (from `/dev-team:task`), return a compact summary:
+
 - Branch name
 - PR number
 - Files changed

--- a/tests/unit/hooks.test.js
+++ b/tests/unit/hooks.test.js
@@ -2815,6 +2815,108 @@ describe("dev-team-merge-gate", () => {
     });
   });
 
+  // ─── Complexity-aware enforcement ─────────────────────────────────────────
+
+  describe("complexity-aware merge gate", () => {
+    const branch = "feat/747-complexity-gate";
+    const mergeCmd = `gh pr merge ${branch}`;
+    const sanitized = branch.replace(/[^a-zA-Z0-9-]/g, "-");
+
+    function setupDirs() {
+      const reviewsDir = path.join(tmpDir, ".dev-team", ".reviews");
+      const assessmentsDir = path.join(tmpDir, ".dev-team", ".assessments");
+      fs.mkdirSync(reviewsDir, { recursive: true });
+      fs.mkdirSync(assessmentsDir, { recursive: true });
+      return { reviewsDir, assessmentsDir };
+    }
+
+    function writeAssessment(assessmentsDir, data) {
+      fs.writeFileSync(path.join(assessmentsDir, sanitized + ".json"), JSON.stringify(data));
+    }
+
+    function writeSidecar(reviewsDir, agent, branchName) {
+      const sidecar = { branch: branchName, agent, hash: "h" + agent, tier: "FULL" };
+      fs.writeFileSync(path.join(reviewsDir, `${agent}-h${agent}.json`), JSON.stringify(sidecar));
+    }
+
+    it("allows COMPLEX merge when all required reviewers present (exit 0)", () => {
+      const { reviewsDir, assessmentsDir } = setupDirs();
+      writeAssessment(assessmentsDir, {
+        branch,
+        complexity: "COMPLEX",
+        reviewTier: "FULL",
+        requiredReviewers: ["szabo", "knuth"],
+        assessedAt: "2026-04-03T18:45:00Z",
+      });
+      writeSidecar(reviewsDir, "szabo", branch);
+      writeSidecar(reviewsDir, "knuth", branch);
+      const result = runMergeGate(mergeCmd);
+      assert.equal(result.code, 0, "all required reviewers present should allow merge");
+    });
+
+    it("blocks COMPLEX merge when a required reviewer is missing (exit 2)", () => {
+      const { reviewsDir, assessmentsDir } = setupDirs();
+      writeAssessment(assessmentsDir, {
+        branch,
+        complexity: "COMPLEX",
+        reviewTier: "FULL",
+        requiredReviewers: ["szabo", "knuth"],
+        assessedAt: "2026-04-03T18:45:00Z",
+      });
+      writeSidecar(reviewsDir, "szabo", branch);
+      // knuth missing
+      const result = runMergeGate(mergeCmd);
+      assert.equal(result.code, 2, "missing required reviewer should block");
+      assert.ok(result.stderr.includes("knuth"), "should name the missing reviewer");
+      assert.ok(result.stderr.includes("COMPLEX"), "should mention COMPLEX");
+    });
+
+    it("allows SIMPLE assessment with any sidecar (exit 0)", () => {
+      const { reviewsDir, assessmentsDir } = setupDirs();
+      writeAssessment(assessmentsDir, {
+        branch,
+        complexity: "SIMPLE",
+        reviewTier: "LIGHT",
+        requiredReviewers: [],
+        assessedAt: "2026-04-03T18:45:00Z",
+      });
+      writeSidecar(reviewsDir, "szabo", branch);
+      const result = runMergeGate(mergeCmd);
+      assert.equal(result.code, 0, "SIMPLE with any sidecar should allow merge");
+    });
+
+    it("falls back to any-sidecar when no assessment file exists (exit 0)", () => {
+      const { reviewsDir } = setupDirs();
+      // No assessment written
+      writeSidecar(reviewsDir, "szabo", branch);
+      const result = runMergeGate(mergeCmd);
+      assert.equal(result.code, 0, "no assessment should fall back to any-sidecar");
+    });
+
+    it("falls back to any-sidecar when assessment has malformed JSON (exit 0)", () => {
+      const { reviewsDir, assessmentsDir } = setupDirs();
+      fs.writeFileSync(path.join(assessmentsDir, sanitized + ".json"), "not-valid-json{{{");
+      writeSidecar(reviewsDir, "szabo", branch);
+      const result = runMergeGate(mergeCmd);
+      assert.equal(result.code, 0, "malformed assessment should fall back to any-sidecar");
+    });
+
+    it("is case-insensitive for reviewer agent names", () => {
+      const { reviewsDir, assessmentsDir } = setupDirs();
+      writeAssessment(assessmentsDir, {
+        branch,
+        complexity: "COMPLEX",
+        reviewTier: "FULL",
+        requiredReviewers: ["Szabo", "Knuth"],
+        assessedAt: "2026-04-03T18:45:00Z",
+      });
+      writeSidecar(reviewsDir, "szabo", branch);
+      writeSidecar(reviewsDir, "knuth", branch);
+      const result = runMergeGate(mergeCmd);
+      assert.equal(result.code, 0, "case-insensitive matching should allow merge");
+    });
+  });
+
   // ─── detectBranch: PR number lookup ───────────────────────────────────────
 
   describe("detectBranch with PR number", () => {


### PR DESCRIPTION
Closes #747

## Summary

- Extend `templates/hooks/dev-team-merge-gate.js` to read Brooks assessment sidecars from `.dev-team/.assessments/<branch>.json` and enforce required reviewers for COMPLEX tasks
- Update `templates/skills/dev-team-implement/SKILL.md` to write the assessment sidecar after Brooks pre-assessment
- Add 6 unit tests covering: COMPLEX with all/missing reviewers, SIMPLE fallback, no assessment file, malformed JSON, case-insensitive matching

## Design

After the existing any-sidecar check passes, the hook reads `.dev-team/.assessments/<sanitized-branch>.json`. If `complexity === "COMPLEX"` and `requiredReviewers` is non-empty, it verifies that each required reviewer has a matching sidecar (by the `agent` JSON field, case-insensitive). Missing reviewers produce a blocking error listing who is missing and who was found.

Fallback behavior (no assessment, SIMPLE assessment, malformed JSON) is unchanged — any branch-matching sidecar suffices.

## Test plan

- [x] COMPLEX assessment with all required reviewers present -> allow (exit 0)
- [x] COMPLEX assessment with missing required reviewer -> block (exit 2)
- [x] SIMPLE assessment with empty requiredReviewers -> fall back to any-sidecar (exit 0)
- [x] No assessment file -> fall back to current behavior (exit 0)
- [x] Assessment with malformed JSON -> fall back (exit 0)
- [x] Case-insensitive reviewer matching (exit 0)
- [x] All 821 existing tests pass
- [x] oxlint clean, oxfmt clean