### PR TITLE
feat: PR format enforcement hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ npx @fredericboyer/dev-team create-agent <name>     # Scaffold a custom agent
 
 **Opus** agents do deep analysis — Szabo, Knuth, Brooks, and Turing are read-only; Drucker uses opus for orchestration with full access. **Sonnet** agents implement (faster, full write access). Hopper handles backend, frontend, and infrastructure. Borges runs at end-of-workflow for memory consolidation. Rams reviews design system compliance.
 
-### Hooks (12)
+### Hooks (17)
 
 | Hook | Trigger | Behavior |
 |------|---------|----------|
@@ -147,6 +147,11 @@ npx @fredericboyer/dev-team create-agent <name>     # Scaffold a custom agent
 | Review gate | Before commit | **Blocks** commit without review evidence. Stateless commit gates for adversarial review enforcement. |
 | Merge gate | Before merge | **Blocks** `gh pr merge` without review sidecars. Complexity-aware enforcement via assessment sidecars. |
 | Implementer guard | Before SendMessage | **Blocks** shutdown of implementing agents before review findings are routed. Config-aware. |
+| PR title format | Before `gh pr create` | **Blocks** PR creation when title does not match `pr.titleFormat` (conventional, issue-prefix, plain). |
+| PR link keyword | Before `gh pr create` | **Blocks** PR creation when body is missing `pr.linkKeyword` issue reference (e.g., `Closes #123`). |
+| PR draft advisory | Before `gh pr create` | **Advisory** warning when `pr.draft` is enabled but `--draft` flag is missing. Never blocks. |
+| PR template sections | Before `gh pr create` | **Blocks** PR creation when body is missing required sections from `pr.template` array. |
+| PR auto-label | Before `gh pr create` | **Advisory** label suggestions based on branch prefix (`feat/` -> enhancement, `fix/` -> bug). |
 | Worktree create | Before worktree creation | **Serializes** parallel worktree creation to prevent git lock races. |
 | Worktree remove | After worktree removal | **Cleans up** worktree artifacts and stale branch references. |
 
@@ -324,7 +329,7 @@ Updates agents, hooks, and skills to the latest templates. Preserves your agent 
 
 ```
 .dev-team/
-  hooks/               # 8 quality enforcement scripts
+  hooks/               # 13 quality enforcement scripts
   config.json          # Installation preferences
 .claude/
   agents/              # 11 agent definitions (.agent.md, YAML frontmatter + prompt)

--- a/src/init.ts
+++ b/src/init.ts
@@ -312,6 +312,31 @@ const QUALITY_HOOKS: HookDefinition[] = [
     file: "dev-team-implementer-guard.js",
     description: "Block shutdown of implementing agents before review completes",
   },
+  {
+    label: "PR title format",
+    file: "dev-team-pr-title-format.js",
+    description: "Validate PR title matches configured format (conventional, issue-prefix, plain)",
+  },
+  {
+    label: "PR link keyword",
+    file: "dev-team-pr-link-keyword.js",
+    description: "Require PR body to contain an issue link keyword (e.g., Closes #NNN)",
+  },
+  {
+    label: "PR draft advisory",
+    file: "dev-team-pr-draft.js",
+    description: "Warn when pr.draft is enabled but --draft flag is missing (advisory only)",
+  },
+  {
+    label: "PR template sections",
+    file: "dev-team-pr-template.js",
+    description: "Validate PR body contains required template sections",
+  },
+  {
+    label: "PR auto-label",
+    file: "dev-team-pr-auto-label.js",
+    description: "Auto-suggest labels based on branch prefix when pr.autoLabel is enabled",
+  },
 ];
 
 interface PresetDefinition {

--- a/templates/hooks/dev-team-pr-auto-label.js
+++ b/templates/hooks/dev-team-pr-auto-label.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+/**
+ * dev-team-pr-auto-label.js
+ * PreToolUse hook on Bash — appends --label flags based on branch prefix.
+ *
+ * When pr.autoLabel is true, maps branch prefixes to GitHub labels:
+ *   feat/  -> enhancement
+ *   fix/   -> bug
+ *   docs/  -> documentation
+ *   chore/ -> chore
+ *   test/  -> test
+ *
+ * The hook outputs advisory label suggestions. It never blocks.
+ *
+ * When pr.autoLabel is not true, exits 0 immediately.
+ * When workflow.pr is false, exits 0 immediately.
+ * --skip-format in the command bypasses all PR format hooks (logged as deviation).
+ */
+
+"use strict";
+
+const { execFileSync } = require("child_process");
+const { readConfig, isEnabled } = require("./lib/workflow-config");
+
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || "{}");
+} catch {
+  process.exit(0);
+}
+
+const command = (input.tool_input && input.tool_input.command) || "";
+
+// Only intercept gh pr create commands
+if (!/\bgh\s+pr\s+create\b/.test(command)) {
+  process.exit(0);
+}
+
+// Skip when PR workflow is disabled
+if (!isEnabled("pr")) {
+  process.exit(0);
+}
+
+// Escape hatch
+if (/--skip-format\b/.test(command)) {
+  console.warn(
+    "[dev-team pr-auto-label] WARNING: --skip-format used — PR format hooks bypassed. " +
+      "This is logged as a process deviation for Borges calibration.",
+  );
+  process.exit(0);
+}
+
+const config = readConfig();
+const pr = config.pr || {};
+
+if (pr.autoLabel !== true) {
+  process.exit(0);
+}
+
+// Determine current branch
+let branch = "";
+try {
+  branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
+    timeout: 3000,
+  }).trim();
+} catch {
+  process.exit(0);
+}
+
+if (!branch || branch === "HEAD") {
+  process.exit(0);
+}
+
+// Map branch prefixes to labels
+const PREFIX_LABEL_MAP = {
+  "feat/": "enhancement",
+  "fix/": "bug",
+  "docs/": "documentation",
+  "chore/": "chore",
+  "test/": "test",
+};
+
+const labelsToAdd = [];
+for (const [prefix, label] of Object.entries(PREFIX_LABEL_MAP)) {
+  if (branch.startsWith(prefix)) {
+    // Check if this label is already in the command
+    const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const labelPattern = new RegExp("--label\\s+['\"]?" + escapedLabel + "['\"]?", "i");
+    if (!labelPattern.test(command)) {
+      labelsToAdd.push(label);
+    }
+  }
+}
+
+if (labelsToAdd.length === 0) {
+  process.exit(0);
+}
+
+// Output the labels to append
+const labelFlags = labelsToAdd.map((l) => "--label " + l).join(" ");
+console.log(
+  "[dev-team pr-auto-label] Auto-labeling from branch prefix '" + branch.split("/")[0] + "/':",
+);
+console.log("  Appending: " + labelFlags);
+console.log("  Tip: the agent should add " + labelFlags + " to the gh pr create command.");
+
+process.exit(0);

--- a/templates/hooks/dev-team-pr-draft.js
+++ b/templates/hooks/dev-team-pr-draft.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+/**
+ * dev-team-pr-draft.js
+ * PreToolUse hook on Bash — warns when pr.draft is true but --draft flag is missing.
+ *
+ * This is advisory only (never blocks). When pr.draft is true, the team prefers
+ * draft PRs for initial creation. The hook warns but allows the command to proceed.
+ *
+ * When workflow.pr is false, exits 0 immediately.
+ * --skip-format in the command bypasses all PR format hooks (logged as deviation).
+ */
+
+"use strict";
+
+const { readConfig, isEnabled } = require("./lib/workflow-config");
+
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || "{}");
+} catch {
+  process.exit(0);
+}
+
+const command = (input.tool_input && input.tool_input.command) || "";
+
+// Only intercept gh pr create commands
+if (!/\bgh\s+pr\s+create\b/.test(command)) {
+  process.exit(0);
+}
+
+// Skip when PR workflow is disabled
+if (!isEnabled("pr")) {
+  process.exit(0);
+}
+
+// Escape hatch
+if (/--skip-format\b/.test(command)) {
+  console.warn(
+    "[dev-team pr-draft] WARNING: --skip-format used — PR format hooks bypassed. " +
+      "This is logged as a process deviation for Borges calibration.",
+  );
+  process.exit(0);
+}
+
+const config = readConfig();
+const pr = config.pr || {};
+
+// Only check when pr.draft is explicitly true
+if (pr.draft !== true) {
+  process.exit(0);
+}
+
+// Check if --draft flag is present
+if (/--draft\b/.test(command)) {
+  process.exit(0);
+}
+
+// Advisory warning — do NOT block (exit 0, not exit 2)
+console.warn(
+  "[dev-team pr-draft] WARNING: pr.draft is enabled but --draft flag is missing.\n" +
+    "  Consider adding --draft to create the PR as a draft.\n" +
+    "  This is advisory only — the PR will be created as non-draft.",
+);
+
+process.exit(0);

--- a/templates/hooks/dev-team-pr-link-keyword.js
+++ b/templates/hooks/dev-team-pr-link-keyword.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+/**
+ * dev-team-pr-link-keyword.js
+ * PreToolUse hook on Bash — validates PR body contains a link keyword referencing an issue.
+ *
+ * Checks that the PR body contains `<linkKeyword> #NNN` (e.g., "Closes #123").
+ * When pr.linkKeyword is empty or not set, skips validation.
+ * When workflow.pr is false, exits 0 immediately.
+ * --skip-format in the command bypasses all PR format hooks (logged as deviation).
+ */
+
+"use strict";
+
+const { readConfig, isEnabled } = require("./lib/workflow-config");
+
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || "{}");
+} catch {
+  process.exit(0);
+}
+
+const command = (input.tool_input && input.tool_input.command) || "";
+
+// Only intercept gh pr create commands
+if (!/\bgh\s+pr\s+create\b/.test(command)) {
+  process.exit(0);
+}
+
+// Skip when PR workflow is disabled
+if (!isEnabled("pr")) {
+  process.exit(0);
+}
+
+// Escape hatch
+if (/--skip-format\b/.test(command)) {
+  console.warn(
+    "[dev-team pr-link-keyword] WARNING: --skip-format used — PR format hooks bypassed. " +
+      "This is logged as a process deviation for Borges calibration.",
+  );
+  process.exit(0);
+}
+
+const config = readConfig();
+const pr = config.pr || {};
+const linkKeyword = pr.linkKeyword || "";
+
+// When linkKeyword is empty, skip validation
+if (!linkKeyword) {
+  process.exit(0);
+}
+
+// Extract --body value from command
+const bodyMatch = command.match(/--body\s+(?:"([\s\S]*?)(?<!\\)"|'([\s\S]*?)'|(\S+))/);
+if (!bodyMatch) {
+  // No --body flag — gh pr create will prompt interactively, we cannot validate
+  process.exit(0);
+}
+const body = (bodyMatch[1] || bodyMatch[2] || bodyMatch[3] || "").replace(/\\"/g, '"');
+
+if (!body) {
+  process.exit(0);
+}
+
+// Check for linkKeyword followed by #NNN (case-insensitive)
+const escaped = linkKeyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const pattern = new RegExp(escaped + "\\s+#\\d+", "i");
+if (!pattern.test(body)) {
+  console.error("[dev-team pr-link-keyword] BLOCKED — PR body must contain an issue link.\n");
+  console.error("  Expected: " + linkKeyword + " #NNN");
+  console.error('  Example: "' + linkKeyword + ' #123"');
+  console.error("\nUse --skip-format to bypass.");
+  process.exit(2);
+}
+
+process.exit(0);

--- a/templates/hooks/dev-team-pr-template.js
+++ b/templates/hooks/dev-team-pr-template.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+/**
+ * dev-team-pr-template.js
+ * PreToolUse hook on Bash — validates PR body contains required sections from pr.template.
+ *
+ * Reads pr.template (array of section headings, e.g., ["## Summary", "## Test plan"])
+ * and blocks the PR if any required section is missing from the body.
+ *
+ * When pr.template is empty or not set, skips validation.
+ * When workflow.pr is false, exits 0 immediately.
+ * --skip-format in the command bypasses all PR format hooks (logged as deviation).
+ */
+
+"use strict";
+
+const { readConfig, isEnabled } = require("./lib/workflow-config");
+
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || "{}");
+} catch {
+  process.exit(0);
+}
+
+const command = (input.tool_input && input.tool_input.command) || "";
+
+// Only intercept gh pr create commands
+if (!/\bgh\s+pr\s+create\b/.test(command)) {
+  process.exit(0);
+}
+
+// Skip when PR workflow is disabled
+if (!isEnabled("pr")) {
+  process.exit(0);
+}
+
+// Escape hatch
+if (/--skip-format\b/.test(command)) {
+  console.warn(
+    "[dev-team pr-template] WARNING: --skip-format used — PR format hooks bypassed. " +
+      "This is logged as a process deviation for Borges calibration.",
+  );
+  process.exit(0);
+}
+
+const config = readConfig();
+const pr = config.pr || {};
+const template = pr.template;
+
+// When template is not set or empty, skip validation
+if (!Array.isArray(template) || template.length === 0) {
+  process.exit(0);
+}
+
+// Extract --body value from command
+const bodyMatch = command.match(/--body\s+(?:"([\s\S]*?)(?<!\\)"|'([\s\S]*?)'|(\S+))/);
+if (!bodyMatch) {
+  // No --body flag — gh pr create will prompt interactively, we cannot validate
+  process.exit(0);
+}
+const body = (bodyMatch[1] || bodyMatch[2] || bodyMatch[3] || "").replace(/\\"/g, '"');
+
+if (!body) {
+  console.error(
+    "[dev-team pr-template] BLOCKED — PR body is empty but required sections are configured.\n",
+  );
+  console.error("  Required sections: " + template.join(", "));
+  console.error("\nUse --skip-format to bypass.");
+  process.exit(2);
+}
+
+// Check for each required section (case-insensitive)
+const missingSections = [];
+for (const section of template) {
+  if (typeof section !== "string") continue;
+  // Match the section heading at the start of a line
+  const escaped = section.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp("(?:^|\\n)" + escaped, "i");
+  if (!pattern.test(body)) {
+    missingSections.push(section);
+  }
+}
+
+if (missingSections.length > 0) {
+  console.error("[dev-team pr-template] BLOCKED — PR body is missing required sections.\n");
+  console.error("  Missing: " + missingSections.join(", "));
+  console.error("  Required: " + template.join(", "));
+  console.error("\nAdd the missing sections to the PR body, or use --skip-format to bypass.");
+  process.exit(2);
+}
+
+process.exit(0);

--- a/templates/hooks/dev-team-pr-title-format.js
+++ b/templates/hooks/dev-team-pr-title-format.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+/**
+ * dev-team-pr-title-format.js
+ * PreToolUse hook on Bash — validates PR title matches pr.titleFormat config.
+ *
+ * Formats:
+ *   - "conventional": title matches conventional commits (feat: ..., fix: ..., etc.)
+ *   - "plain": any title accepted
+ *   - "issue-prefix": title starts with [#NNN]
+ *
+ * Escape hatch: --skip-format bypasses all PR format hooks.
+ */
+
+"use strict";
+
+const { readConfig, isEnabled } = require("./lib/workflow-config");
+
+let input = {};
+try {
+  input = JSON.parse(process.argv[2] || "{}");
+} catch {
+  process.exit(0);
+}
+
+const command = (input.tool_input && input.tool_input.command) || "";
+
+if (!/\bgh\s+pr\s+create\b/.test(command)) {
+  process.exit(0);
+}
+
+if (/--skip-format\b/.test(command)) {
+  console.warn(
+    "[dev-team pr-title-format] WARNING: --skip-format used — PR format hooks bypassed.",
+  );
+  process.exit(0);
+}
+
+if (!isEnabled("pr")) {
+  process.exit(0);
+}
+
+const config = readConfig();
+
+const titleFormat = (config.pr && config.pr.titleFormat) || "plain";
+
+if (titleFormat === "plain") {
+  process.exit(0);
+}
+
+const titleMatch = command.match(/--title\s+(?:"([^"]+)"|'([^']+)'|(\S+))/);
+if (!titleMatch) {
+  process.exit(0);
+}
+const title = titleMatch[1] || titleMatch[2] || titleMatch[3];
+
+if (titleFormat === "conventional") {
+  const conventionalPattern =
+    /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?:\s.+/;
+  if (!conventionalPattern.test(title)) {
+    console.error(
+      `[dev-team pr-title-format] BLOCKED — title "${title}" does not match conventional commits format.`,
+    );
+    console.error("  Expected: <type>(<scope>): <description>");
+    console.error(
+      "  Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert",
+    );
+    process.exit(2);
+  }
+}
+
+if (titleFormat === "issue-prefix") {
+  if (!/^\[#\d+\]/.test(title)) {
+    console.error(`[dev-team pr-title-format] BLOCKED — title "${title}" missing issue prefix.`);
+    console.error("  Expected: [#NNN] <description>");
+    process.exit(2);
+  }
+}
+
+process.exit(0);

--- a/templates/hooks/lib/workflow-config.js
+++ b/templates/hooks/lib/workflow-config.js
@@ -73,4 +73,25 @@ function _resetCache() {
   _workflow = null;
 }
 
-module.exports = { isEnabled, _resetCache };
+/**
+ * Read and return the full .dev-team/config.json object.
+ * Returns an empty object on any failure. Result is NOT cached
+ * (config may change between hook invocations in a session).
+ */
+function readConfig() {
+  try {
+    const configPath = path.join(process.cwd(), ".dev-team", "config.json");
+    const stat = fs.lstatSync(configPath);
+    if (stat.isSymbolicLink() || !stat.isFile()) return {};
+    const raw = fs.readFileSync(configPath, "utf-8");
+    const config = JSON.parse(raw);
+    if (config && typeof config === "object" && !Array.isArray(config)) {
+      return config;
+    }
+  } catch {
+    // Missing config, parse error — return empty
+  }
+  return {};
+}
+
+module.exports = { isEnabled, readConfig, _resetCache };

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -38,6 +38,26 @@
           {
             "type": "command",
             "command": "node .dev-team/hooks/dev-team-merge-gate.js"
+          },
+          {
+            "type": "command",
+            "command": "node .dev-team/hooks/dev-team-pr-title-format.js"
+          },
+          {
+            "type": "command",
+            "command": "node .dev-team/hooks/dev-team-pr-link-keyword.js"
+          },
+          {
+            "type": "command",
+            "command": "node .dev-team/hooks/dev-team-pr-draft.js"
+          },
+          {
+            "type": "command",
+            "command": "node .dev-team/hooks/dev-team-pr-template.js"
+          },
+          {
+            "type": "command",
+            "command": "node .dev-team/hooks/dev-team-pr-auto-label.js"
           }
         ]
       },

--- a/tests/scenarios/node-project.test.js
+++ b/tests/scenarios/node-project.test.js
@@ -57,7 +57,7 @@ describe("Node.js project scenario", () => {
 
     // Hooks installed in .dev-team/
     const hooks = fs.readdirSync(path.join(tmpDir, ".dev-team", "hooks"));
-    assert.equal(hooks.length, 13); // 10 quality hooks + 2 infra hooks + lib/ directory
+    assert.equal(hooks.length, 18); // 15 quality hooks + 2 infra hooks + lib/ directory
 
     // Existing CLAUDE.md preserved
     const claudeMd = fs.readFileSync(path.join(tmpDir, "CLAUDE.md"), "utf-8");

--- a/tests/unit/pr-format-hooks.test.js
+++ b/tests/unit/pr-format-hooks.test.js
@@ -1,0 +1,495 @@
+"use strict";
+
+const { describe, it, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const HOOKS_DIR = path.join(__dirname, "..", "..", "templates", "hooks");
+
+/**
+ * Helper: run a hook script with the given tool_input JSON and return the exit code.
+ * Captures stdout and stderr regardless of exit code.
+ */
+function runHook(hookFile, toolInput, options = {}) {
+  const input = JSON.stringify({ tool_input: toolInput });
+  const cwd = options.cwd || process.cwd();
+  try {
+    const stdout = execFileSync(process.execPath, [path.join(HOOKS_DIR, hookFile), input], {
+      encoding: "utf-8",
+      timeout: 5000,
+      cwd,
+      env: { ...process.env, PATH: process.env.PATH },
+    });
+    return { code: 0, stdout, stderr: "" };
+  } catch (err) {
+    return { code: err.status, stdout: err.stdout || "", stderr: err.stderr || "" };
+  }
+}
+
+/**
+ * Create a temporary directory with a .dev-team/config.json containing the given config.
+ * Initializes a git repo with an initial commit so git rev-parse works.
+ */
+function createTempConfig(config) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pr-hooks-test-"));
+  const devTeamDir = path.join(tmpDir, ".dev-team");
+  fs.mkdirSync(devTeamDir, { recursive: true });
+  fs.writeFileSync(path.join(devTeamDir, "config.json"), JSON.stringify(config, null, 2));
+  // Initialize a git repo with an initial commit so rev-parse works
+  try {
+    execFileSync("git", ["init", "--initial-branch=main"], {
+      cwd: tmpDir,
+      stdio: "pipe",
+    });
+  } catch {
+    execFileSync("git", ["init"], { cwd: tmpDir, stdio: "pipe" });
+  }
+  execFileSync("git", ["config", "user.email", "test@test.com"], {
+    cwd: tmpDir,
+    stdio: "pipe",
+  });
+  execFileSync("git", ["config", "user.name", "Test"], {
+    cwd: tmpDir,
+    stdio: "pipe",
+  });
+  // Create an initial commit so HEAD exists
+  fs.writeFileSync(path.join(tmpDir, ".gitkeep"), "");
+  execFileSync("git", ["add", "."], { cwd: tmpDir, stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: tmpDir, stdio: "pipe" });
+  return tmpDir;
+}
+
+function cleanupTempDir(tmpDir) {
+  if (tmpDir && tmpDir.startsWith(os.tmpdir())) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+// --- PR Title Format ---
+
+describe("dev-team-pr-title-format", () => {
+  const hook = "dev-team-pr-title-format.js";
+
+  it("exits 0 for non-gh-pr-create commands", () => {
+    const result = runHook(hook, {
+      command: "git push origin main",
+    });
+    assert.equal(result.code, 0);
+  });
+
+  it("exits 0 when no config exists (defaults to plain)", () => {
+    const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), "pr-noconfig-"));
+    try {
+      const result = runHook(
+        hook,
+        { command: 'gh pr create --title "anything"' },
+        { cwd: emptyDir },
+      );
+      assert.equal(result.code, 0);
+    } finally {
+      fs.rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+
+  describe("conventional format", () => {
+    let tmpDir;
+    beforeEach(() => {
+      tmpDir = createTempConfig({ pr: { titleFormat: "conventional" } });
+    });
+    afterEach(() => cleanupTempDir(tmpDir));
+
+    it("allows valid conventional title", () => {
+      const result = runHook(
+        hook,
+        { command: 'gh pr create --title "feat: add login"' },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 0);
+    });
+
+    it("allows conventional title with scope", () => {
+      const result = runHook(
+        hook,
+        {
+          command: 'gh pr create --title "fix(auth): correct token refresh"',
+        },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 0);
+    });
+
+    it("allows conventional title with breaking change indicator", () => {
+      const result = runHook(
+        hook,
+        { command: 'gh pr create --title "feat\!: breaking change"' },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 0);
+    });
+
+    it("blocks non-conventional title", () => {
+      const result = runHook(
+        hook,
+        { command: 'gh pr create --title "Add login feature"' },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 2);
+      assert.ok(result.stderr.includes("BLOCKED"));
+    });
+
+    it("exits 0 when --skip-format is used", () => {
+      const result = runHook(
+        hook,
+        { command: 'gh pr create --skip-format --title "Bad title"' },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 0);
+    });
+
+    it("exits 0 when no --title flag present", () => {
+      const result = runHook(
+        hook,
+        {
+          command: "gh pr create",
+        },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 0);
+    });
+  });
+
+  describe("issue-prefix format", () => {
+    let tmpDir;
+    beforeEach(() => {
+      tmpDir = createTempConfig({ pr: { titleFormat: "issue-prefix" } });
+    });
+    afterEach(() => cleanupTempDir(tmpDir));
+
+    it("allows title with issue prefix", () => {
+      const result = runHook(
+        hook,
+        { command: 'gh pr create --title "[#123] Add login"' },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 0);
+    });
+
+    it("blocks title without issue prefix", () => {
+      const result = runHook(
+        hook,
+        { command: 'gh pr create --title "Add login"' },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 2);
+      assert.ok(result.stderr.includes("BLOCKED"));
+    });
+  });
+
+  describe("workflow.pr disabled", () => {
+    let tmpDir;
+    beforeEach(() => {
+      tmpDir = createTempConfig({
+        workflow: { pr: false },
+        pr: { titleFormat: "conventional" },
+      });
+    });
+    afterEach(() => cleanupTempDir(tmpDir));
+
+    it("exits 0 when workflow.pr is false", () => {
+      const result = runHook(
+        hook,
+        { command: 'gh pr create --title "Bad title"' },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 0);
+    });
+  });
+});
+
+// --- PR Link Keyword ---
+
+describe("dev-team-pr-link-keyword", () => {
+  const hook = "dev-team-pr-link-keyword.js";
+
+  it("exits 0 for non-gh-pr-create commands", () => {
+    const result = runHook(hook, {
+      command: "git push origin main",
+    });
+    assert.equal(result.code, 0);
+  });
+
+  it("exits 0 when no linkKeyword configured", () => {
+    const result = runHook(hook, {
+      command: 'gh pr create --body "no link"',
+    });
+    assert.equal(result.code, 0);
+  });
+
+  describe("with Closes keyword", () => {
+    let tmpDir;
+    beforeEach(() => {
+      tmpDir = createTempConfig({ pr: { linkKeyword: "Closes" } });
+    });
+    afterEach(() => cleanupTempDir(tmpDir));
+
+    it("allows body with correct link keyword", () => {
+      const result = runHook(
+        hook,
+        {
+          command: 'gh pr create --title "feat: x" --body "Closes #123"',
+        },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 0);
+    });
+
+    it("blocks body without link keyword", () => {
+      const result = runHook(
+        hook,
+        {
+          command: 'gh pr create --title "feat: x" --body "No link here"',
+        },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 2);
+      assert.ok(result.stderr.includes("BLOCKED"));
+    });
+
+    it("exits 0 when --skip-format is used", () => {
+      const result = runHook(
+        hook,
+        { command: 'gh pr create --skip-format --body "No link"' },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 0);
+    });
+
+    it("exits 0 when no --body flag present", () => {
+      const result = runHook(
+        hook,
+        {
+          command: "gh pr create",
+        },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 0);
+    });
+  });
+});
+
+// --- PR Draft Advisory ---
+
+describe("dev-team-pr-draft", () => {
+  const hook = "dev-team-pr-draft.js";
+
+  it("exits 0 for non-gh-pr-create commands", () => {
+    const result = runHook(hook, {
+      command: "git push origin main",
+    });
+    assert.equal(result.code, 0);
+  });
+
+  it("exits 0 when pr.draft is not set", () => {
+    const result = runHook(hook, {
+      command: "gh pr create",
+    });
+    assert.equal(result.code, 0);
+  });
+
+  describe("with pr.draft enabled", () => {
+    let tmpDir;
+    beforeEach(() => {
+      tmpDir = createTempConfig({ pr: { draft: true } });
+    });
+    afterEach(() => cleanupTempDir(tmpDir));
+
+    it("exits 0 when --draft is present", () => {
+      const result = runHook(
+        hook,
+        {
+          command: "gh pr create --draft",
+        },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 0);
+    });
+
+    it("exits 0 when --draft is missing (advisory only, never blocks)", () => {
+      const result = runHook(
+        hook,
+        {
+          command: "gh pr create",
+        },
+        { cwd: tmpDir },
+      );
+      // Advisory only — must exit 0 regardless
+      assert.equal(result.code, 0);
+    });
+
+    it("exits 0 when --skip-format is used", () => {
+      const result = runHook(
+        hook,
+        {
+          command: "gh pr create --skip-format",
+        },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 0);
+    });
+  });
+});
+
+// --- PR Template Sections ---
+
+describe("dev-team-pr-template", () => {
+  const hook = "dev-team-pr-template.js";
+
+  it("exits 0 for non-gh-pr-create commands", () => {
+    const result = runHook(hook, {
+      command: "git push origin main",
+    });
+    assert.equal(result.code, 0);
+  });
+
+  it("exits 0 when no template configured", () => {
+    const result = runHook(hook, {
+      command: 'gh pr create --body "anything"',
+    });
+    assert.equal(result.code, 0);
+  });
+
+  describe("with required sections", () => {
+    let tmpDir;
+    beforeEach(() => {
+      tmpDir = createTempConfig({
+        pr: { template: ["## Summary", "## Test plan"] },
+      });
+    });
+    afterEach(() => cleanupTempDir(tmpDir));
+
+    it("allows body with all required sections", () => {
+      // Use actual newlines in the body string
+      const body = "## Summary\nSome summary\n## Test plan\nSome tests";
+      const result = runHook(
+        hook,
+        { command: 'gh pr create --body "' + body + '"' },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 0);
+    });
+
+    it("blocks body missing a required section", () => {
+      const body = "## Summary\nSome summary";
+      const result = runHook(
+        hook,
+        { command: 'gh pr create --body "' + body + '"' },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 2);
+      assert.ok(result.stderr.includes("BLOCKED"));
+      assert.ok(result.stderr.includes("## Test plan"));
+    });
+
+    it("exits 0 when --skip-format is used", () => {
+      const result = runHook(
+        hook,
+        { command: 'gh pr create --skip-format --body "no sections"' },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 0);
+    });
+
+    it("exits 0 when no --body flag present", () => {
+      const result = runHook(
+        hook,
+        {
+          command: "gh pr create",
+        },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 0);
+    });
+  });
+});
+
+// --- PR Auto-Label ---
+
+describe("dev-team-pr-auto-label", () => {
+  const hook = "dev-team-pr-auto-label.js";
+
+  it("exits 0 for non-gh-pr-create commands", () => {
+    const result = runHook(hook, {
+      command: "git push origin main",
+    });
+    assert.equal(result.code, 0);
+  });
+
+  it("exits 0 when pr.autoLabel is not set", () => {
+    const result = runHook(hook, {
+      command: "gh pr create",
+    });
+    assert.equal(result.code, 0);
+  });
+
+  describe("with autoLabel enabled on feat/ branch", () => {
+    let tmpDir;
+    beforeEach(() => {
+      tmpDir = createTempConfig({ pr: { autoLabel: true } });
+      execFileSync("git", ["checkout", "-b", "feat/123-test"], {
+        cwd: tmpDir,
+        stdio: "pipe",
+      });
+    });
+    afterEach(() => cleanupTempDir(tmpDir));
+
+    it("suggests enhancement label for feat/ branch", () => {
+      const result = runHook(
+        hook,
+        {
+          command: "gh pr create",
+        },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 0);
+      assert.ok(result.stdout.includes("enhancement"));
+    });
+
+    it("exits 0 when --skip-format is used", () => {
+      const result = runHook(
+        hook,
+        {
+          command: "gh pr create --skip-format",
+        },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 0);
+    });
+  });
+
+  describe("with autoLabel enabled on fix/ branch", () => {
+    let tmpDir;
+    beforeEach(() => {
+      tmpDir = createTempConfig({ pr: { autoLabel: true } });
+      execFileSync("git", ["checkout", "-b", "fix/456-bugfix"], {
+        cwd: tmpDir,
+        stdio: "pipe",
+      });
+    });
+    afterEach(() => cleanupTempDir(tmpDir));
+
+    it("suggests bug label for fix/ branch", () => {
+      const result = runHook(
+        hook,
+        {
+          command: "gh pr create",
+        },
+        { cwd: tmpDir },
+      );
+      assert.equal(result.code, 0);
+      assert.ok(result.stdout.includes("bug"));
+    });
+  });
+});

--- a/tests/unit/pr-format-hooks.test.js
+++ b/tests/unit/pr-format-hooks.test.js
@@ -124,7 +124,7 @@ describe("dev-team-pr-title-format", () => {
     it("allows conventional title with breaking change indicator", () => {
       const result = runHook(
         hook,
-        { command: 'gh pr create --title "feat\!: breaking change"' },
+        { command: 'gh pr create --title "feat!: breaking change"' },
         { cwd: tmpDir },
       );
       assert.equal(result.code, 0);


### PR DESCRIPTION
## Summary
- Add 5 new PreToolUse hooks enforcing `pr.*` config fields from `.dev-team/config.json` on `gh pr create` commands
- Hooks: title format (conventional/issue-prefix/plain), link keyword, draft advisory, template sections, auto-label
- Add `readConfig()` to `workflow-config.js` lib for full config access
- All hooks share `--skip-format` escape hatch and respect `workflow.pr` toggle
- 33 new unit tests covering all hooks and config variations (890 total, 0 failures)

Closes #780

## Test plan
- [x] All 890 tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Format clean (`npm run format`)
- [x] Lint clean (`npx oxlint src/`)
- [x] Hook count updated in README (12 -> 17)
- [x] Scenario test updated for new hook count (13 -> 18 entries in hooks dir)