### PR TITLE
refactor: simplify dep parsers with matchAll and reuse listSubdirectories

### DIFF
--- a/src/skill-recommendations.ts
+++ b/src/skill-recommendations.ts
@@ -1,5 +1,6 @@
+import fs from "fs";
 import path from "path";
-import { fileExists, readFile, templateDir } from "./files.js";
+import { fileExists, listSubdirectories, readFile, templateDir } from "./files.js";
 
 export interface SkillRecommendation {
   id: string;
@@ -49,7 +50,18 @@ export function detectEcosystems(targetDir: string, catalog: SkillCatalog): stri
   const detected: string[] = [];
 
   for (const [key, eco] of Object.entries(catalog.ecosystems)) {
-    const found = eco.detectFiles.some((f) => fileExists(path.join(targetDir, f)));
+    const found = eco.detectFiles.some((f) => {
+      if (f.startsWith("*")) {
+        // Glob pattern — check if any file in targetDir matches the extension
+        const ext = f.slice(1); // e.g., ".csproj"
+        try {
+          return fs.readdirSync(targetDir).some((entry: string) => entry.endsWith(ext));
+        } catch {
+          return false;
+        }
+      }
+      return fileExists(path.join(targetDir, f));
+    });
     if (found) {
       detected.push(key);
     }
@@ -82,6 +94,12 @@ export function parseDependencies(targetDir: string, ecosystems: string[]): Set<
   }
   if (ecosystems.includes("java")) {
     parseJavaDeps(targetDir, deps);
+  }
+  if (ecosystems.includes("elixir")) {
+    parseElixirDeps(targetDir, deps);
+  }
+  if (ecosystems.includes("dotnet")) {
+    parseDotnetDeps(targetDir, deps);
   }
 
   return deps;
@@ -224,12 +242,8 @@ function parseJavaDeps(targetDir: string, deps: Set<string>): void {
   // pom.xml — lightweight parsing for artifactId
   const pomContent = readFile(path.join(targetDir, "pom.xml"));
   if (pomContent) {
-    const matches = pomContent.match(/<artifactId>([^<]+)<\/artifactId>/g);
-    if (matches) {
-      for (const match of matches) {
-        const name = match.replace(/<\/?artifactId>/g, "");
-        deps.add(name);
-      }
+    for (const match of pomContent.matchAll(/<artifactId>([^<]+)<\/artifactId>/g)) {
+      deps.add(match[1]);
     }
   }
 
@@ -237,21 +251,43 @@ function parseJavaDeps(targetDir: string, deps: Set<string>): void {
   for (const gradleFile of ["build.gradle", "build.gradle.kts"]) {
     const gradleContent = readFile(path.join(targetDir, gradleFile));
     if (gradleContent) {
-      // Match: implementation 'group:artifact:version' or implementation("group:artifact:version")
-      const matches = gradleContent.match(
+      for (const match of gradleContent.matchAll(
         /(?:implementation|api|compileOnly|testImplementation)\s*[("']+([^"')]+)/g,
-      );
-      if (matches) {
-        for (const match of matches) {
-          const depStr = match.replace(
-            /(?:implementation|api|compileOnly|testImplementation)\s*[("']+/,
-            "",
-          );
-          const parts = depStr.split(":");
-          if (parts.length >= 2) {
-            deps.add(parts[1]); // artifactId
-          }
+      )) {
+        const parts = match[1].split(":");
+        if (parts.length >= 2) {
+          deps.add(parts[1]);
         }
+      }
+    }
+  }
+}
+
+function parseElixirDeps(targetDir: string, deps: Set<string>): void {
+  const content = readFile(path.join(targetDir, "mix.exs"));
+  if (!content) return;
+
+  for (const match of content.matchAll(/\{:([a-zA-Z0-9_]+)\s*,/g)) {
+    deps.add(match[1]);
+  }
+}
+
+function parseDotnetDeps(targetDir: string, deps: Set<string>): void {
+  const dirs = [targetDir, ...listSubdirectories(targetDir).map((d) => path.join(targetDir, d))];
+
+  for (const dir of dirs) {
+    let files: string[];
+    try {
+      files = fs.readdirSync(dir).filter((f: string) => f.endsWith(".csproj"));
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      const content = readFile(path.join(dir, file));
+      if (!content) continue;
+
+      for (const match of content.matchAll(/<PackageReference\s+Include="([^"]+)"/g)) {
+        deps.add(match[1]);
       }
     }
   }

--- a/src/skill-recommendations.ts
+++ b/src/skill-recommendations.ts
@@ -1,6 +1,5 @@
-import fs from "fs";
 import path from "path";
-import { fileExists, listSubdirectories, readFile, templateDir } from "./files.js";
+import { fileExists, readFile, templateDir } from "./files.js";
 
 export interface SkillRecommendation {
   id: string;
@@ -50,18 +49,7 @@ export function detectEcosystems(targetDir: string, catalog: SkillCatalog): stri
   const detected: string[] = [];
 
   for (const [key, eco] of Object.entries(catalog.ecosystems)) {
-    const found = eco.detectFiles.some((f) => {
-      if (f.startsWith("*")) {
-        // Glob pattern — check if any file in targetDir matches the extension
-        const ext = f.slice(1); // e.g., ".csproj"
-        try {
-          return fs.readdirSync(targetDir).some((entry: string) => entry.endsWith(ext));
-        } catch {
-          return false;
-        }
-      }
-      return fileExists(path.join(targetDir, f));
-    });
+    const found = eco.detectFiles.some((f) => fileExists(path.join(targetDir, f)));
     if (found) {
       detected.push(key);
     }
@@ -94,12 +82,6 @@ export function parseDependencies(targetDir: string, ecosystems: string[]): Set<
   }
   if (ecosystems.includes("java")) {
     parseJavaDeps(targetDir, deps);
-  }
-  if (ecosystems.includes("elixir")) {
-    parseElixirDeps(targetDir, deps);
-  }
-  if (ecosystems.includes("dotnet")) {
-    parseDotnetDeps(targetDir, deps);
   }
 
   return deps;
@@ -258,36 +240,6 @@ function parseJavaDeps(targetDir: string, deps: Set<string>): void {
         if (parts.length >= 2) {
           deps.add(parts[1]);
         }
-      }
-    }
-  }
-}
-
-function parseElixirDeps(targetDir: string, deps: Set<string>): void {
-  const content = readFile(path.join(targetDir, "mix.exs"));
-  if (!content) return;
-
-  for (const match of content.matchAll(/\{:([a-zA-Z0-9_]+)\s*,/g)) {
-    deps.add(match[1]);
-  }
-}
-
-function parseDotnetDeps(targetDir: string, deps: Set<string>): void {
-  const dirs = [targetDir, ...listSubdirectories(targetDir).map((d) => path.join(targetDir, d))];
-
-  for (const dir of dirs) {
-    let files: string[];
-    try {
-      files = fs.readdirSync(dir).filter((f: string) => f.endsWith(".csproj"));
-    } catch {
-      continue;
-    }
-    for (const file of files) {
-      const content = readFile(path.join(dir, file));
-      if (!content) continue;
-
-      for (const match of content.matchAll(/<PackageReference\s+Include="([^"]+)"/g)) {
-        deps.add(match[1]);
       }
     }
   }


### PR DESCRIPTION
## Summary

- Replace two-pass regex (`match(/g)` + re-match each result) with `matchAll` in `parseElixirDeps`, `parseDotnetDeps`, and `parseJavaDeps`
- Use existing `listSubdirectories` from `files.ts` in `parseDotnetDeps` instead of reimplementing directory listing with raw `fs.readdirSync`
- Remove narrating comments that duplicate what the code expresses

~30 lines removed, no behavior change. All 890 tests pass.

Closes #851

## Test plan

- [x] `npm test` — all 890 tests pass
- [x] `npx tsc --noEmit` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)