### PR TITLE
fix: add detached HEAD warning log and test to review-gate

### DIFF
--- a/templates/hooks/dev-team-review-gate.js
+++ b/templates/hooks/dev-team-review-gate.js
@@ -173,6 +173,7 @@ function findSidecar(agent, sanitizedBranch) {
 const branch = currentBranch();
 if (!branch) {
   // Cannot determine branch - skip gates to avoid blocking detached HEAD states
+  console.warn("[dev-team review-gate] WARNING: detached HEAD — review gate skipped.");
   process.exit(0);
 }
 const sanitizedBranch = sanitizeBranch(branch);

--- a/tests/unit/review-gate.test.js
+++ b/tests/unit/review-gate.test.js
@@ -115,6 +115,30 @@ describe("dev-team-review-gate", () => {
     }
   });
 
+  it("exits 0 with warning on detached HEAD", () => {
+    const tmpDir = createTempRepo();
+    try {
+      // Detach HEAD by checking out a specific SHA
+      const sha = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: tmpDir,
+        encoding: "utf-8",
+      }).trim();
+      execFileSync("git", ["checkout", sha], { cwd: tmpDir, encoding: "utf-8" });
+
+      fs.writeFileSync(path.join(tmpDir, "handler.js"), "module.exports = {}");
+      execFileSync("git", ["add", "handler.js"], { cwd: tmpDir, encoding: "utf-8" });
+
+      const result = runGate({ command: "git commit -m 'detached'" }, tmpDir);
+      assert.equal(result.code, 0, "detached HEAD should exit 0");
+      assert.ok(
+        result.stderr.includes("detached HEAD"),
+        "should warn about detached HEAD: " + result.stderr,
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   // --- Gate 1: Review evidence ---
 
   describe("Gate 1 - review evidence", () => {


### PR DESCRIPTION
## Summary
- Add `console.warn` to the review-gate detached HEAD path so it logs a diagnostic message instead of silently exiting 0
- Add a test that checks out a specific SHA (detached HEAD), runs the hook, and verifies exit 0 + warning output

Closes #806

## Test plan
- [x] New test: detached HEAD exits 0 with warning message
- [x] All 824 existing tests pass