### PR TITLE
feat: decouple PR creation from implement skill

### DIFF
--- a/templates/skills/dev-team-implement/SKILL.md
+++ b/templates/skills/dev-team-implement/SKILL.md
@@ -81,21 +81,18 @@ The implementing agent works on the task on a feature branch.
 - Clean working tree: no uncommitted debris
 - If validation fails, route back to implementer with specific failure reason. If it fails twice, escalate to human.
 
-**Deliver the work**: Create the PR. The PR body must include `Closes #NNN` for the associated GitHub issue.
+**Deliver the work**: Push the branch to remote. PR creation is handled by the orchestrator or a separate pipeline step (`/dev-team:pr`). Do NOT create a PR from this skill.
 
-**Clean up worktree**: If the work was done in a worktree, clean it up after the branch is pushed and the PR is created.
+**Clean up worktree**: If the work was done in a worktree, clean it up after the branch is pushed.
 
 ## Output
 
 Return a structured summary:
 
 - Branch name
-- PR number
 - Files changed
 - Complexity classification
 - Whether ADR was written
-
-Report the PR URL on completion.
 
 ## Security preamble
 


### PR DESCRIPTION
## Summary
- Removes PR creation responsibility from the implement skill — it now stops at "branch pushed to remote"
- Removes PR number and PR URL from the skill's output section
- Supports the reordered pipeline where review happens before PR creation

Closes #776

## Test plan
- [x] All 839 tests pass
- [ ] Verify `/dev-team:implement` no longer creates PRs when used in a task pipeline

Generated with [Claude Code](https://claude.com/claude-code)