### PR TITLE
fix: add .dev-team/.assessments/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ coverage/
 .dev-team/.memory-reviewed
 .dev-team/agent-status/
 .dev-team/.reviews/
+.dev-team/.assessments/
 
 # Claude Code runtime artifacts
 .claude/worktrees/


### PR DESCRIPTION
## Summary
- Adds `.dev-team/.assessments/` to `.gitignore` alongside the existing `.dev-team/.reviews/` entry
- ADR-043 states assessment sidecars should be gitignored but the entry was missing

## Test plan
- [x] `npm test` — all 824 tests pass
- [x] Verified `.gitignore` diff is minimal (1 line addition)

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)