### PR TITLE
feat: add Elixir and .NET ecosystem detection and skill recommendations

### DIFF
--- a/.claude/rules/dev-team-learnings.md
+++ b/.claude/rules/dev-team-learnings.md
@@ -52,5 +52,7 @@
 - ~~**init.ts and update.ts core entry points have no unit tests.**~~ **Resolved in v3.5.0 (#715, PR #718).** 657 lines of tests added covering exported constants, pure utility functions (compareSemver, cleanupLegacyMemoryDirs, migrateToV3Layout). Interactive run() branches remain untested by design.
 - ~~**CI scripts must exist in package.json for local parity.**~~ **Resolved in v3.5.0 (#714, PR #717).** validate:docs script added to package.json.
 
+- **Validation scripts must cover dogfooding copies, not just templates.** v4.0.0 audit found validate-hooks.js only checks `templates/hooks/` and validate-agents.js only checks `templates/agents/`. The installed copies in `.dev-team/hooks/` and `.claude/agents/` (used for dogfooding) are unvalidated in CI. When the project dogfoods its own tool, validation must cover both template sources and installed copies.
+
 ## Overruled Challenges
 <\!-- When the human overrules an agent, record why — prevents re-flagging -->

--- a/.claude/rules/dev-team-learnings.md
+++ b/.claude/rules/dev-team-learnings.md
@@ -52,7 +52,7 @@
 - ~~**init.ts and update.ts core entry points have no unit tests.**~~ **Resolved in v3.5.0 (#715, PR #718).** 657 lines of tests added covering exported constants, pure utility functions (compareSemver, cleanupLegacyMemoryDirs, migrateToV3Layout). Interactive run() branches remain untested by design.
 - ~~**CI scripts must exist in package.json for local parity.**~~ **Resolved in v3.5.0 (#714, PR #717).** validate:docs script added to package.json.
 
-- **Validation scripts must cover dogfooding copies, not just templates.** v4.0.0 audit found validate-hooks.js only checks `templates/hooks/` and validate-agents.js only checks `templates/agents/`. The installed copies in `.dev-team/hooks/` and `.claude/agents/` (used for dogfooding) are unvalidated in CI. When the project dogfoods its own tool, validation must cover both template sources and installed copies.
+- **Validation scripts must cover dogfooding copies, not just templates.** v4.0.0 audit found validate-hooks.js validates `templates/hooks/` and `.claude/hooks/`, but not `.dev-team/hooks/`; validate-agents.js only checks `templates/agents/`, so `.claude/agents/` remains unvalidated in CI. When the project dogfoods its own tool, validation must cover both template sources and installed copies.
 
 ## Overruled Challenges
 <\!-- When the human overrules an agent, record why — prevents re-flagging -->

--- a/src/skill-recommendations.ts
+++ b/src/skill-recommendations.ts
@@ -1,5 +1,6 @@
+import fs from "fs";
 import path from "path";
-import { fileExists, readFile, templateDir } from "./files.js";
+import { fileExists, listSubdirectories, readFile, templateDir } from "./files.js";
 
 export interface SkillRecommendation {
   id: string;
@@ -49,7 +50,17 @@ export function detectEcosystems(targetDir: string, catalog: SkillCatalog): stri
   const detected: string[] = [];
 
   for (const [key, eco] of Object.entries(catalog.ecosystems)) {
-    const found = eco.detectFiles.some((f) => fileExists(path.join(targetDir, f)));
+    const found = eco.detectFiles.some((f) => {
+      if (f.startsWith("*")) {
+        const ext = f.slice(1);
+        try {
+          return fs.readdirSync(targetDir).some((entry: string) => entry.endsWith(ext));
+        } catch {
+          return false;
+        }
+      }
+      return fileExists(path.join(targetDir, f));
+    });
     if (found) {
       detected.push(key);
     }
@@ -82,6 +93,12 @@ export function parseDependencies(targetDir: string, ecosystems: string[]): Set<
   }
   if (ecosystems.includes("java")) {
     parseJavaDeps(targetDir, deps);
+  }
+  if (ecosystems.includes("elixir")) {
+    parseElixirDeps(targetDir, deps);
+  }
+  if (ecosystems.includes("dotnet")) {
+    parseDotnetDeps(targetDir, deps);
   }
 
   return deps;
@@ -252,6 +269,36 @@ function parseJavaDeps(targetDir: string, deps: Set<string>): void {
             deps.add(parts[1]); // artifactId
           }
         }
+      }
+    }
+  }
+}
+
+function parseElixirDeps(targetDir: string, deps: Set<string>): void {
+  const content = readFile(path.join(targetDir, "mix.exs"));
+  if (!content) return;
+
+  for (const match of content.matchAll(/\{:([a-zA-Z0-9_]+)\s*,/g)) {
+    deps.add(match[1]);
+  }
+}
+
+function parseDotnetDeps(targetDir: string, deps: Set<string>): void {
+  const dirs = [targetDir, ...listSubdirectories(targetDir).map((d) => path.join(targetDir, d))];
+
+  for (const dir of dirs) {
+    let files: string[];
+    try {
+      files = fs.readdirSync(dir).filter((f: string) => f.endsWith(".csproj"));
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      const content = readFile(path.join(dir, file));
+      if (!content) continue;
+
+      for (const match of content.matchAll(/<PackageReference\s+Include="([^"]+)"/g)) {
+        deps.add(match[1]);
       }
     }
   }

--- a/src/skill-recommendations.ts
+++ b/src/skill-recommendations.ts
@@ -53,11 +53,15 @@ export function detectEcosystems(targetDir: string, catalog: SkillCatalog): stri
     const found = eco.detectFiles.some((f) => {
       if (f.startsWith("*")) {
         const ext = f.slice(1);
-        try {
-          return fs.readdirSync(targetDir).some((entry: string) => entry.endsWith(ext));
-        } catch {
-          return false;
-        }
+        if (ext.length === 0) return false;
+        const dirs = [targetDir, ...listSubdirectories(targetDir).map((d) => path.join(targetDir, d))];
+        return dirs.some((dir) => {
+          try {
+            return fs.readdirSync(dir).some((entry: string) => entry.endsWith(ext));
+          } catch {
+            return false;
+          }
+        });
       }
       return fileExists(path.join(targetDir, f));
     });
@@ -297,8 +301,11 @@ function parseDotnetDeps(targetDir: string, deps: Set<string>): void {
       const content = readFile(path.join(dir, file));
       if (!content) continue;
 
-      for (const match of content.matchAll(/<PackageReference\s+Include="([^"]+)"/g)) {
-        deps.add(match[1]);
+      for (const tagMatch of content.matchAll(/<PackageReference\b[^>]*>/g)) {
+        const attr = /\b(?:Include|Update)\s*=\s*"([^"]+)"/.exec(tagMatch[0]);
+        if (attr) {
+          deps.add(attr[1]);
+        }
       }
     }
   }

--- a/src/skill-recommendations.ts
+++ b/src/skill-recommendations.ts
@@ -54,7 +54,10 @@ export function detectEcosystems(targetDir: string, catalog: SkillCatalog): stri
       if (f.startsWith("*")) {
         const ext = f.slice(1);
         if (ext.length === 0) return false;
-        const dirs = [targetDir, ...listSubdirectories(targetDir).map((d) => path.join(targetDir, d))];
+        const dirs = [
+          targetDir,
+          ...listSubdirectories(targetDir).map((d) => path.join(targetDir, d)),
+        ];
         return dirs.some((dir) => {
           try {
             return fs.readdirSync(dir).some((entry: string) => entry.endsWith(ext));

--- a/templates/skill-recommendations.json
+++ b/templates/skill-recommendations.json
@@ -10,7 +10,8 @@
     "supabase",
     "playwright",
     "vuejs",
-    "rust-lang"
+    "rust-lang",
+    "elixir-lang"
   ],
   "ecosystems": {
     "node": {
@@ -36,6 +37,14 @@
     "java": {
       "detectFiles": ["pom.xml", "build.gradle", "build.gradle.kts"],
       "label": "Java / Kotlin"
+    },
+    "elixir": {
+      "detectFiles": ["mix.exs"],
+      "label": "Elixir"
+    },
+    "dotnet": {
+      "detectFiles": ["*.csproj", "*.sln"],
+      "label": "C# / .NET"
     }
   },
   "skills": [
@@ -164,6 +173,24 @@
       "detectDeps": ["spring-boot-starter"],
       "detectFiles": [],
       "ecosystem": "java"
+    },
+    {
+      "id": "phoenix",
+      "name": "Phoenix Framework Documentation Lookup",
+      "description": "Search Phoenix docs for LiveView, channels, Ecto, and deployment",
+      "source": "elixir-lang",
+      "detectDeps": ["phoenix", "phoenix_html", "phoenix_live_view"],
+      "detectFiles": [],
+      "ecosystem": "elixir"
+    },
+    {
+      "id": "dotnet",
+      "name": ".NET Documentation Lookup",
+      "description": "Search .NET docs for ASP.NET Core, Entity Framework, Blazor, and MAUI",
+      "source": "microsoft",
+      "detectDeps": ["Microsoft.AspNetCore.App", "Microsoft.EntityFrameworkCore", "Microsoft.NET.Sdk.Blazor"],
+      "detectFiles": [],
+      "ecosystem": "dotnet"
     }
   ]
 }

--- a/tests/unit/skill-recommendations.test.js
+++ b/tests/unit/skill-recommendations.test.js
@@ -78,6 +78,24 @@ describe("detectEcosystems", () => {
     assert.ok(ecosystems.includes("java"));
   });
 
+  it("detects Elixir from mix.exs", () => {
+    fs.writeFileSync(path.join(tmpDir, "mix.exs"), "defmodule MyApp.MixProject do\nend\n");
+    const ecosystems = detectEcosystems(tmpDir, catalog);
+    assert.ok(ecosystems.includes("elixir"));
+  });
+
+  it("detects C#/.NET from .csproj file", () => {
+    fs.writeFileSync(path.join(tmpDir, "MyApp.csproj"), "<Project></Project>");
+    const ecosystems = detectEcosystems(tmpDir, catalog);
+    assert.ok(ecosystems.includes("dotnet"));
+  });
+
+  it("detects C#/.NET from .sln file", () => {
+    fs.writeFileSync(path.join(tmpDir, "MyApp.sln"), "Microsoft Visual Studio Solution File");
+    const ecosystems = detectEcosystems(tmpDir, catalog);
+    assert.ok(ecosystems.includes("dotnet"));
+  });
+
   it("detects multiple ecosystems simultaneously", () => {
     fs.writeFileSync(path.join(tmpDir, "package.json"), "{}");
     fs.writeFileSync(path.join(tmpDir, "requirements.txt"), "");
@@ -185,6 +203,37 @@ describe("parseDependencies", () => {
     );
     const deps = parseDependencies(tmpDir, ["java"]);
     assert.ok(deps.has("spring-boot-starter"));
+  });
+
+  it("parses Elixir dependencies from mix.exs", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "mix.exs"),
+      'defmodule MyApp.MixProject do\n  defp deps do\n    [\n      {:phoenix, "~> 1.7"},\n      {:phoenix_live_view, "~> 0.20"},\n      {:ecto_sql, "~> 3.10"}\n    ]\n  end\nend\n',
+    );
+    const deps = parseDependencies(tmpDir, ["elixir"]);
+    assert.ok(deps.has("phoenix"));
+    assert.ok(deps.has("phoenix_live_view"));
+    assert.ok(deps.has("ecto_sql"));
+  });
+
+  it("parses C#/.NET dependencies from .csproj PackageReference", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "MyApp.csproj"),
+      '<Project Sdk="Microsoft.NET.Sdk.Web">\n  <ItemGroup>\n    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />\n    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />\n  </ItemGroup>\n</Project>\n',
+    );
+    const deps = parseDependencies(tmpDir, ["dotnet"]);
+    assert.ok(deps.has("Microsoft.EntityFrameworkCore"));
+    assert.ok(deps.has("Newtonsoft.Json"));
+  });
+
+  it("parses C#/.NET dependencies from nested .csproj", () => {
+    fs.mkdirSync(path.join(tmpDir, "src"));
+    fs.writeFileSync(
+      path.join(tmpDir, "src", "MyApp.csproj"),
+      '<Project>\n  <ItemGroup>\n    <PackageReference Include="Serilog" Version="3.0.0" />\n  </ItemGroup>\n</Project>\n',
+    );
+    const deps = parseDependencies(tmpDir, ["dotnet"]);
+    assert.ok(deps.has("Serilog"));
   });
 
   it("handles invalid package.json gracefully", () => {
@@ -318,6 +367,27 @@ describe("matchSkills", () => {
     const matches = matchSkills(tmpDir, catalog, ["java"], deps);
     const spring = matches.find((m) => m.id === "spring-boot");
     assert.ok(spring, "expected Spring Boot skill to match");
+  });
+
+  it("matches Phoenix skill from Elixir dependency", () => {
+    const deps = new Set(["phoenix"]);
+    const matches = matchSkills(tmpDir, catalog, ["elixir"], deps);
+    const phoenix = matches.find((m) => m.id === "phoenix");
+    assert.ok(phoenix, "expected Phoenix skill to match");
+  });
+
+  it("matches .NET skill from C# dependency", () => {
+    const deps = new Set(["Microsoft.EntityFrameworkCore"]);
+    const matches = matchSkills(tmpDir, catalog, ["dotnet"], deps);
+    const dotnet = matches.find((m) => m.id === "dotnet");
+    assert.ok(dotnet, "expected .NET skill to match");
+  });
+
+  it("matches .NET skill from ASP.NET dependency", () => {
+    const deps = new Set(["Microsoft.AspNetCore.App"]);
+    const matches = matchSkills(tmpDir, catalog, ["dotnet"], deps);
+    const dotnet = matches.find((m) => m.id === "dotnet");
+    assert.ok(dotnet, "expected .NET skill to match via ASP.NET dep");
   });
 
   it("matches Rust skill from Cargo.toml file", () => {


### PR DESCRIPTION
## Summary

- Add Elixir ecosystem detection (`mix.exs`) with `parseElixirDeps` and Phoenix Framework skill recommendation
- Add C#/.NET ecosystem detection (`*.csproj`, `*.sln`) with `parseDotnetDeps` (scans root + one level deep) and .NET Documentation skill recommendation
- Add glob pattern support in `detectEcosystems` for extension-based file matching
- 9 new tests covering detection, parsing, and matching for both ecosystems

Closes #853

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `npm test` — all 899 tests pass (9 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)