### PR TITLE
feat: realign disable-model-invocation, remove --embedded flag

### DIFF
--- a/.claude/rules/dev-team-learnings.md
+++ b/.claude/rules/dev-team-learnings.md
@@ -28,7 +28,7 @@
 
 ## Design Principles
 
-- **Skill composability: orchestration skills can invoke other skills.** /dev-team:extract and /dev-team:review are invoked by /dev-team:task as sub-skills. Use `disable-model-invocation: true` on sub-skills to prevent autonomous firing. The `--embedded` flag signals compact output mode for skill-to-skill invocation. See ADR-035 for the formal pattern.
+- **Skill composability: orchestration skills can invoke other skills.** /dev-team:extract and /dev-team:review are invoked by /dev-team:task as pipeline steps. Pipeline step skills use `disable-model-invocation: false` (user-entry skills use `true`). The `--embedded` flag has been removed — pipeline skills always return structured output. See ADR-035 for the composability pattern.
 - **Don't encode what agents already know.** AI agents have built-in knowledge of languages, frameworks, conventions, and standards. Hardcoding language-specific patterns (test file regex, linter commands, complexity keywords) into hooks or config creates static encyclopedias that are always incomplete. Instead, hooks should detect the ecosystem (read manifest files) and delegate language-specific reasoning to the agent. Include only what agents can't discover: tool preferences, legacy traps, test quirks, custom middleware warnings. (See: "AGENTS.md Verdict" — if the agent can discover it from code, delete it.)
 - **Adapter registry for multi-runtime portability (ADR-036).** ~~Superseded by ADR-040 (GitHub-first, Claude Code-only). Non-Claude adapters planned for removal in #660.~~
 

--- a/templates/skills/dev-team-challenge/SKILL.md
+++ b/templates/skills/dev-team-challenge/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: dev-team-challenge
 description: Challenge a proposed approach, implementation, or design decision. Use when the user says "challenge this", "what could go wrong", "play devil's advocate", or wants a critical review of an idea before committing to it.
+disable-model-invocation: false
 ---
 
 Critically examine the following proposal or implementation: $ARGUMENTS

--- a/templates/skills/dev-team-extract/SKILL.md
+++ b/templates/skills/dev-team-extract/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev-team-extract
 description: Borges memory extraction — spawns Borges to record metrics, extract memory entries, and verify completion gates. Called by task, review, audit, and retro skills after their primary work is done.
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 Extract memory and metrics via @dev-team-borges for: $ARGUMENTS

--- a/templates/skills/dev-team-implement/SKILL.md
+++ b/templates/skills/dev-team-implement/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev-team-implement
 description: Implement a task on a feature branch with architect pre-assessment, agent selection, and validation. Use standalone or as Step 1 of /dev-team:task.
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 Implement: $ARGUMENTS
@@ -87,7 +87,7 @@ The implementing agent works on the task on a feature branch.
 
 ## Output
 
-When invoked with `--embedded` (from `/dev-team:task`), return a compact summary:
+Return a structured summary:
 
 - Branch name
 - PR number
@@ -95,7 +95,7 @@ When invoked with `--embedded` (from `/dev-team:task`), return a compact summary
 - Complexity classification
 - Whether ADR was written
 
-When invoked standalone, report the PR URL and wait for the user's next action.
+Report the PR URL on completion.
 
 ## Security preamble
 

--- a/templates/skills/dev-team-merge/SKILL.md
+++ b/templates/skills/dev-team-merge/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev-team-merge
 description: Merge a PR with monitoring -- waits for review workflows, addresses unresolved threads, resolves them via GraphQL, sets auto-merge, and monitors until complete.
-user_invocable: true
+disable-model-invocation: false
 ---
 
 Merge a pull request with full monitoring: $ARGUMENTS

--- a/templates/skills/dev-team-review/SKILL.md
+++ b/templates/skills/dev-team-review/SKILL.md
@@ -1,23 +1,14 @@
 ---
 name: dev-team-review
 description: Orchestrated multi-agent parallel review. Use to review a PR, branch, or set of changes with multiple specialist agents simultaneously. Spawns agents based on changed file patterns and produces a unified review summary.
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 Run a multi-agent parallel review of: $ARGUMENTS
 
-## Invocation modes
-
-This skill supports two invocation modes:
-
-- **Standalone** (user calls `/dev-team:review` directly): Full review lifecycle including the Completion section (finding outcome log + `/dev-team:extract`).
-- **Embedded** (called by `/dev-team:task` during Step 2): Produce the review report and return findings to the caller. **Skip the Completion section entirely** — the task skill handles finding routing, iteration, and extraction in its own Steps 2 and 4. When called with the flag `--embedded`, operate in embedded mode.
-
-In embedded mode, the review skill produces its report and returns control to the task skill. The review report output (findings, filtered, verdict sections) is identical in both modes — the Completion section is a post-report lifecycle action, not part of the report itself.
-
 ## Setup
 
-0. **Parse flags:** If `$ARGUMENTS` contains `--embedded`, note embedded mode and strip the flag. If `$ARGUMENTS` contains `--light`, note LIGHT review mode and strip the flag. Process the remaining arguments as the review target.
+0. **Parse flags:** If `$ARGUMENTS` contains `--light`, note LIGHT review mode and strip the flag. Process the remaining arguments as the review target.
 
 1. Determine what to review:
    - If a PR number or branch is given, use `git diff` to get the changed files
@@ -113,8 +104,6 @@ State the verdict clearly. List what must be fixed for approval if requesting ch
 Before issuing any `gh issue`, `gh pr`, or other platform-specific CLI commands, check `.dev-team/config.json` for the `platform` and `issueTracker` fields. If the project specifies a non-GitHub platform (e.g., `"gitlab"`, `"bitbucket"`, `"other"`), adapt issue tracker and PR commands accordingly — use `glab` for GitLab, the Bitbucket API, or the appropriate CLI for the configured platform. If `platform` is absent from config.json, default to `"github"`. The steps in this skill assume GitHub by default.
 
 ### Completion
-
-**Standalone mode only** (skip this section entirely when `--embedded` flag is present):
 
 After the review report is delivered:
 1. Format the **finding outcome log** with every finding's classification, source agent, and outcome (accepted/overruled/ignored), including reasoning for overrules. Then call `/dev-team:extract` with the formatted log.

--- a/templates/skills/dev-team-scorecard/SKILL.md
+++ b/templates/skills/dev-team-scorecard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev-team-scorecard
 description: Audit process conformance after a workflow completes (task, review, or audit). Checks Borges ran, findings acknowledged, metrics recorded, review executed, memory updated, and conditionally checks ADR written and issue closed.
-user_invocable: false
+disable-model-invocation: true
 ---
 
 Audit process conformance for: $ARGUMENTS

--- a/templates/skills/dev-team-task/SKILL.md
+++ b/templates/skills/dev-team-task/SKILL.md
@@ -32,7 +32,7 @@ At each phase boundary, emit a structured status line before proceeding. This gi
 **Single-issue mode:**
 ```
 [dev-team:task] Step 1/4: Implement — <agent> on <branch>...
-[dev-team:task] Step 2/4: Review — /dev-team:review --embedded (round <N>)...
+[dev-team:task] Step 2/4: Review — /dev-team:review (round <N>)...
 [dev-team:task] Step 3/4: Merge — /dev-team:merge PR #NNN...
 [dev-team:task] Step 4/4: Extract — spawning Borges...
 [dev-team:task] Done — PR #NNN merged, <N> DEFECTs fixed
@@ -52,7 +52,7 @@ Phase markers are consistent with agent-level progress reporting (ADR-026).
 
 ## Step 1: Implement
 
-Call `/dev-team:implement --embedded` with the task description. The implement skill handles agent selection, Brooks pre-assessment, Definition of Done negotiation, best-practices research, implementation, validation, and PR creation.
+Call `/dev-team:implement` with the task description. The implement skill handles agent selection, Brooks pre-assessment, Definition of Done negotiation, best-practices research, implementation, validation, and PR creation.
 
 For SIMPLE tasks (or when `--skip-assessment` is appropriate), pass that flag through.
 
@@ -62,18 +62,16 @@ The implement skill returns: branch name, PR number, files changed, complexity c
 
 **Review intensity** is determined by the complexity classification from Brooks' pre-assessment:
 
-- **SIMPLE tasks -> LIGHT review**: Call `/dev-team:review --embedded --light`. LIGHT reviews are advisory only — all findings (including `[DEFECT]`) are treated as advisory. A single reviewer is spawned. The review serves as a quality signal but does not block progress.
-- **COMPLEX tasks -> FULL review**: Call `/dev-team:review --embedded`. Full reviewer set, blocking `[DEFECT]` semantics, standard iteration loop.
+- **SIMPLE tasks -> LIGHT review**: Call `/dev-team:review --light`. LIGHT reviews are advisory only — all findings (including `[DEFECT]`) are treated as advisory. A single reviewer is spawned. The review serves as a quality signal but does not block progress.
+- **COMPLEX tasks -> FULL review**: Call `/dev-team:review`. Full reviewer set, blocking `[DEFECT]` semantics, standard iteration loop.
 - **If pre-assessment was skipped** (bug fixes, typo fixes, config tweaks): default to LIGHT review.
 
-Call `/dev-team:review --embedded [--light]` with the current branch or PR as the argument. The review skill handles:
+Call `/dev-team:review [--light]` with the current branch or PR as the argument. The review skill handles:
 - Agent selection based on changed file patterns (full set for FULL review, single reviewer for LIGHT)
 - Spawning reviewers in parallel as background tasks
 - Timeout handling for unresponsive reviewers
 - The judge pass (filter/deduplicate/validate findings)
 - Producing a structured report with classified findings
-
-The `--embedded` flag tells the review skill to skip its Completion section (finding outcome log + `/dev-team:extract`) — the task skill handles extraction in Step 4.
 
 Receive the review report and proceed to finding routing below.
 
@@ -101,7 +99,7 @@ After the implementer has acknowledged all findings, **compact the context** bef
 - Produce a structured summary: all findings (agent, classification, file, status/outcome), files changed, outstanding items
 - This compact summary is available in the task skill's context for continuity across rounds
 
-Call `/dev-team:review --embedded` again for the next round, passing the compact summary as part of the arguments so that reviewers have prior-round context (which findings were raised, how they were resolved, and what remains outstanding). The review skill spawns fresh reviewers each round — they receive the current diff, the compact summary, and their agent definition. They do NOT receive raw conversation history from prior rounds.
+Call `/dev-team:review` again for the next round, passing the compact summary as part of the arguments so that reviewers have prior-round context (which findings were raised, how they were resolved, and what remains outstanding). The review skill spawns fresh reviewers each round — they receive the current diff, the compact summary, and their agent definition. They do NOT receive raw conversation history from prior rounds.
 
 Continue iterating until no `[DEFECT]` remains or max iterations reached. If max iterations reached without convergence, report remaining defects and exit.
 
@@ -109,7 +107,7 @@ Continue iterating until no `[DEFECT]` remains or max iterations reached. If max
 
 The task skill's iteration model uses two strategies to manage context growth:
 
-1. **Fresh reviewers per round**: Each `/dev-team:review --embedded` call spawns new reviewer agents. They receive only the current diff and the compact summary — not raw conversation history from prior rounds. This provides a natural context reset that prevents reviewers from anchoring on stale findings.
+1. **Fresh reviewers per round**: Each `/dev-team:review` call spawns new reviewer agents. They receive only the current diff and the compact summary — not raw conversation history from prior rounds. This provides a natural context reset that prevents reviewers from anchoring on stale findings.
 
 2. **Compact summaries between rounds**: After each round, the orchestrator produces a structured summary (findings, outcomes, files changed, outstanding items). This compressed representation replaces verbose raw findings in subsequent rounds.
 
@@ -160,7 +158,7 @@ Drucker spawns one implementing agent per independent issue, each on its own bra
 **Sequential chain gate:** When issues are sequenced due to file conflicts, verify the previous change is integrated into the shared codebase before starting the next dependent task. Do not spawn the next agent until integration is confirmed. This is a hard gate.
 
 ### Steps 2–3 (per-branch, as each PR lands)
-Review each branch **the moment its implementing agent finishes** — do not wait for all implementations to complete. As soon as an agent reports completion and passes Step 1 validation (non-empty diff, tests pass, relevance, clean tree), immediately call `/dev-team:review --embedded [--light]` for that branch (using `--light` for SIMPLE branches, omitting it for COMPLEX branches).
+Review each branch **the moment its implementing agent finishes** — do not wait for all implementations to complete. As soon as an agent reports completion and passes Step 1 validation (non-empty diff, tests pass, relevance, clean tree), immediately call `/dev-team:review [--light]` for that branch (using `--light` for SIMPLE branches, omitting it for COMPLEX branches).
 
 This means reviews and implementations run concurrently: some branches are under review while others are still being implemented. For sequential chains, the first branch in a chain enters review while the next dependent branch is being implemented — though the next branch still waits for the predecessor to merge before starting.
 


### PR DESCRIPTION
## Summary

- Realigns `disable-model-invocation` on all 9 template skills: top-level entry-point skills (`task`, `retro`, `audit`, `scorecard`) get `true`; pipeline step skills (`challenge`, `implement`, `review`, `merge`, `extract`) get `false`
- Fixes `scorecard` (had wrong field `user_invocable: false`) and `merge` (had `user_invocable: true`)
- Removes all `--embedded` flag references from `task`, `implement`, and `review` — pipeline skills now always return structured output without dual-mode behavior
- Updates `.claude/rules/dev-team-learnings.md` to reflect the new composability model

Closes #786

## Test plan

- [x] `npm test` passes on skill/learnings changes
- [x] All 9 `templates/skills/*/SKILL.md` files have correct `disable-model-invocation` values
- [x] No `--embedded` references remain in `templates/skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)